### PR TITLE
Remove Hadoop classification annotations across API and runtime modules

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/client/TezAppMasterStatus.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezAppMasterStatus.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.client;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Defines status for the App Master executing the DAG
  */
-@Public
 public enum TezAppMasterStatus {
   /** App Master initializing itself */
   INITIALIZING,

--- a/tez-api/src/main/java/org/apache/tez/client/TezClient.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClient.java
@@ -19,9 +19,6 @@
 package org.apache.tez.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
@@ -51,7 +48,6 @@ import java.util.concurrent.TimeUnit;
  * session mode configuration, the same application can be running in session or
  * non-session mode.
  */
-@Public
 public class TezClient {
 
   private static final String appIdStrPrefix = "application";
@@ -64,7 +60,6 @@ public class TezClient {
     throw new TezUncheckedException("TezClient not supported");
   }
 
-  @Private
   TezClient(String name, TezConfiguration tezConf,
             @Nullable Map<String, LocalResource> localResources,
             @Nullable Credentials credentials) {
@@ -75,14 +70,12 @@ public class TezClient {
     throw new TezUncheckedException("TezClient not supported");
   }
 
-  @Private
   protected TezClient(String name, TezConfiguration tezConf, boolean isSession,
                       @Nullable Map<String, LocalResource> localResources,
                       @Nullable Credentials credentials) {
     throw new TezUncheckedException("TezClient not supported");
   }
 
-  @Private
   protected TezClient(String name, TezConfiguration tezConf, boolean isSession,
             @Nullable Map<String, LocalResource> localResources,
             @Nullable Credentials credentials, ServicePluginsDescriptor servicePluginsDescriptor) {
@@ -180,7 +173,6 @@ public class TezClient {
   /**
    * A builder for setting up an instance of {@link org.apache.tez.client.TezClient}
    */
-  @Public
   public static class TezClientBuilder {
 
     private TezClientBuilder(String name, TezConfiguration tezConf) {
@@ -211,8 +203,6 @@ public class TezClient {
   //Copied this helper method from 
   //org.apache.hadoop.yarn.api.records.ApplicationId in Hadoop 2.8+
   //to simplify implementation on 2.7.x
-  @Public
-  @Unstable
   public static ApplicationId appIdfromString(String appIdStr) {
     if (!appIdStr.startsWith(APPLICATION_ID_PREFIX)) {
       throw new IllegalArgumentException("Invalid ApplicationId prefix: "

--- a/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
@@ -19,17 +19,14 @@
 package org.apache.tez.client;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tez.dag.api.TezConstants;
 
 import java.util.List;
 
-@Private
 public class TezClientUtils {
 
-  @Private
   @VisibleForTesting
   public static void addLog4jSystemProperties(String logLevel,
       List<String> vargs) {

--- a/tez-api/src/main/java/org/apache/tez/common/ContainerSignatureMatcher.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ContainerSignatureMatcher.java
@@ -19,12 +19,8 @@ package org.apache.tez.common;
 
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public interface ContainerSignatureMatcher {
   /**
    * Checks the compatibility between the specified container signatures.

--- a/tez-api/src/main/java/org/apache/tez/common/ReflectionUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ReflectionUtils.java
@@ -27,16 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.dag.api.TezReflectionException;
 import org.apache.tez.dag.api.TezUncheckedException;
 
-@Private
 public class ReflectionUtils {
 
   private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<String, Class<?>>();
 
-  @Private
   public static Class<?> getClazz(String className) throws TezReflectionException {
     Class<?> clazz = CLAZZ_CACHE.get(className);
     if (clazz == null) {
@@ -73,7 +70,6 @@ public class ReflectionUtils {
     return instance;
   }
 
-  @Private
   public static <T> T createClazzInstance(String className) throws TezReflectionException {
     Class<?> clazz = getClazz(className);
     @SuppressWarnings("unchecked")
@@ -81,7 +77,6 @@ public class ReflectionUtils {
     return instance;
   }
 
-  @Private
   public static <T> T createClazzInstance(String className, Class<?>[] parameterTypes, Object[] parameters)
     throws TezReflectionException {
     Class<?> clazz = getClazz(className);

--- a/tez-api/src/main/java/org/apache/tez/common/ServicePluginLifecycle.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ServicePluginLifecycle.java
@@ -14,8 +14,6 @@
 
 package org.apache.tez.common;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * Defines a lifecycle for a Service. The typical implementation for services when used within the
@@ -26,8 +24,6 @@ import org.apache.hadoop.classification.InterfaceStability;
  * stop() - is invoked when the service is no longer required, and could be invoked while in any
  * state, in case of failures
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public interface ServicePluginLifecycle {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/common/TezUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/TezUtils.java
@@ -30,7 +30,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.client.TezClientUtils;
 import org.apache.tez.dag.api.UserPayload;
@@ -42,7 +41,6 @@ import org.xerial.snappy.SnappyOutputStream;
  * Utility methods for setting up a DAG. Has helpers for setting up log4j configuration, converting
  * {@link org.apache.hadoop.conf.Configuration} to {@link org.apache.tez.dag.api.UserPayload} etc.
  */
-@InterfaceAudience.Public
 public class TezUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(TezUtils.class);

--- a/tez-api/src/main/java/org/apache/tez/common/annotation/ConfigurationProperty.java
+++ b/tez-api/src/main/java/org/apache/tez/common/annotation/ConfigurationProperty.java
@@ -23,9 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
-@Private
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ConfigurationProperty {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/ConfigurationScope.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/ConfigurationScope.java
@@ -22,9 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
-@Private
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ConfigurationScope {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/DAGNotRunningException.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/DAGNotRunningException.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 /**
  *  Checked Exception thrown upon error
  */
-@Private
 public class DAGNotRunningException extends TezException {
   private static final long serialVersionUID = 6337442733802964448L;
   public DAGNotRunningException(Throwable cause) { super(cause); }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/DAGSubmissionTimedOut.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/DAGSubmissionTimedOut.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Exception thrown when DAG submission to a Tez Session times out.
  */
-@Public
 public class DAGSubmissionTimedOut extends TezException {
 
   private static final long serialVersionUID = 8521202283261990622L;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/DagTypeConverters.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/DagTypeConverters.java
@@ -17,12 +17,10 @@
  */
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
-@Private
 public class DagTypeConverters {
 
   public static UserPayload convertToTezUserPayload(@Nullable ByteBuffer payload, int version) {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/DataSinkDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/DataSinkDescriptor.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.security.Credentials;
 
 import com.google.common.collect.Sets;
@@ -34,7 +33,6 @@ import com.google.common.collect.Sets;
  * Defines the output and output committer for a data sink 
  *
  */
-@Public
 public class DataSinkDescriptor {
   private final OutputDescriptor outputDescriptor;
   private final OutputCommitterDescriptor committerDescriptor;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/DataSourceDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/DataSourceDescriptor.java
@@ -26,9 +26,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.tez.dag.api.TaskLocationHint;
@@ -41,7 +38,6 @@ import com.google.common.collect.Sets;
  * Defines the input and input initializer for a data source 
  *
  */
-@Public
 public class DataSourceDescriptor {
   private final InputDescriptor inputDescriptor;
   private final InputInitializerDescriptor initializerDescriptor;
@@ -178,7 +174,6 @@ public class DataSourceDescriptor {
    * Returns -1 when this is determined at runtime in the AM.
    * @return number of tasks
    */
-  @InterfaceAudience.Private
   public int getNumberOfShards() {
     return numShards;
   }
@@ -188,7 +183,6 @@ public class DataSourceDescriptor {
    * Is null when this calculation happens on the AppMaster (default)
    * @return credentials.
    */
-  @InterfaceAudience.Private
   public @Nullable Credentials getCredentials() {
     return credentials;
   }
@@ -198,7 +192,6 @@ public class DataSourceDescriptor {
    * Is null when shard calculation happens on the AppMaster (default)
    * @return List of {@link TaskLocationHint}
    */
-  @InterfaceAudience.Private
   public @Nullable VertexLocationHint getLocationHint() {
     return locationHint;
   }
@@ -207,7 +200,6 @@ public class DataSourceDescriptor {
    * Get the list of additional local files which were specified during creation.
    * @return  Map of additional local files or null if there are none
    */
-  @InterfaceAudience.Private
   public @Nullable Map<String, LocalResource> getAdditionalLocalFiles() {
     return additionalLocalFiles;
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/Edge.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/Edge.java
@@ -17,8 +17,6 @@
  */
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Edge defines the connection between a producer and consumer vertex in the DAG.
@@ -27,7 +25,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * edge.
  * 
  */
-@Public
 public class Edge {
 
   private final Vertex inputVertex;
@@ -87,7 +84,6 @@ public class Edge {
   /*
    * Used to identify the edge in the configuration
    */
-  @Private
   public String getId() {
     // ensure it is unique.
     return String.valueOf(System.identityHashCode(this));

--- a/tez-api/src/main/java/org/apache/tez/dag/api/EdgeManagerPlugin.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/EdgeManagerPlugin.java
@@ -21,8 +21,6 @@ package org.apache.tez.dag.api;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.runtime.api.events.DataMovementEvent;
 import org.apache.tez.runtime.api.events.InputReadErrorEvent;
 
@@ -31,8 +29,6 @@ import org.apache.tez.runtime.api.events.InputReadErrorEvent;
  * consumer vertices. The routing is bi-directional. Users can customize the 
  * routing by providing an implementation of this interface.
  */
-@Public
-@Unstable
 public abstract class EdgeManagerPlugin {
 
   private final EdgeManagerPluginContext context;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/EdgeManagerPluginContext.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/EdgeManagerPluginContext.java
@@ -18,16 +18,12 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 
 /**
  * Context information provided to {@link EdgeManagerPlugin}s
  * This interface is not supposed to be implemented by users
  *
  */
-@Public
-@Unstable
 public interface EdgeManagerPluginContext {
   
   /**

--- a/tez-api/src/main/java/org/apache/tez/dag/api/EdgeManagerPluginDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/EdgeManagerPluginDescriptor.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Describes the @link {@link EdgeManagerPlugin}
  */
-@Public
 public class EdgeManagerPluginDescriptor extends EntityDescriptor<EdgeManagerPluginDescriptor> {
 
   private EdgeManagerPluginDescriptor(String edgeManagerPluginClassName) {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/EntityDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/EntityDescriptor.java
@@ -25,8 +25,6 @@ import java.nio.ByteBuffer;
 import java.util.Objects;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
@@ -38,7 +36,6 @@ import org.apache.hadoop.io.Writable;
   * <br>This is not supposed to be extended by users. Users are expected to use the derived
   * classes for specific entities
  */
-@Public
 @SuppressWarnings("unchecked")
 public class EntityDescriptor<T extends EntityDescriptor<T>> implements Writable {
   // abstract in Tez, but not in MR3
@@ -48,7 +45,6 @@ public class EntityDescriptor<T extends EntityDescriptor<T>> implements Writable
   private String className;
   protected String historyText;
 
-  @Private // for Writable
   public EntityDescriptor() {
   }
 
@@ -86,7 +82,6 @@ public class EntityDescriptor<T extends EntityDescriptor<T>> implements Writable
     return (T) this;
   }
 
-  @Private // Internal use only
   public String getHistoryText() {
     return this.historyText;
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/GroupInputEdge.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/GroupInputEdge.java
@@ -17,8 +17,6 @@
  */
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.MergedLogicalInput;
 
 /**
@@ -28,7 +26,6 @@ import org.apache.tez.runtime.api.MergedLogicalInput;
  * the input vertices. The output vertex tasks see a unified/merged
  * view of the data from all the input vertices.
  */
-@Public
 public class GroupInputEdge {
 
   private final VertexGroup inputVertexGroup;
@@ -96,7 +93,6 @@ public class GroupInputEdge {
   /*
    * Used to identify the edge in the configuration
    */
-  @Private
   public String getId() {
     return String.valueOf(this.hashCode());
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/InputDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/InputDescriptor.java
@@ -18,17 +18,13 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.Input;
 
 /**
  * Describes the {@link Input}
  */
-@Public
 public class InputDescriptor extends EntityDescriptor<InputDescriptor> {
 
-  @Private // for Writable
   public InputDescriptor() {
     super();
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/InputInitializerDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/InputInitializerDescriptor.java
@@ -18,17 +18,13 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.InputInitializer;
 
 /**
  * Describes the {@link InputInitializer}
  */
-@Public
 public class InputInitializerDescriptor extends EntityDescriptor<InputInitializerDescriptor> {
 
-  @Private // for Writable
   public InputInitializerDescriptor() {
     super();
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/OutputCommitterDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/OutputCommitterDescriptor.java
@@ -18,17 +18,13 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.OutputCommitter;
 
 /**
  * Describes the {@link OutputCommitter}
  */
-@Public
 public class OutputCommitterDescriptor extends EntityDescriptor<OutputCommitterDescriptor> {
 
-  @Private // for Writable
   public OutputCommitterDescriptor() {
     super();
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/OutputDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/OutputDescriptor.java
@@ -18,17 +18,13 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.Output;
 
 /**
  * Describes the {@link Output}
  */
-@Public
 public class OutputDescriptor extends EntityDescriptor<OutputDescriptor> {
 
-  @Private // for Writable
   public OutputDescriptor() {
     super();
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/PreWarmVertex.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/PreWarmVertex.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.tez.client.TezClient;
@@ -49,8 +47,6 @@ import org.apache.tez.runtime.api.Processor;
  * processors can be used to initialize classes etc. and setup the environment
  * for the actual processing to reduce latency.
  */
-@Unstable
-@Public
 public class PreWarmVertex extends Vertex {
 
 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/ProcessorDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/ProcessorDescriptor.java
@@ -18,17 +18,13 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.Processor;
 
 /**
  * Describes the {@link Processor}
  */
-@Public
 public class ProcessorDescriptor extends EntityDescriptor<ProcessorDescriptor> {
 
-  @Private // for Writable
   public ProcessorDescriptor() {
     super();
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/RootInputLeafOutput.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/RootInputLeafOutput.java
@@ -18,9 +18,7 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
-@Private
 public class RootInputLeafOutput <T extends EntityDescriptor<T>, S extends EntityDescriptor<S>> {
 
   private final String name;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/Scope.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/Scope.java
@@ -17,9 +17,7 @@
  */
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
-@Private
 public enum Scope {
   // DO NOT CHANGE THE ORDER
   AM,       // can only been set at AM level 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/SessionNotRunning.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/SessionNotRunning.java
@@ -18,13 +18,11 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Exception thrown when the client cannot communicate with the Tez Session
  * as the Tez Session is no longer running.
  */
-@Public
 public class SessionNotRunning extends TezException {
 
   private static final long serialVersionUID = -287996170505550316L;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezException.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezException.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  *  Checked Exception thrown upon error
  */
-@Public
 public class TezException extends Exception {
   private static final long serialVersionUID = 6337442733802964447L;
   public TezException(Throwable cause) { super(cause); }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezUncheckedException.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezUncheckedException.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Unchecked Exception thrown upon error
  */
-@Public
 public class TezUncheckedException extends RuntimeException {
 
   private static final long serialVersionUID = -4956339297375386184L;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/UserPayload.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/UserPayload.java
@@ -22,14 +22,11 @@ import com.google.common.annotations.VisibleForTesting;
 import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * Wrapper class to hold user payloads
  * Provides a version to help in evolving the payloads
  */
-@Public
 public final class UserPayload {
   private final ByteBuffer payload;
   private final int version;
@@ -93,7 +90,6 @@ public final class UserPayload {
     return payload != null && payload != EMPTY_BYTE;
   }
 
-  @InterfaceStability.Unstable
   @VisibleForTesting
   public byte[] deepCopyAsArray() {
     ByteBuffer src = getPayload();

--- a/tez-api/src/main/java/org/apache/tez/dag/api/VertexGroup.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/VertexGroup.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -38,7 +37,6 @@ import com.google.common.collect.Sets;
  * member vertices of the VertexGroup.
  * A VertexGroup is not part of the final DAG.
  */
-@Public
 public class VertexGroup {
 
   static class GroupInfo {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/VertexLocationHint.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/VertexLocationHint.java
@@ -21,14 +21,12 @@ package org.apache.tez.dag.api;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Describes the placements hints for tasks in a vertex.
  * The system will make a best-effort attempt to run the tasks 
  * close to the specified locations.
  */
-@Public
 public class VertexLocationHint  {
 
   private final List<TaskLocationHint> taskLocationHints;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/VertexManagerPluginDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/VertexManagerPluginDescriptor.java
@@ -18,16 +18,12 @@
 
 package org.apache.tez.dag.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Describes the {@link VertexManagerPlugin} 
  */
-@Public
 public class VertexManagerPluginDescriptor extends EntityDescriptor<VertexManagerPluginDescriptor> {
 
-  @Private // for Writable
   public VertexManagerPluginDescriptor() {
     super();
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
@@ -24,8 +24,6 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.tez.dag.api.TezException;
 
@@ -33,7 +31,6 @@ import org.apache.tez.dag.api.TezException;
  * Class for monitoring the <code>DAG</code> running in a Tez DAG
  * Application Master.
  */
-@Public
 public abstract class DAGClient implements Closeable {
 
   /**
@@ -42,7 +39,6 @@ public abstract class DAGClient implements Closeable {
    */
   public abstract String getExecutionContext();
 
-  @Private
   /**
    * Get the YARN ApplicationReport for the app running the DAG. For performance
    * reasons this may be stale copy and should be used to access static info. It

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGStatus.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGStatus.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.dag.api.DAG;
 import org.apache.tez.dag.api.records.DAGProtos.DAGStatusProtoOrBuilder;
@@ -35,7 +33,6 @@ import org.apache.tez.dag.api.TezUncheckedException;
 /**
  * Describes the status of the {@link DAG}
  */
-@Public
 public class DAGStatus {
 
   private static final String LINE_SEPARATOR = System
@@ -59,7 +56,6 @@ public class DAGStatus {
   TezCounters dagCounters = null;
   AtomicBoolean countersInitialized = new AtomicBoolean(false);
 
-  @InterfaceAudience.Private
   public DAGStatus(DAGStatusProtoOrBuilder proxy, DagStatusSource source) {
     this.proxy = proxy;
     this.source = source;
@@ -143,7 +139,6 @@ public class DAGStatus {
     return dagCounters;
   }
 
-  @InterfaceAudience.Private
   DagStatusSource getSource() {
     return this.source;
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DagStatusSource.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DagStatusSource.java
@@ -14,9 +14,7 @@
 
 package org.apache.tez.dag.api.client;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
-@InterfaceAudience.Private
 public enum DagStatusSource {
   AM, RM, TIMELINE
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/Progress.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/Progress.java
@@ -18,15 +18,11 @@
 
 package org.apache.tez.dag.api.client;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.dag.api.records.DAGProtos.ProgressProtoOrBuilder;
 
 /**
  * Describes the progress made by DAG execution
  */
-@Public
-@Evolving
 public class Progress {
   
   ProgressProtoOrBuilder proxy = null;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/StatusGetOpts.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/StatusGetOpts.java
@@ -18,15 +18,11 @@
 
 package org.apache.tez.dag.api.client;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * Status Get Options used when making calls like getDAGStatus and
  * getVertexStatus in DAGClient
  */
-@Public
-@Evolving
 public enum StatusGetOpts {
   /** Retrieve Counters with Status */
   GET_COUNTERS

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/VertexStatus.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/VertexStatus.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.dag.api.Vertex;
 import org.apache.tez.dag.api.records.DAGProtos;
@@ -33,7 +32,6 @@ import org.apache.tez.dag.api.TezUncheckedException;
 /**
  * Describes the status of the {@link Vertex}
  */
-@Public
 public class VertexStatus {
 
   public enum State {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientAMProtocolBlockingPB.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientAMProtocolBlockingPB.java
@@ -18,11 +18,9 @@
 
 package org.apache.tez.dag.api.client.rpc;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.DAGClientAMProtocol;
 
-@Private
 @ProtocolInfo(
     protocolName = "org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolBlockingPB",
     protocolVersion = 1)

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/package-info.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.dag.api.client.rpc;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/event/VertexState.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/event/VertexState.java
@@ -18,14 +18,10 @@
 
 package org.apache.tez.dag.api.event;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * Vertex state information.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public enum VertexState {
   /**
    * Indicates that the Vertex had entered the SUCCEEDED state. A vertex could

--- a/tez-api/src/main/java/org/apache/tez/dag/api/event/VertexStateUpdate.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/event/VertexStateUpdate.java
@@ -18,14 +18,10 @@
 
 package org.apache.tez.dag.api.event;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * Updates that are sent to user code running within the AM, on Vertex state changes.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class VertexStateUpdate {
 
   private final String vertexName;

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/AbstractLogicalIOProcessor.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/AbstractLogicalIOProcessor.java
@@ -17,7 +17,6 @@
  */
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Abstract representation of the interface {@link LogicalIOProcessor}.
@@ -25,7 +24,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * to be the base class that is derived to implement the user {@link Processor}
  *
  */
-@Public
 public abstract class AbstractLogicalIOProcessor implements LogicalIOProcessor,
     LogicalIOProcessorFrameworkInterface {
   private final ProcessorContext context;

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/AbstractLogicalOutput.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/AbstractLogicalOutput.java
@@ -19,7 +19,6 @@ package org.apache.tez.runtime.api;
 
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * An abstract class which should be the base class for all implementations of LogicalOutput.
@@ -30,7 +29,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * This includes default implementations of a new method for convenience.
  *
  */
-@Public
 public abstract class AbstractLogicalOutput implements LogicalOutput, LogicalOutputFrameworkInterface {
 
   private final int numPhysicalOutputs;

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/DecompressorPool.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/DecompressorPool.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 
-@Public
 public interface DecompressorPool {
   public Decompressor getDecompressor(CompressionCodec codec);
   public void returnDecompressor(Class<? extends Compressor> compressorType, Decompressor decompressor);

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/Event.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/Event.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Base class for all events generated within the Tez execution engine.
@@ -26,7 +25,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * and Outputs.
  * Users are not expected to implement or derive from this class
  */
-@Public
 public abstract class Event {
 
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/Input.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/Input.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Represents an input through which a {@link Processor} receives data on an edge.
@@ -29,7 +28,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * 
  * Actual implementations are expected to derive from {@link AbstractLogicalInput}
  */
-@Public
 public interface Input {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputContext.java
@@ -18,13 +18,11 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Context handle for the Input to initialize itself.
  * This interface is not supposed to be implemented by users
  */
-@Public
 public interface InputContext extends TaskContext {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputFrameworkInterface.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputFrameworkInterface.java
@@ -22,7 +22,6 @@ package org.apache.tez.runtime.api;
 
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 
 /**
@@ -44,7 +43,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * 
  * Input implementations are expected to derive from {@link AbstractLogicalInput}
  */
-@Public
 public interface InputFrameworkInterface {
   /**
    * Initializes the <code>Input</code>.

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputInitializer.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputInitializer.java
@@ -21,8 +21,6 @@ package org.apache.tez.runtime.api;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.dag.api.event.VertexStateUpdate;
 import org.apache.tez.runtime.api.events.InputInitializerEvent;
 
@@ -32,8 +30,6 @@ import org.apache.tez.runtime.api.events.InputInitializerEvent;
  * distribute data across the tasks for the vertex, determine the number of
  * tasks at runtime, update the Input payload etc.
  */
-@Unstable
-@Public
 public abstract class InputInitializer {
 
   private final InputInitializerContext initializerContext;

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputInitializerContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputInitializerContext.java
@@ -22,8 +22,6 @@ import javax.annotation.Nullable;
 import java.util.EnumSet;
 import java.util.Set;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.tez.common.counters.TezCounters;
@@ -34,8 +32,6 @@ import org.apache.tez.dag.api.event.VertexStateUpdate;
 /**
  * A context that provides information to the {@link InputInitializer}
  */
-@Unstable
-@Public
 public interface InputInitializerContext {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputSpecUpdate.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputSpecUpdate.java
@@ -20,9 +20,6 @@ package org.apache.tez.runtime.api;
 
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 
 import com.google.common.collect.Lists;
@@ -33,8 +30,6 @@ import com.google.common.collect.Lists;
  * numPhysicalInputs for each work unit.
  * 
  */
-@Unstable
-@Public
 public class InputSpecUpdate {
 
   private final boolean forAllWorkUnits;
@@ -82,7 +77,6 @@ public class InputSpecUpdate {
     this.numPhysicalInputs = Lists.newArrayList(perWorkUnitNumPhysicalInputs);
   }
 
-  @Private
   public int getNumPhysicalInputsForWorkUnit(int index) {
     if (this.forAllWorkUnits) {
       return numPhysicalInputs.get(0);
@@ -91,13 +85,11 @@ public class InputSpecUpdate {
     }
   }
   
-  @Private
   /* Used for recovery serialization */
   public boolean isForAllWorkUnits() {
     return this.forAllWorkUnits;
   }
   
-  @Private
   /* Used for recovery serialization */
   public List<Integer> getAllNumPhysicalInputs() {
     return numPhysicalInputs;

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputStatistics.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputStatistics.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.dag.api.Vertex;
 
 /**
@@ -27,8 +25,6 @@ import org.apache.tez.dag.api.Vertex;
  * logical input in a {@link Vertex}. Inputs can be external inputs or inputs
  * from other vertices.
  */
-@Public
-@Evolving
 public interface InputStatistics {
   
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalIOProcessor.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalIOProcessor.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Represents a processor which consumes {@link LogicalInput}s and produces
  * {@link LogicalOutput}s
  */
-@Public
 public interface LogicalIOProcessor extends Processor {
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalIOProcessorFrameworkInterface.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalIOProcessorFrameworkInterface.java
@@ -20,14 +20,12 @@ package org.apache.tez.runtime.api;
 
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Represents a processor framework interface which consumes {@link LogicalInput}s and produces
  * {@link LogicalOutput}s.
  * Users are expected to implements {@link AbstractLogicalIOProcessor}
  */
-@Public
 public interface LogicalIOProcessorFrameworkInterface extends ProcessorFrameworkInterface {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalInput.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalInput.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * An {@link Input} which handles all incoming physical connections on an
@@ -28,6 +27,5 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * 
  * User implementations are expected to derive from {@link AbstractLogicalInput}
  */
-@Public
 public interface LogicalInput extends Input {
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalInputFrameworkInterface.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalInputFrameworkInterface.java
@@ -20,13 +20,11 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Defines the framework facing interfact for a {@link LogicalInput}
  *
  * User implementations are expected to derive from {@link AbstractLogicalInput}
  */
-@Public
 public interface LogicalInputFrameworkInterface extends InputFrameworkInterface {
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalOutput.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalOutput.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * An @link {@link Output} which handles all outgoing physical connections on an
@@ -27,7 +26,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * outputs from the {@link Processor}
  * Users are expected to derive from {@link AbstractLogicalOutput}
  */
-@Public
 public interface LogicalOutput extends Output {
 
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalOutputFrameworkInterface.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/LogicalOutputFrameworkInterface.java
@@ -20,12 +20,10 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Framework facing interface for the {@link LogicalOutput}
  * Users are expected to derive from {@link AbstractLogicalOutput}
  */
-@Public
 public interface LogicalOutputFrameworkInterface extends OutputFrameworkInterface {
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MemoryUpdateCallback.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MemoryUpdateCallback.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 
 /**
  * This interface will be used by Tez to inform components about available
@@ -28,8 +26,6 @@ import org.apache.hadoop.classification.InterfaceStability.Unstable;
  * for appropriate memory limits for the respective components.
  * 
  */
-@Unstable
-@Public
 public abstract class MemoryUpdateCallback {
 
   public abstract void memoryAssigned(long assignedSize);

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MergedInputContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MergedInputContext.java
@@ -18,14 +18,12 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.dag.api.UserPayload;
 
 /**
  * Context for {@link MergedLogicalInput}
  * This interface is not supposed to be implemented by users
  */
-@Public
 public interface MergedInputContext {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MergedLogicalInput.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MergedLogicalInput.java
@@ -22,8 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * A LogicalInput that is used to merge the data from multiple inputs and provide a
@@ -37,8 +35,6 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
  * take care of initializing and closing the Input after a {@link Processor} completes. </p>
  * <p/>
  */
-@Public
-@Evolving
 public abstract class MergedLogicalInput implements LogicalInput {
 
   private AtomicBoolean notifiedInputReady = new AtomicBoolean(false);

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/ObjectRegistry.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/ObjectRegistry.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * A simple shared object registry to cache objects in the memory of the
@@ -32,8 +30,6 @@ import org.apache.hadoop.classification.InterfaceStability.Evolving;
  * is while the session (to which that task belongs) is running. <br>
  * This interface is not supposed to be implemented by users.
  */
-@Public
-@Evolving
 public interface ObjectRegistry {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/Output.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/Output.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Represents an Output through which a TezProcessor writes information to an edge.
@@ -30,7 +29,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * Users are expected to derive from {@link AbstractLogicalOutput}
  *
  */
-@Public
 public interface Output {
 
 

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/OutputCommitter.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/OutputCommitter.java
@@ -18,16 +18,12 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.dag.api.client.VertexStatus;
 
 /**
  * OutputCommitter to "finalize" the output and make it user-visible if needed.
  * The OutputCommitter is allowed only on a terminal Output.
  */
-@InterfaceStability.Evolving
-@Public
 public abstract class OutputCommitter {
 
   private final OutputCommitterContext committerContext;

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/OutputCommitterContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/OutputCommitterContext.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.dag.api.UserPayload;
 
@@ -27,7 +26,6 @@ import org.apache.tez.dag.api.UserPayload;
  * information that it needs. This interface is not supposed to be implemented
  * by users
  */
-@Public
 public interface OutputCommitterContext {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/OutputContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/OutputContext.java
@@ -18,13 +18,11 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Context handle for the Output to initialize itself.
  * This interface is not supposed to be implemented by users
  */
-@Public
 public interface OutputContext extends TaskContext {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/OutputFrameworkInterface.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/OutputFrameworkInterface.java
@@ -22,7 +22,6 @@ package org.apache.tez.runtime.api;
 
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * Represents the Tez framework part of an {@link org.apache.tez.runtime.api.Output}.
@@ -38,7 +37,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * Users are expected to derive from {@link AbstractLogicalOutput}
  *
  */
-@Public
 public interface OutputFrameworkInterface {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/OutputStatistics.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/OutputStatistics.java
@@ -19,8 +19,6 @@
 package org.apache.tez.runtime.api;
 
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.dag.api.Vertex;
 
 /**
@@ -28,8 +26,6 @@ import org.apache.tez.dag.api.Vertex;
  * logical output in a {@link Vertex}. Outputs can be external outputs or
  * outputs to other vertices.
  */
-@Public
-@Evolving
 public interface OutputStatistics {
   
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/OutputStatisticsReporter.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/OutputStatisticsReporter.java
@@ -18,14 +18,10 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * Report statistics about the {@link Output}
  */
-@Public
-@Evolving
 public interface OutputStatisticsReporter {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/Processor.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/Processor.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 
 /**
  * {@link Processor} represents the <em>Tez</em> entity responsible for
@@ -27,6 +26,5 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
  * 
  * Users are expected to derive from {@link AbstractLogicalIOProcessor}
  */
-@Public
 public interface Processor {
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/ProcessorFrameworkInterface.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/ProcessorFrameworkInterface.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 
 import java.util.List;
 
@@ -32,7 +30,6 @@ import java.util.List;
  * <p/>
  * Users are expected to derive from {@link AbstractLogicalIOProcessor}
  */
-@Public
 public interface ProcessorFrameworkInterface {
 
   /**
@@ -63,6 +60,5 @@ public interface ProcessorFrameworkInterface {
    * Indicates <code>Processor</code> to abort. Cleanup can be done.
    *
    */
-  @Unstable
   public void abort();
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/ProgressFailedException.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/ProgressFailedException.java
@@ -18,12 +18,8 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.dag.api.TezException;
 
-@Public
-@Evolving
 /**
  * Exception invoked when getProgress fails
  */

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/Writer.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/Writer.java
@@ -18,15 +18,11 @@
 
 package org.apache.tez.runtime.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * A <code>Writer</code> represents the data being written by an {@link Output}
  * It encapsulates the data type etc of the data being provided by the {@link Output}
  * E.g. There can be Key-Value writers, byte writers etc. */
-@Public
-@Evolving
 public abstract class Writer {
 
 }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/CompositeDataMovementEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/CompositeDataMovementEvent.java
@@ -21,8 +21,6 @@ package org.apache.tez.runtime.api.events;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.dag.api.EdgeManagerPluginOnDemand.CompositeEventRouteMetadata;
 import org.apache.tez.runtime.api.Event;
 
@@ -38,7 +36,6 @@ import org.apache.tez.runtime.api.Event;
  * the Physical Outputs that it generates.
  * 
  */
-@Public
 public class CompositeDataMovementEvent extends Event
   implements com.datamonad.mr3.api.CompositeEventToLogicalInput {
 
@@ -100,7 +97,6 @@ public class CompositeDataMovementEvent extends Event
    *         {@link CompositeDataMovementEvent} with indices specified by the
    *         method parameters
    */
-  @Private
   public DataMovementEvent expand(int sourceIndex, int targetIndex) {
     return new DataMovementEvent(sourceIndex, targetIndex, version, userPayload);
   }
@@ -157,7 +153,6 @@ public class CompositeDataMovementEvent extends Event
     };
   }
 
-  @Private
   public CompositeRoutedDataMovementEvent expandRouted(CompositeEventRouteMetadata routeMeta) {
     return CompositeRoutedDataMovementEvent.create(routeMeta.getSource(), routeMeta.getTarget(), routeMeta.getCount(), version, userPayload);
   }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/CustomProcessorEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/CustomProcessorEvent.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.runtime.api.Event;
 
 import java.nio.ByteBuffer;
@@ -47,7 +45,6 @@ public class CustomProcessorEvent extends Event
     return new CustomProcessorEvent(payload);
   }
 
-  @Private
   public static CustomProcessorEvent create(ByteBuffer payload, int version) {
     return new CustomProcessorEvent(payload, version);
   }
@@ -56,7 +53,6 @@ public class CustomProcessorEvent extends Event
     return payload.asReadOnlyBuffer();
   }
 
-  @Private
   public void setVersion(int version) {
     this.version = version;
   }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/DataMovementEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/DataMovementEvent.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.Output;
 
@@ -31,7 +29,6 @@ import java.nio.ByteBuffer;
  * ( such as URI for file-based output data, port info in case of
  * streaming-based data transfers ) to the Input on the destination vertex.
  */
-@Public
 public final class DataMovementEvent extends Event
   implements com.datamonad.mr3.api.EventToLogicalInput {
 
@@ -61,7 +58,6 @@ public final class DataMovementEvent extends Event
     return CompositeRoutedDataMovementEvent.create(srcOutputIndex, destInputIndex, count, version, userPayload);
   }
 
-  @Private
   public static DataMovementEvent createRaw(int version,
                                             ByteBuffer userPayload) {
     return new DataMovementEvent(-1, -1, version, userPayload);
@@ -100,7 +96,6 @@ public final class DataMovementEvent extends Event
   private int version;
 
 
-  @Private
   DataMovementEvent(int sourceIndex,
                     int targetIndex,
                     int version,
@@ -126,7 +121,6 @@ public final class DataMovementEvent extends Event
     return new DataMovementEvent(sourceIndex, -1, -1, userPayload);
   }
   
-  @Private
   /**
    * Constructor for Processor-generated User Events
    * @param userPayload
@@ -135,7 +129,6 @@ public final class DataMovementEvent extends Event
     return new DataMovementEvent(userPayload);
   }
 
-  @Private
   public static DataMovementEvent create(int sourceIndex,
                                          int targetIndex,
                                          int version,
@@ -153,7 +146,6 @@ public final class DataMovementEvent extends Event
    * @return Copy of this {@link DataMovementEvent} with the target input index
    *         added to it
    */
-  @Private
   public DataMovementEvent makeCopy(int targetIndex) {
     return new DataMovementEvent(sourceIndex, targetIndex, version, userPayload);
   }
@@ -170,7 +162,6 @@ public final class DataMovementEvent extends Event
     return targetIndex;
   }
 
-  @Private
   public void setTargetIndex(int targetIndex) {
     this.targetIndex = targetIndex;
   }
@@ -179,7 +170,6 @@ public final class DataMovementEvent extends Event
     return version;
   }
 
-  @Private
   public void setVersion(int version) {
     this.version = version;
   }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputConfigureVertexTasksEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputConfigureVertexTasksEvent.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.dag.api.VertexLocationHint;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.InputInitializer;
@@ -30,8 +28,6 @@ import org.apache.tez.runtime.api.InputSpecUpdate;
  * to configure the tasks of the vertex. It could change the task 
  * placement hints or input specification for the inputs of the tasks
  */
-@Unstable
-@Public
 public class InputConfigureVertexTasksEvent extends Event
   implements com.datamonad.mr3.api.EventFromInputInitializerToVertexManager {
 

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputDataInformationEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputDataInformationEvent.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.dag.api.VertexManagerPlugin;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.InputInitializer;
@@ -41,8 +39,6 @@ import java.nio.ByteBuffer;
  * Events, after being processed by a {@link VertexManagerPlugin}, must
  * contain the payload in a serialized form.
  */
-@Unstable
-@Public
 public final class InputDataInformationEvent extends Event
   implements
     com.datamonad.mr3.api.EventFromInputInitializerToVertexManager,

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputFailedEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputFailedEvent.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.Event;
 
@@ -28,7 +27,6 @@ import org.apache.tez.runtime.api.Event;
  * source.
  * Users are not expected to send this event.
  */
-@Private
 public class InputFailedEvent extends Event
   implements com.datamonad.mr3.api.EventToLogicalInput {
 
@@ -61,17 +59,14 @@ public class InputFailedEvent extends Event
    */
   private int version;
   
-  @Private // for Writable
   public InputFailedEvent() {
   }
   
-  @Private
   private InputFailedEvent(int targetIndex, int version) {
     this.targetIndex = targetIndex;
     this.version = version;
   }
 
-  @Private
   public static InputFailedEvent create(int targetIndex, int version) {
     return new InputFailedEvent(targetIndex, version);
   }
@@ -87,7 +82,6 @@ public class InputFailedEvent extends Event
    * @return copy of the {@link InputFailedEvent} with the target input index
    *         added
    */
-  @Private
   public InputFailedEvent makeCopy(int targetIndex) {
     return create(targetIndex, version);
   }
@@ -96,7 +90,6 @@ public class InputFailedEvent extends Event
     return targetIndex;
   }
 
-  @Private
   public void setTargetIndex(int targetIndex) {
     this.targetIndex = targetIndex;
   }
@@ -105,7 +98,6 @@ public class InputFailedEvent extends Event
     return version;
   }
 
-  @Private
   public void setVersion(int version) {
     this.version = version;
   }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputInitializerEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputInitializerEvent.java
@@ -21,9 +21,6 @@
 package org.apache.tez.runtime.api.events;
 
 import java.util.Objects;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.InputInitializer;
 
@@ -40,8 +37,6 @@ import java.nio.ByteBuffer;
  * was running failed. If the Task had succeeded once, the event would already have been sent - and
  * will not be resent when the task reruns and succeeds. </p>
  */
-@Unstable
-@Public
 public class InputInitializerEvent extends Event
   implements com.datamonad.mr3.api.EventToInputInitializer {
 
@@ -106,7 +101,6 @@ public class InputInitializerEvent extends Event
     return eventPayload == null ? null : eventPayload.asReadOnlyBuffer();
   }
 
-  @InterfaceAudience.Private
   public void setSourceVertexName(String srcVertexName) {
     this.sourceVertexName = srcVertexName;
   }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputReadErrorEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputReadErrorEvent.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.runtime.api.Event;
 
 /**
@@ -26,7 +25,6 @@ import org.apache.tez.runtime.api.Event;
  * This is not necessarily a fatal event - it's an indication to the AM to retry
  * source data generation.
  */
-@Public
 public final class InputReadErrorEvent extends Event {
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputUpdatePayloadEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputUpdatePayloadEvent.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.api.events;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.InputInitializer;
 
@@ -33,8 +31,6 @@ import java.util.Objects;
  * This event is specific to an Input, and should only be sent once - ideally
  * before {@link InputDataInformationEvent}s
  */
-@Unstable
-@Public
 public class InputUpdatePayloadEvent extends Event
   implements com.datamonad.mr3.api.EventFromInputInitializerToVertexManager {
 

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerEndReason.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerEndReason.java
@@ -14,11 +14,7 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public enum ContainerEndReason {
   NODE_FAILED, // Completed because the node running the container was marked as dead
   INTERNAL_PREEMPTION, // Preempted by the AM, due to an internal decision

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLaunchRequest.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLaunchRequest.java
@@ -14,8 +14,6 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
@@ -25,8 +23,6 @@ import org.apache.hadoop.yarn.api.records.Token;
 /**
  * Contains specifications for a container which needs to be launched
  */
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class ContainerLaunchRequest extends ContainerLauncherOperationBase {
 
   private final ContainerLaunchContext clc;

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncher.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncher.java
@@ -14,8 +14,6 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.tez.common.ServicePluginLifecycle;
 
 /**
@@ -23,8 +21,6 @@ import org.apache.tez.common.ServicePluginLifecycle;
  * of executors.
  */
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public abstract class ContainerLauncher implements ServicePluginLifecycle {
 
   private final ContainerLauncherContext containerLauncherContext;

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherContext.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherContext.java
@@ -15,13 +15,9 @@
 package org.apache.tez.serviceplugins.api;
 
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public interface ContainerLauncherContext extends ServicePluginContextBase {
 
   // TODO TEZ-2003 (post) TEZ-2664 Tez abstraction for ContainerId, NodeId, other YARN constructs

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherDescriptor.java
@@ -14,12 +14,8 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.tez.dag.api.NamedEntityDescriptor;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class ContainerLauncherDescriptor extends NamedEntityDescriptor<ContainerLauncherDescriptor> {
 
   private ContainerLauncherDescriptor(String containerLauncherName, String containerLauncherClassname) {

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherOperationBase.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherOperationBase.java
@@ -14,14 +14,10 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Token;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class ContainerLauncherOperationBase {
 
   // TODO TEZ-2702 (TEZ-2003 post)

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerStopRequest.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerStopRequest.java
@@ -14,8 +14,6 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Token;
@@ -23,8 +21,6 @@ import org.apache.hadoop.yarn.api.records.Token;
 /**
  * Contains specifications for a container which needs to be stopped
  */
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class ContainerStopRequest extends ContainerLauncherOperationBase {
 
   private final String schedulerName;

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ServicePluginError.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ServicePluginError.java
@@ -14,11 +14,7 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 /**
  * Represents errors from a ServicePlugin. The default implementation {@link ServicePluginErrorDefaults}
  * lists a basic set of errors.

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ServicePluginErrorDefaults.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ServicePluginErrorDefaults.java
@@ -26,7 +26,6 @@ package org.apache.tez.serviceplugins.api;/*
  * limitations under the License.
  */
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
  * A default set of errors from ServicePlugins
@@ -35,7 +34,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
  * Fatal errors cause the AM to go down.
  *
  */
-@InterfaceAudience.Public
 public enum ServicePluginErrorDefaults implements ServicePluginError {
   /**
    * Indicates that the service is currently unavailable.

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskAttemptEndReason.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskAttemptEndReason.java
@@ -14,11 +14,7 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public enum TaskAttemptEndReason {
   NODE_FAILED, // Completed because the node running the container was marked as dead
   COMMUNICATION_ERROR, // Communication error with the task

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskCommunicatorDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskCommunicatorDescriptor.java
@@ -14,12 +14,8 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.tez.dag.api.NamedEntityDescriptor;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class TaskCommunicatorDescriptor extends NamedEntityDescriptor<TaskCommunicatorDescriptor> {
 
 

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskScheduler.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskScheduler.java
@@ -16,8 +16,6 @@ package org.apache.tez.serviceplugins.api;
 
 import javax.annotation.Nullable;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -33,8 +31,6 @@ import org.apache.tez.common.ServicePluginLifecycle;
  * The plugin is initialized with an instance of {@link TaskSchedulerContext} - which provides
  * a mechanism to notify the system about allocation decisions and resources to the Tez framework.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public abstract class TaskScheduler implements ServicePluginLifecycle {
 
   // TODO TEZ-2003 (post) TEZ-2668

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskSchedulerContext.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskSchedulerContext.java
@@ -18,8 +18,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -39,8 +37,6 @@ import org.apache.tez.common.ContainerSignatureMatcher;
  * scheduler
  * which implement the {@link TaskScheduler} interface
  */
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public interface TaskSchedulerContext extends ServicePluginContextBase {
 
   class AppFinalStatus {

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskSchedulerDescriptor.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/TaskSchedulerDescriptor.java
@@ -14,12 +14,8 @@
 
 package org.apache.tez.serviceplugins.api;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.tez.dag.api.NamedEntityDescriptor;
 
-@InterfaceAudience.Public
-@InterfaceStability.Unstable
 public class TaskSchedulerDescriptor extends NamedEntityDescriptor<TaskSchedulerDescriptor> {
 
   private TaskSchedulerDescriptor(String taskSchedulerName, String schedulerClassname) {

--- a/tez-common/src/main/java/org/apache/tez/common/TezExecutors.java
+++ b/tez-common/src/main/java/org/apache/tez/common/TezExecutors.java
@@ -20,14 +20,10 @@ package org.apache.tez.common;
 
 import java.util.concurrent.ExecutorService;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 
 /**
  * Interface to capture factory of ExecutorService.
  */
-@Private
-@Unstable
 public interface TezExecutors {
 
   /**

--- a/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
+++ b/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
@@ -17,20 +17,16 @@
 
 package org.apache.tez.common;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 import java.util.BitSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-@Private
 public class TezUtilsInternal {
 
   private static final Pattern pattern = Pattern.compile("\\W");
-  @Private
   public static final int MAX_VERTEX_NAME_LENGTH = 40;
 
-  @Private
   public static String cleanVertexName(String vertexName) {
     return sanitizeString(vertexName).substring(0,
         vertexName.length() > MAX_VERTEX_NAME_LENGTH ? MAX_VERTEX_NAME_LENGTH : vertexName.length());

--- a/tez-common/src/main/java/org/apache/tez/dag/records/TezID.java
+++ b/tez-common/src/main/java/org/apache/tez/dag/records/TezID.java
@@ -24,8 +24,6 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.WritableComparable;
 
 /**
@@ -36,8 +34,6 @@ import org.apache.hadoop.io.WritableComparable;
  * @see TezTaskID
  * @see TezTaskAttemptID
  */
-@InterfaceAudience.Public
-@InterfaceStability.Stable
 public abstract class TezID implements WritableComparable<TezID> {
   public static final char SEPARATOR = '_';
   protected int id;

--- a/tez-common/src/main/java/org/apache/tez/dag/records/TezTaskAttemptID.java
+++ b/tez-common/src/main/java/org/apache/tez/dag/records/TezTaskAttemptID.java
@@ -22,8 +22,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * TezTaskAttemptID represents the immutable and unique identifier for
@@ -40,8 +38,6 @@ import org.apache.hadoop.classification.InterfaceStability;
  *
  * @see TezTaskID
  */
-@InterfaceAudience.Public
-@InterfaceStability.Stable
 public class TezTaskAttemptID extends TezID implements TaskIDAware {
   public static final String ATTEMPT = "attempt";
   private TezTaskID taskId;
@@ -61,7 +57,6 @@ public class TezTaskAttemptID extends TezID implements TaskIDAware {
     return tezTaskAttemptIDCache.getInstance(new TezTaskAttemptID(taskID, id));
   }
 
-  @InterfaceAudience.Private
   public static void clearCache() {
     tezTaskAttemptIDCache.clear();
   }

--- a/tez-common/src/main/java/org/apache/tez/dag/records/package-info.java
+++ b/tez-common/src/main/java/org/apache/tez/dag/records/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.dag.records;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-common/src/main/java/org/apache/tez/dag/utils/RelocalizationUtils.java
+++ b/tez-common/src/main/java/org/apache/tez/dag/utils/RelocalizationUtils.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -35,7 +34,6 @@ import org.apache.tez.dag.api.TezException;
 
 import com.google.common.collect.Lists;
 
-@InterfaceAudience.Private
 public class RelocalizationUtils {
   
   public static List<URL> processAdditionalResources(Map<String, URI> additionalResources,

--- a/tez-common/src/main/java/org/apache/tez/dag/utils/package-info.java
+++ b/tez-common/src/main/java/org/apache/tez/dag/utils/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.dag.utils;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-common/src/main/java/org/apache/tez/runtime/common/resources/InitialMemoryRequestContext.java
+++ b/tez-common/src/main/java/org/apache/tez/runtime/common/resources/InitialMemoryRequestContext.java
@@ -20,10 +20,8 @@ package org.apache.tez.runtime.common.resources;
 
 import java.util.Objects;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 
-@Private
 public class InitialMemoryRequestContext {
 
   public static enum ComponentType {

--- a/tez-common/src/main/java/org/apache/tez/runtime/common/resources/package-info.java
+++ b/tez-common/src/main/java/org/apache/tez/runtime/common/resources/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.common.resources;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/TezTaskCommunicatorImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/TezTaskCommunicatorImpl.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.Objects;
 
 import com.google.common.collect.Maps;
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.ipc.ProtocolSignature;
@@ -63,7 +62,6 @@ import org.apache.tez.runtime.api.impl.TezHeartbeatResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@InterfaceAudience.Private
 public class TezTaskCommunicatorImpl extends TaskCommunicator {
 
   private static final Logger LOG = LoggerFactory.getLogger(TezTaskCommunicatorImpl.class);

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/AMUserCodeException.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/AMUserCodeException.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.dag.app.dag.impl;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.dag.api.TezException;
 
 
@@ -28,7 +27,6 @@ import org.apache.tez.dag.api.TezException;
  * <li>EdgeManager</li> 
  * <li>InputInitializer</li>
  */
-@Private
 public class AMUserCodeException extends TezException {
 
   private static final long serialVersionUID = -3642816091492797520L;

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/package-info.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/package-info.java
@@ -15,6 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@InterfaceAudience.Private
 package org.apache.tez.dag.app.dag.impl;
-import org.apache.hadoop.classification.InterfaceAudience;

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/package-info.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/package-info.java
@@ -15,6 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@InterfaceAudience.Private
 package org.apache.tez.dag.app.dag;
-import org.apache.hadoop.classification.InterfaceAudience;

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/package-info.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/package-info.java
@@ -15,6 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@InterfaceAudience.Private
 package org.apache.tez.dag.app;
-import org.apache.hadoop.classification.InterfaceAudience;

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/security/authorize/TezAMPolicyProvider.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/security/authorize/TezAMPolicyProvider.java
@@ -17,8 +17,6 @@
  */
 package org.apache.tez.dag.app.security.authorize;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.security.authorize.PolicyProvider;
 import org.apache.hadoop.security.authorize.Service;
 import org.apache.tez.common.TezTaskUmbilicalProtocol;
@@ -28,8 +26,6 @@ import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolBlockingPB;
 /**
  * {@link PolicyProvider} for YARN Tez client protocols.
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class TezAMPolicyProvider extends PolicyProvider {
   
   private static final Service[] tezApplicationMasterServices = 

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/security/authorize/package-info.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/security/authorize/package-info.java
@@ -15,6 +15,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@InterfaceAudience.Private
 package org.apache.tez.dag.app.security.authorize;
-import org.apache.hadoop.classification.InterfaceAudience;

--- a/tez-examples/src/main/java/org/apache/tez/examples/TezExampleBase.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/TezExampleBase.java
@@ -33,8 +33,6 @@ import org.apache.tez.client.CallerContext;
 import org.apache.tez.common.TezUtilsInternal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -50,7 +48,6 @@ import org.apache.tez.dag.api.client.DAGStatus;
 import org.apache.tez.dag.api.client.StatusGetOpts;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-@InterfaceAudience.Private
 public abstract class TezExampleBase extends Configured implements Tool {
 
   private static final Logger LOG = LoggerFactory.getLogger(TezExampleBase.class);
@@ -300,7 +297,6 @@ public abstract class TezExampleBase extends Configured implements Tool {
   protected abstract int runJob(String[] args, TezConfiguration tezConf,
                                 TezClient tezClient) throws Exception;
   
-  @Private
   @VisibleForTesting
   public ApplicationId getAppId() {
     if (tezClientInternal == null) {

--- a/tez-mapreduce/src/main/java/org/apache/hadoop/mapred/split/TezGroupedSplit.java
+++ b/tez-mapreduce/src/main/java/org/apache/hadoop/mapred/split/TezGroupedSplit.java
@@ -25,8 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -39,8 +37,6 @@ import org.apache.tez.dag.api.TezUncheckedException;
  * Implements an InputSplit that provides a generic wrapper around 
  * a group of real InputSplits
  */
-@Public
-@Evolving
 public class TezGroupedSplit implements InputSplit, Configurable {
 
   List<InputSplit> wrappedSplits = null;

--- a/tez-mapreduce/src/main/java/org/apache/hadoop/mapreduce/split/SplitLocationProviderMapReduce.java
+++ b/tez-mapreduce/src/main/java/org/apache/hadoop/mapreduce/split/SplitLocationProviderMapReduce.java
@@ -16,12 +16,10 @@ package org.apache.hadoop.mapreduce.split;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.tez.mapreduce.grouper.MapReduceSplitContainer;
 import org.apache.tez.mapreduce.grouper.SplitContainer;
 import org.apache.tez.mapreduce.grouper.SplitLocationProviderWrapper;
 
-@InterfaceAudience.Private
 public class SplitLocationProviderMapReduce implements SplitLocationProviderWrapper {
 
   private final SplitLocationProvider locationProvider;

--- a/tez-mapreduce/src/main/java/org/apache/hadoop/mapreduce/split/SplitMetaInfoReaderTez.java
+++ b/tez-mapreduce/src/main/java/org/apache/hadoop/mapreduce/split/SplitMetaInfoReaderTez.java
@@ -24,8 +24,6 @@ import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -40,8 +38,6 @@ import org.apache.tez.mapreduce.hadoop.MRJobConfig;
 /**
  * A utility that reads the split meta info and creates split meta info objects
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class SplitMetaInfoReaderTez {
 
   public static final Logger LOG = LoggerFactory.getLogger(SplitMetaInfoReaderTez.class);

--- a/tez-mapreduce/src/main/java/org/apache/hadoop/mapreduce/split/TezGroupedSplit.java
+++ b/tez-mapreduce/src/main/java/org/apache/hadoop/mapreduce/split/TezGroupedSplit.java
@@ -25,9 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -40,8 +37,6 @@ import org.apache.tez.dag.api.TezUncheckedException;
  * A Mapreduce InputSplit that provides a generic wrapper
  * around a set of real InputSplits.
  */
-@Public
-@Evolving
 public class TezGroupedSplit extends InputSplit 
   implements Writable, Configurable {
 
@@ -52,12 +47,10 @@ public class TezGroupedSplit extends InputSplit
   long length = 0;
   Configuration conf;
 
-  @InterfaceAudience.Private
   public TezGroupedSplit() {
     
   }
 
-  @InterfaceAudience.Private
   /**
    * Meant for internal usage only
    */

--- a/tez-mapreduce/src/main/java/org/apache/tez/common/MRFrameworkConfigs.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/common/MRFrameworkConfigs.java
@@ -20,9 +20,7 @@
 
 package org.apache.tez.common;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
-@InterfaceAudience.Private
 public class MRFrameworkConfigs {
 
   /**

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/committer/MROutputCommitter.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/committer/MROutputCommitter.java
@@ -20,7 +20,6 @@ package org.apache.tez.mapreduce.committer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.mapred.FileOutputCommitter;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobContext;
@@ -49,7 +48,6 @@ import java.io.IOException;
  * Implements the {@link OutputCommitter} and provide Map Reduce compatible
  * output commit operations for Map Reduce compatible data sinks. 
  */
-@Public
 public class MROutputCommitter extends OutputCommitter {
 
   private static final Logger LOG = LoggerFactory.getLogger(MROutputCommitter.class);

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/MRInputAMSplitGenerator.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/MRInputAMSplitGenerator.java
@@ -26,8 +26,6 @@ import com.google.common.collect.Lists;
 import org.apache.tez.mapreduce.grouper.TezSplitGrouper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.split.TezMapReduceSplitsGrouper;
@@ -55,8 +53,6 @@ import org.apache.tez.runtime.api.events.InputInitializerEvent;
  * recommended {@link InputInitializer} to use when reading Map Reduce 
  * compatible data sources.
  */
-@Public
-@Evolving
 public class MRInputAMSplitGenerator extends InputInitializer {
 
   private boolean sendSerializedEvents;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/MRInputSplitDistributor.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/MRInputSplitDistributor.java
@@ -24,8 +24,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.tez.common.TezUtils;
@@ -53,8 +51,6 @@ import com.google.common.collect.Lists;
  * and splits must be produced at the client. They can still be distributed
  * intelligently among tasks at runtime using this.
  */
-@Public
-@Evolving
 public class MRInputSplitDistributor extends InputInitializer {
 
   private static final Logger LOG = LoggerFactory.getLogger(MRInputSplitDistributor.class);

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/Utils.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/Utils.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -32,7 +31,6 @@ import org.apache.hadoop.mapred.Counters.Counter;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.mapreduce.hadoop.mapred.MRCounters;
 
-@Private
 public class Utils {
 
   /**
@@ -44,7 +42,6 @@ public class Utils {
    *   the path.
    * @return a Statistics instance, or null if none is found for the scheme.
    */
-  @Private
   public static List<Statistics> getFsStatistics(Path path, Configuration conf) throws IOException {
     List<Statistics> matchedStats = new ArrayList<FileSystem.Statistics>();
     path = path.getFileSystem(conf).makeQualified(path);

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/GroupedSplitContainer.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/GroupedSplitContainer.java
@@ -18,14 +18,12 @@ package org.apache.tez.mapreduce.grouper;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.tez.dag.api.TezUncheckedException;
 
 
 /**
  * An entity to hold grouped splits - either mapred or mapreduce.
  */
-@InterfaceAudience.Private
 public class GroupedSplitContainer {
 
   private final List<SplitContainer> wrappedSplits;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitContainer.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitContainer.java
@@ -16,9 +16,7 @@ package org.apache.tez.mapreduce.grouper;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
-@InterfaceAudience.Private
 /**
  * Interface to represent both mapred and mapreduce splits
  */

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitLocationProviderWrapper.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitLocationProviderWrapper.java
@@ -16,9 +16,7 @@ package org.apache.tez.mapreduce.grouper;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
-@InterfaceAudience.Private
 public interface SplitLocationProviderWrapper {
   String[] getPreferredLocations(SplitContainer splitContainer) throws IOException, InterruptedException;
 }

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitLocationProviderWrapperMapred.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitLocationProviderWrapperMapred.java
@@ -16,10 +16,8 @@ package org.apache.tez.mapreduce.grouper;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.mapred.split.SplitLocationProvider;
 
-@InterfaceAudience.Private
 public class SplitLocationProviderWrapperMapred implements SplitLocationProviderWrapper {
 
   private final SplitLocationProvider locationProvider;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitSizeEstimatorWrapper.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/SplitSizeEstimatorWrapper.java
@@ -16,13 +16,11 @@ package org.apache.tez.mapreduce.grouper;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
 
 /**
  * An interface to handle split size estimation across mapred and mapreduce splits
  */
-@InterfaceAudience.Private
 public interface SplitSizeEstimatorWrapper {
 
   long getEstimatedSize(SplitContainer splitContainer) throws IOException, InterruptedException;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/InputSplitInfo.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/InputSplitInfo.java
@@ -20,8 +20,6 @@ package org.apache.tez.mapreduce.hadoop;
 
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.Credentials;
 import org.apache.tez.dag.api.TaskLocationHint;
@@ -36,8 +34,6 @@ import org.apache.tez.mapreduce.protos.MRRuntimeProtos.MRSplitsProto;
  * getSplitsProto method is only applicable when generating splits to memory.
  * 
  */
-@Private
-@Unstable
 public interface InputSplitInfo {
 
   public enum Type {

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/MRConfig.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/MRConfig.java
@@ -17,7 +17,6 @@
  */
 package org.apache.tez.mapreduce.hadoop;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 
 /**
  * Place holder for cluster level configuration keys.
@@ -25,7 +24,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
  * The keys should have "mapreduce.cluster." as the prefix.
  *
  */
-@InterfaceAudience.Private
 public interface MRConfig {
 
   // Cluster-level configuration parameters

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/MRHelpers.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/MRHelpers.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.mapreduce.hadoop;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.mapreduce.combine.MRCombiner;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
@@ -28,8 +26,6 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
  * This class contains helper methods for frameworks which migrate from MapReduce to Tez, and need
  * to continue to work with existing MapReduce configurations.
  */
-@Public
-@Evolving
 public class MRHelpers {
 
   /**

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/MRInputHelpers.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/MRInputHelpers.java
@@ -42,10 +42,6 @@ import com.google.protobuf.ByteString;
 import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -79,8 +75,6 @@ import org.apache.tez.mapreduce.input.MRInputLegacy;
 import org.apache.tez.mapreduce.protos.MRRuntimeProtos;
 import org.apache.tez.mapreduce.protos.MRRuntimeProtos.MRSplitProto;
 
-@Public
-@Unstable
 public class MRInputHelpers {
 
   private static final Logger LOG = LoggerFactory.getLogger(MRInputHelpers.class);
@@ -108,8 +102,6 @@ public class MRInputHelpers {
    * @return an instance of {@link org.apache.tez.dag.api.DataSourceDescriptor} which can be added
    * as a data source to a {@link org.apache.tez.dag.api.Vertex}
    */
-  @InterfaceStability.Unstable
-  @InterfaceAudience.LimitedPrivate({"hive, pig"})
   public static DataSourceDescriptor configureMRInputWithLegacySplitGeneration(Configuration conf,
                                                                                Path splitsDir,
                                                                                boolean useLegacyInput) {
@@ -147,8 +139,6 @@ public class MRInputHelpers {
    * which provides access to the underlying configuration bytes
    * @throws IOException
    */
-  @InterfaceStability.Evolving
-  @InterfaceAudience.LimitedPrivate({"hive, pig"})
   public static MRRuntimeProtos.MRInputUserPayloadProto parseMRInputPayload(UserPayload payload)
       throws IOException {
     return MRRuntimeProtos.MRInputUserPayloadProto.parseFrom(UnsafeByteOperations.unsafeWrap(payload.getPayload()));
@@ -165,8 +155,6 @@ public class MRInputHelpers {
    * @throws java.io.IOException
    */
   @SuppressWarnings("unchecked")
-  @InterfaceStability.Evolving
-  @InterfaceAudience.LimitedPrivate({"hive, pig"})
   public static InputSplit createOldFormatSplitFromUserPayload(
       MRRuntimeProtos.MRSplitProto splitProto, SerializationFactory serializationFactory)
       throws IOException {
@@ -200,7 +188,6 @@ public class MRInputHelpers {
    * @return an instance of the split
    * @throws IOException
    */
-  @InterfaceStability.Evolving
   @SuppressWarnings("unchecked")
   public static org.apache.hadoop.mapreduce.InputSplit createNewFormatSplitFromUserPayload(
       MRRuntimeProtos.MRSplitProto splitProto, SerializationFactory serializationFactory)
@@ -225,7 +212,6 @@ public class MRInputHelpers {
     return inputSplit;
   }
 
-  @InterfaceStability.Evolving
   public static <T extends org.apache.hadoop.mapreduce.InputSplit> MRRuntimeProtos.MRSplitProto createSplitProto(
       T newSplit, SerializationFactory serializationFactory)
       throws IOException, InterruptedException {
@@ -248,8 +234,6 @@ public class MRInputHelpers {
     return builder.build();
   }
 
-  @InterfaceStability.Evolving
-  @InterfaceAudience.LimitedPrivate({"hive, pig"})
   public static MRRuntimeProtos.MRSplitProto createSplitProto(
       org.apache.hadoop.mapred.InputSplit oldSplit) throws IOException {
     MRRuntimeProtos.MRSplitProto.Builder builder = MRRuntimeProtos.MRSplitProto.newBuilder();
@@ -288,8 +272,6 @@ public class MRInputHelpers {
    * @throws ClassNotFoundException
    * @throws InterruptedException
    */
-  @InterfaceStability.Unstable
-  @InterfaceAudience.LimitedPrivate({"hive, pig"})
   public static InputSplitInfoMem generateInputSplitsToMem(Configuration conf,
                                                            boolean groupSplits, int targetTasks)
       throws IOException, ClassNotFoundException, InterruptedException {
@@ -320,7 +302,6 @@ public class MRInputHelpers {
    * @throws ClassNotFoundException
    * @throws InterruptedException
    */
-  @InterfaceStability.Unstable
   public static InputSplitInfoMem generateInputSplitsToMem(Configuration conf,
       boolean groupSplits, boolean sortSplits, int targetTasks)
       throws IOException, ClassNotFoundException, InterruptedException {
@@ -723,7 +704,6 @@ public class MRInputHelpers {
    * the user-specified InputFormat replaced by either {@link org.apache.hadoop.mapred.split.TezGroupedSplitsInputFormat}
    * or {@link org.apache.hadoop.mapreduce.split.TezGroupedSplitsInputFormat}
    */
-  @InterfaceAudience.Private
   protected static UserPayload createMRInputPayloadWithGrouping(Configuration conf) throws IOException {
     Preconditions
         .checkArgument(conf != null, "Configuration must be specified");
@@ -731,7 +711,6 @@ public class MRInputHelpers {
         null, true, true);
   }
 
-  @InterfaceAudience.Private
   protected static UserPayload createMRInputPayload(Configuration conf,
                                                     MRRuntimeProtos.MRSplitsProto mrSplitsProto) throws
       IOException {
@@ -748,7 +727,6 @@ public class MRInputHelpers {
    * the user-specified InputFormat replaced by either {@link org.apache.hadoop.mapred.split.TezGroupedSplitsInputFormat}
    * or {@link org.apache.hadoop.mapreduce.split.TezGroupedSplitsInputFormat}
    */
-  @InterfaceAudience.Private
   protected static UserPayload createMRInputPayload(Configuration conf,
       MRRuntimeProtos.MRSplitsProto mrSplitsProto, boolean isGrouped,
       boolean isSorted) throws

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapred/TaskAttemptContextImpl.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapred/TaskAttemptContextImpl.java
@@ -17,8 +17,6 @@
 
 package org.apache.tez.mapreduce.hadoop.mapred;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.TaskAttemptContext;
 import org.apache.hadoop.mapred.TaskAttemptID;
@@ -26,8 +24,6 @@ import org.apache.hadoop.mapreduce.Counter;
 import org.apache.hadoop.util.Progressable;
 import org.apache.tez.mapreduce.processor.MRTaskReporter;
 
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class TaskAttemptContextImpl
        extends org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl 
        implements TaskAttemptContext {

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapred/package-info.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapred/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.mapreduce.hadoop.mapred;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/MapContextImpl.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/MapContextImpl.java
@@ -20,8 +20,6 @@ package org.apache.tez.mapreduce.hadoop.mapreduce;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -40,8 +38,6 @@ import org.apache.tez.runtime.api.TaskContext;
  * @param <KEYOUT> the key output type from the Mapper
  * @param <VALUEOUT> the value output type from the Mapper
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class MapContextImpl<KEYIN,VALUEIN,KEYOUT,VALUEOUT> 
     extends TaskInputOutputContextImpl<KEYIN,VALUEIN,KEYOUT,VALUEOUT> 
     implements MapContext<KEYIN, VALUEIN, KEYOUT, VALUEOUT> {

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/TaskAttemptContextImpl.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/TaskAttemptContextImpl.java
@@ -17,8 +17,6 @@
 
 package org.apache.tez.mapreduce.hadoop.mapreduce;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.Counter;
@@ -34,8 +32,6 @@ import org.apache.tez.mapreduce.common.Utils;
 // NOTE: NEWTEZ: This is a copy of org.apache.tez.mapreduce.hadoop.mapred (not mapreduce). mapred likely does not need it's own copy of this class.
 // Meant for use by the "mapreduce" API
 
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class TaskAttemptContextImpl
        extends org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl {
 

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/TaskInputOutputContextImpl.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/TaskInputOutputContextImpl.java
@@ -20,8 +20,6 @@ package org.apache.tez.mapreduce.hadoop.mapreduce;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapreduce.Mapper;
@@ -40,8 +38,6 @@ import org.apache.tez.runtime.api.TaskContext;
  * @param <KEYOUT> the output key type for the task
  * @param <VALUEOUT> the output value type for the task
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public abstract class TaskInputOutputContextImpl<KEYIN,VALUEIN,KEYOUT,VALUEOUT> 
        extends TaskAttemptContextImpl 
        implements TaskInputOutputContext<KEYIN, VALUEIN, KEYOUT, VALUEOUT> {

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/package-info.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/mapreduce/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.mapreduce.hadoop.mapreduce;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/package-info.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.mapreduce.hadoop;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/MRInputUtils.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/MRInputUtils.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -42,7 +41,6 @@ import org.apache.tez.mapreduce.protos.MRRuntimeProtos.MRSplitProto;
 /**
  * Helper methods for InputFormat based Inputs. Private to Tez.
  */
-@Private
 public class MRInputUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(MRInputUtils.class);
@@ -128,7 +126,6 @@ public class MRInputUtils {
     return split;
   }
   
-  @Private
   public static InputSplit getOldSplitDetailsFromEvent(MRSplitProto splitProto, Configuration conf)
       throws IOException {
     SerializationFactory serializationFactory = new SerializationFactory(conf);

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/MRReader.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/MRReader.java
@@ -20,11 +20,9 @@ package org.apache.tez.mapreduce.lib;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.api.KeyValueReader;
 
-@Private
 public abstract class MRReader extends KeyValueReader {
   
   public abstract void setSplit(Object split) throws IOException;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/package-info.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.mapreduce.lib;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/output/MROutputLegacy.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/output/MROutputLegacy.java
@@ -18,12 +18,10 @@
 
 package org.apache.tez.mapreduce.output;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.tez.runtime.api.OutputContext;
 
-@Private
 public class MROutputLegacy extends MROutput {
 
   /**

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/output/MultiMROutput.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/output/MultiMROutput.java
@@ -32,7 +32,6 @@ import org.apache.tez.runtime.api.Output;
 import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.apache.tez.runtime.library.api.KeyValueWriterWithBasePath;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -46,7 +45,6 @@ import org.apache.tez.mapreduce.hadoop.mapred.MRReporter;
  * OutputFormat implementations.
  *
  */
-@Public
 public class MultiMROutput extends MROutput {
 
   Map<String, org.apache.hadoop.mapreduce.RecordWriter<?, ?>>

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTaskReporter.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTaskReporter.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.mapreduce.processor;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.Reporter;
@@ -31,8 +29,6 @@ import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.api.TaskContext;
 
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class MRTaskReporter
     extends org.apache.hadoop.mapreduce.StatusReporter
     implements Reporter {

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/SimpleMRProcessor.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/SimpleMRProcessor.java
@@ -22,8 +22,6 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.mapreduce.output.MROutput;
 import org.apache.tez.runtime.api.LogicalOutput;
 import org.apache.tez.runtime.api.Processor;
@@ -37,8 +35,6 @@ import com.google.common.collect.Lists;
  * processing by calling commit (if needed) on all {@link MROutput}s 
  * connected to this {@link Processor}. 
  */
-@Public
-@Evolving
 public abstract class SimpleMRProcessor extends SimpleProcessor {
   private static final Logger LOG = LoggerFactory.getLogger(SimpleMRProcessor.class);
 

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/map/MapProcessor.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/map/MapProcessor.java
@@ -26,7 +26,6 @@ import org.apache.tez.common.ProgressHelper;
 import org.apache.tez.runtime.api.ProgressFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
@@ -55,7 +54,6 @@ import org.apache.tez.runtime.library.api.KeyValueWriter;
 import org.apache.tez.runtime.library.output.OrderedPartitionedKVOutput;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
-@Private
 public class MapProcessor extends MRTask{
 
   private static final Logger LOG = LoggerFactory.getLogger(MapProcessor.class);

--- a/tez-runtime-internals/src/main/java/org/apache/tez/common/TezConverterUtils.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/common/TezConverterUtils.java
@@ -21,7 +21,6 @@ package org.apache.tez.common;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.tez.dag.api.TezUncheckedException;
@@ -38,7 +37,6 @@ public class TezConverterUtils {
    * @return path from {@link URL}
    * @throws URISyntaxException
    */
-  @Private
   public static URI getURIFromYarnURL(URL url) throws URISyntaxException {
     String scheme = url.getScheme() == null ? "" : url.getScheme();
 
@@ -56,7 +54,6 @@ public class TezConverterUtils {
     return new URI(scheme, authority, url.getFile(), null, null).normalize();
   }
 
-  @Private
   public static TezLocalResource convertYarnLocalResourceToTez(LocalResource lr)
       throws URISyntaxException {
     return new TezLocalResource(getURIFromYarnURL(lr.getResource()), lr.getSize(),
@@ -86,43 +83,43 @@ public class TezConverterUtils {
     }
   }
 
-  // @Private
-  // public static void writeLocalResource(LocalResource lr, DataOutput out)
-  // throws IOException {
-  // // Not bothering with type, visibility and pattern. Pattern may be needed
-  // at
-  // // some point.
-  // // Size and length will not be required once Localization happens via YARN
-  // -
-  // // yarn takes care of validation, original file as well for that matter.
-  // writeYARNURL(lr.getResource(), out);
-  // out.writeLong(lr.getSize());
-  // out.writeLong(lr.getTimestamp());
-  // }
+// 
+// public static void writeLocalResource(LocalResource lr, DataOutput out)
+// throws IOException {
+// // Not bothering with type, visibility and pattern. Pattern may be needed
+// at
+// // some point.
+// // Size and length will not be required once Localization happens via YARN
+// -
+// // yarn takes care of validation, original file as well for that matter.
+// writeYARNURL(lr.getResource(), out);
+// out.writeLong(lr.getSize());
+// out.writeLong(lr.getTimestamp());
+// }
   //
-  // @Private
-  // public static LocalResource readLocalResource(DataInput in) throws
-  // IOException {
-  // return LocalResource.newInstance(readYARNURL(in), null, null,
-  // in.readLong(), in.readLong());
-  // }
+// 
+// public static LocalResource readLocalResource(DataInput in) throws
+// IOException {
+// return LocalResource.newInstance(readYARNURL(in), null, null,
+// in.readLong(), in.readLong());
+// }
   //
-  // @Private
-  // public static void writeYARNURL(URL url, DataOutput out) throws IOException
-  // {
-  // // Assuming all fields have to be present. Otherwise YARN itself would
-  // fail.
-  // out.writeUTF(url.getScheme());
-  // out.writeUTF(url.getHost());
-  // out.writeInt(url.getPort());
-  // out.writeUTF(url.getFile());
-  // }
+// 
+// public static void writeYARNURL(URL url, DataOutput out) throws IOException
+// {
+// // Assuming all fields have to be present. Otherwise YARN itself would
+// fail.
+// out.writeUTF(url.getScheme());
+// out.writeUTF(url.getHost());
+// out.writeInt(url.getPort());
+// out.writeUTF(url.getFile());
+// }
   //
-  // @Private
-  // public static URL readYARNURL(DataInput in) throws IOException {
-  // URL url = URL.newInstance(in.readUTF(), in.readUTF(), in.readInt(),
-  // in.readUTF());
-  // return url;
-  // }
+// 
+// public static URL readYARNURL(DataInput in) throws IOException {
+// URL url = URL.newInstance(in.readUTF(), in.readUTF(), in.readInt(),
+// in.readUTF());
+// return url;
+// }
 
 }

--- a/tez-runtime-internals/src/main/java/org/apache/tez/common/TezTaskUmbilicalProtocol.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/common/TezTaskUmbilicalProtocol.java
@@ -20,8 +20,6 @@ package org.apache.tez.common;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.ipc.VersionedProtocol;
 import org.apache.hadoop.security.token.TokenInfo;
 import org.apache.tez.dag.api.TezException;
@@ -35,8 +33,6 @@ import org.apache.tez.runtime.common.security.JobTokenSelector;
  * reduce task and runs it as a child process.  All communication between child
  * and parent is via this protocol. */
 @TokenInfo(JobTokenSelector.class)
-@InterfaceAudience.Private
-@InterfaceStability.Stable
 // ProtocolInfo will be required once we move to Hadoop PB RPC
 //@ProtocolInfo(protocolName = "TezTaskUmbilicalProtocol", protocolVersion = 1)
 public interface TezTaskUmbilicalProtocol extends VersionedProtocol {

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezUmbilical.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezUmbilical.java
@@ -21,11 +21,9 @@ package org.apache.tez.runtime.api.impl;
 import java.io.IOException;
 import java.util.Collection;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.runtime.api.TaskFailureType;
 
-@Private
 public interface TezUmbilical {
 
   void addEvents(Collection<TezEvent> events);

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/common/security/JobTokenSelector.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/common/security/JobTokenSelector.java
@@ -20,8 +20,6 @@ package org.apache.tez.runtime.common.security;
 
 import java.util.Collection;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
@@ -32,8 +30,6 @@ import org.apache.tez.common.security.JobTokenIdentifier;
  * Look through tokens to find the first job token that matches the service
  * and return it.
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class JobTokenSelector implements TokenSelector<JobTokenIdentifier> {
 
   @SuppressWarnings("unchecked")

--- a/tez-runtime-library/src/main/java/org/apache/tez/common/TezRuntimeFrameworkConfigs.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/common/TezRuntimeFrameworkConfigs.java
@@ -21,12 +21,10 @@
 
 package org.apache.tez.common;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 /**
  * Configuration parameters which are internal to the Inputs and Outputs which exist in the Runtime
  */
-@Private
 public class TezRuntimeFrameworkConfigs {
 
   private static final String TEZ_RUNTIME_FRAMEWORK_PREFIX = "tez.runtime.framework.";

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/IOInterruptedException.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/IOInterruptedException.java
@@ -16,14 +16,10 @@ package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 
 /**
  * Indicates that an IOOperation was interrupted
  */
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
 public class IOInterruptedException extends IOException {
 
   public IOInterruptedException(String message) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReader.java
@@ -20,8 +20,6 @@ package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.runtime.api.Reader;
 
 /**
@@ -37,8 +35,6 @@ import org.apache.tez.runtime.api.Reader;
  * if next() is called after processing everything,
  * IOException would be thrown
  */
-@Public
-@Evolving
 public abstract class KeyValueReader extends Reader {
 
   protected boolean completedProcessing;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueWriter.java
@@ -20,15 +20,11 @@ package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.runtime.api.Writer;
 
 /**
  * A key/value(s) pair based {@link Writer}
  */
-@Public
-@Evolving
 public abstract class KeyValueWriter extends Writer {
   /**
    * Writes a key/value pair.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueWriterWithBasePath.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueWriterWithBasePath.java
@@ -20,16 +20,12 @@ package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.runtime.api.Writer;
 
 /**
  * A key/value(s) pair based {@link Writer} that supports
  * output to different files.
  */
-@Public
-@Evolving
 public abstract class KeyValueWriterWithBasePath extends KeyValueWriter {
   /**
    * Writes a key/value pair.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReader.java
@@ -20,8 +20,6 @@ package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.runtime.api.Reader;
 
 /**
@@ -37,8 +35,6 @@ import org.apache.tez.runtime.api.Reader;
  * if next() is called after processing everything,
  * IOException would be thrown
  */
-@Public
-@Evolving
 public abstract class KeyValuesReader extends Reader {
 
   protected boolean completedProcessing;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesWriter.java
@@ -20,14 +20,10 @@ package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * key/value(s) based {@link KeyValueWriter}
  */
-@Public
-@Evolving
 public abstract class KeyValuesWriter extends KeyValueWriter {
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/Partitioner.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/Partitioner.java
@@ -17,8 +17,6 @@
  */
 package org.apache.tez.runtime.library.api;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 
 /**
@@ -39,8 +37,6 @@ import org.apache.hadoop.conf.Configuration;
  * partitions.
  * 
  */
-@Public
-@Evolving
 public interface Partitioner {
   
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/cartesianproduct/CartesianProductFilter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/cartesianproduct/CartesianProductFilter.java
@@ -21,13 +21,11 @@ import org.apache.tez.dag.api.UserPayload;
 
 import java.util.Map;
 
-import static org.apache.hadoop.classification.InterfaceStability.Evolving;
 
 /**
  * User can extend this base class and override <method>isValidCombination</method> to implement
  * custom filter
  */
-@Evolving
 public abstract class CartesianProductFilter {
   private UserPayload userPayload;
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
@@ -17,9 +17,7 @@
 
 package org.apache.tez.runtime.library.common;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
-@Private
 public class Constants {
 
   public static final String TEZ = "tez";

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/InputIdentifier.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/InputIdentifier.java
@@ -18,9 +18,7 @@
 
 package org.apache.tez.runtime.library.common;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 
-@Private
 public class InputIdentifier {
 
   private final int inputIndex;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/MemoryUpdateCallbackHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/MemoryUpdateCallbackHandler.java
@@ -18,14 +18,10 @@
 
 package org.apache.tez.runtime.library.common;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.runtime.api.MemoryUpdateCallback;
 
 import org.apache.tez.common.Preconditions;
 
-@Public
-@Evolving
 public class MemoryUpdateCallbackHandler extends MemoryUpdateCallback {
 
   private long assignedMemory;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.RawComparator;
@@ -41,7 +40,6 @@ import org.apache.tez.common.Preconditions;
  * 
  */
 
-@Private
 public class ValuesIterator<KEY,VALUE> {
   protected TezRawKeyValueIterator in; //input iterator
   private KEY key;               // current key

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/combine/Combiner.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/combine/Combiner.java
@@ -20,8 +20,6 @@ package org.apache.tez.runtime.library.common.combine;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
@@ -34,8 +32,6 @@ import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
  * Partitioners need to provide a single argument ({@link TezRawKeyValueIterator})
  * constructor.
  */
-@Private
-@Unstable
 public interface Combiner {
   public void combine(TezRawKeyValueIterator rawIter, Writer writer)
       throws InterruptedException, IOException;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/comparator/ProxyComparator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/comparator/ProxyComparator.java
@@ -17,12 +17,8 @@
  */
 package org.apache.tez.runtime.library.common.comparator;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.io.RawComparator;
 
-@Unstable
-@Private
 public interface ProxyComparator<KEY> extends RawComparator {
   /**
    * This comparator interface provides a fast-path for comparisons between keys.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/comparator/TezBytesComparator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/comparator/TezBytesComparator.java
@@ -17,14 +17,10 @@
  */
 package org.apache.tez.runtime.library.common.comparator;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.tez.runtime.library.utils.FastByteComparisons;
 
-@Public
-@Unstable
 public final class TezBytesComparator extends WritableComparator implements
     ProxyComparator<BytesWritable> {
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/security/SecureShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/security/SecureShuffleUtils.java
@@ -25,8 +25,6 @@ import javax.crypto.SecretKey;
 
 import com.google.common.base.Charsets;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.tez.common.security.JobTokenSecretManager;
 
@@ -35,8 +33,6 @@ import org.apache.tez.common.security.JobTokenSecretManager;
  * utilities for generating keys, hashes and verifying them for shuffle
  *
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class SecureShuffleUtils {
 
   public static final String HTTP_HEADER_URL_HASH = "UrlHash";

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/serializer/TezBytesWritableSerialization.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/serializer/TezBytesWritableSerialization.java
@@ -18,8 +18,6 @@
 
 package org.apache.tez.runtime.library.common.serializer;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Unstable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.io.BytesWritable;
@@ -50,8 +48,6 @@ import java.io.OutputStream;
  *            TezBytesComparator.class.getName()).build())
  * </pre>
  */
-@Public
-@Unstable
 public class TezBytesWritableSerialization extends Configured implements Serialization<Writable> {
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.shuffle.impl;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -23,8 +23,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
@@ -34,8 +32,6 @@ import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 /**
  * <code>IFile.InMemoryReader</code> to read map-outputs present in-memory.
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class InMemoryReader extends Reader {
 
   private static class ByteArrayDataInput extends NonSyncByteArrayInputStream implements DataInput {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.shuffle;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFileInputStream.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFileInputStream.java
@@ -27,8 +27,6 @@ import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.fs.ChecksumException;
 import org.apache.hadoop.fs.HasFileDescriptor;
 import org.apache.hadoop.io.IOUtils;
@@ -39,8 +37,6 @@ import org.apache.hadoop.util.DataChecksum;
  * A checksum input stream, used for IFiles.
  * Used to validate the checksum of files created by {@link IFileOutputStream}. 
 */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public class IFileInputStream extends InputStream {
   
   private final InputStream in; //The input stream to be verified for checksum.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.io.compress.Compressor;
 import org.apache.tez.common.Preconditions;
 import com.google.common.collect.Lists;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.apache.tez.runtime.library.utils.CodecUtils;
@@ -1458,7 +1457,6 @@ public class PipelinedSorter extends ExternalSorter {
     }
   }
 
-  @InterfaceAudience.Private
   public boolean needsRLE() {
     return merger.needsRLE();
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -19,8 +19,6 @@ package org.apache.tez.runtime.library.common.sort.impl;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.util.Progress;
 
@@ -28,8 +26,6 @@ import org.apache.hadoop.util.Progress;
  * <code>TezRawKeyValueIterator</code> is an iterator used to iterate over
  * the raw keys and values during sort/merge of intermediate data. 
  */
-@InterfaceAudience.Private
-@InterfaceStability.Unstable
 public interface TezRawKeyValueIterator {
   /** 
    * Gets the current raw key.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/dflt/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/dflt/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.sort.impl.dflt;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.sort.impl;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/task/local/output/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/task/local/output/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.task.local.output;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-@Private
 package org.apache.tez.runtime.library.common.writers;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/BaseConfigBuilder.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/BaseConfigBuilder.java
@@ -22,10 +22,8 @@ package org.apache.tez.runtime.library.conf;
 
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 
-@InterfaceAudience.Private
 interface BaseConfigBuilder<T> {
   /**
    * Used to set additional configuration parameters which are not set via API methods. This is
@@ -57,6 +55,5 @@ interface BaseConfigBuilder<T> {
    * @param conf
    * @return this object for further chained method calls
    */
-  @InterfaceAudience.LimitedPrivate({"hive, pig"})
   public T setFromConfiguration(Configuration conf);
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/HadoopKeyValuesBasedBaseEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/HadoopKeyValuesBasedBaseEdgeConfig.java
@@ -22,10 +22,8 @@ import javax.annotation.Nullable;
 
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.tez.dag.api.UserPayload;
 
-@InterfaceAudience.Private
 abstract class HadoopKeyValuesBasedBaseEdgeConfig {
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/OrderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/OrderedPartitionedKVEdgeConfig.java
@@ -23,8 +23,6 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -39,8 +37,6 @@ import org.apache.tez.runtime.library.output.OrderedPartitionedKVOutput;
  * Values will be picked up from tez-site if not specified, otherwise defaults from
  * {@link org.apache.tez.runtime.library.api.TezRuntimeConfiguration} will be used.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
 public class OrderedPartitionedKVEdgeConfig
     extends HadoopKeyValuesBasedBaseEdgeConfig {
 
@@ -142,8 +138,6 @@ public class OrderedPartitionedKVEdgeConfig
     return edgeProperty;
   }
 
-  @InterfaceAudience.Public
-  @InterfaceStability.Evolving
   public static class Builder extends HadoopKeyValuesBasedBaseEdgeConfig.Builder<Builder> {
 
     private final OrderedPartitionedKVOutputConfig.Builder outputBuilder =
@@ -152,7 +146,6 @@ public class OrderedPartitionedKVEdgeConfig
     private final OrderedGroupedKVInputConfig.Builder inputBuilder =
         new OrderedGroupedKVInputConfig.Builder();
 
-    @InterfaceAudience.Private
     Builder(String keyClassName, String valueClassName, String partitionerClassName,
             Map<String, String> partitionerConf) {
       outputBuilder.setKeyClassName(keyClassName);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedKVEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedKVEdgeConfig.java
@@ -25,8 +25,6 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -42,8 +40,6 @@ import org.apache.tez.runtime.library.output.UnorderedKVOutput;
  * Values will be picked up from tez-site if not specified, otherwise defaults from
  * {@link org.apache.tez.runtime.library.api.TezRuntimeConfiguration} will be used.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
 public class UnorderedKVEdgeConfig extends HadoopKeyValuesBasedBaseEdgeConfig {
   private final UnorderedKVOutputConfig outputConf;
   private final UnorderedKVInputConfig inputConf;
@@ -142,8 +138,6 @@ public class UnorderedKVEdgeConfig extends HadoopKeyValuesBasedBaseEdgeConfig {
     return edgeProperty;
   }
 
-  @InterfaceAudience.Public
-  @InterfaceStability.Evolving
   public static class Builder extends HadoopKeyValuesBasedBaseEdgeConfig.Builder<Builder> {
 
     private final UnorderedKVOutputConfig.Builder outputBuilder =
@@ -152,7 +146,6 @@ public class UnorderedKVEdgeConfig extends HadoopKeyValuesBasedBaseEdgeConfig {
     private final UnorderedKVInputConfig.Builder inputBuilder =
         new UnorderedKVInputConfig.Builder();
 
-    @InterfaceAudience.Private
     Builder(String keyClassName, String valueClassName) {
       outputBuilder.setKeyClassName(keyClassName);
       outputBuilder.setValueClassName(valueClassName);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedPartitionedKVEdgeConfig.java
@@ -25,8 +25,6 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Objects;
 
-import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -42,8 +40,6 @@ import org.apache.tez.runtime.library.output.UnorderedPartitionedKVOutput;
  * Values will be picked up from tez-site if not specified, otherwise defaults from
  * {@link org.apache.tez.runtime.library.api.TezRuntimeConfiguration} will be used.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
 public class UnorderedPartitionedKVEdgeConfig
     extends HadoopKeyValuesBasedBaseEdgeConfig {
 
@@ -147,8 +143,6 @@ public class UnorderedPartitionedKVEdgeConfig
     return edgeProperty;
   }
 
-  @InterfaceAudience.Public
-  @InterfaceStability.Evolving
   public static class Builder extends HadoopKeyValuesBasedBaseEdgeConfig.Builder<Builder> {
 
     private final UnorderedPartitionedKVOutputConfig.Builder outputBuilder =
@@ -157,7 +151,6 @@ public class UnorderedPartitionedKVEdgeConfig
     private final UnorderedKVInputConfig.Builder inputBuilder =
         new UnorderedKVInputConfig.Builder();
 
-    @InterfaceAudience.Private
     Builder(String keyClassName, String valueClassName, String partitionerClassName,
             Map<String, String> partitionerConf) {
       outputBuilder.setKeyClassName(keyClassName);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/package-info.java
@@ -16,9 +16,5 @@
  * limitations under the License.
  */
 
-@Public
-@Evolving
 package org.apache.tez.runtime.library.conf;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/exceptions/FetcherReadTimeoutException.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/exceptions/FetcherReadTimeoutException.java
@@ -19,12 +19,8 @@
 package org.apache.tez.runtime.library.exceptions;
 
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.dag.api.TezException;
 
-@Public
-@Evolving
 /**
  * Exception invoked when socket read timeout happens in fetcher
  */

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/exceptions/InputAlreadyClosedException.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/exceptions/InputAlreadyClosedException.java
@@ -19,12 +19,8 @@
 package org.apache.tez.runtime.library.exceptions;
 
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.dag.api.TezException;
 
-@Public
-@Evolving
 /**
  * Exception invoked when an operation is invoked on an Input that has already been closed.
  */

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/hadoop/compat/NullProgressable.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/hadoop/compat/NullProgressable.java
@@ -18,10 +18,8 @@
 
 package org.apache.tez.runtime.library.hadoop.compat;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.util.Progressable;
 
-@Private
 public class NullProgressable implements Progressable {
 
   public NullProgressable() {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
@@ -21,7 +21,6 @@ package org.apache.tez.runtime.library.input;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.dag.api.GroupInputEdge;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.Input;
@@ -35,7 +34,6 @@ import org.apache.tez.runtime.library.api.KeyValueReader;
  * (e.g. from a {@link GroupInputEdge} and provide a unified view of the 
  * input. It concatenates all the inputs to provide a unified view
  */
-@Public
 public class ConcatenatedMergedKeyValueInput extends MergedLogicalInput {
   private ConcatenatedMergedKeyValueReader concatenatedMergedKeyValueReader;
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValuesInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValuesInput.java
@@ -21,7 +21,6 @@ package org.apache.tez.runtime.library.input;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.tez.dag.api.GroupInputEdge;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.Input;
@@ -37,7 +36,6 @@ import org.apache.tez.runtime.library.api.KeyValuesReader;
  * input. It concatenates all the inputs to provide a unified view
  */
 
-@Public
 public class ConcatenatedMergedKeyValuesInput extends MergedLogicalInput {
 
   private ConcatenatedMergedKeyValuesReader concatenatedMergedKeyValuesReader;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
@@ -20,14 +20,12 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.util.Progress;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
-@Private
 public class OrderedGroupedInputLegacy extends OrderedGroupedKVInput {
 
   private final Progress progress = new Progress();
@@ -36,7 +34,6 @@ public class OrderedGroupedInputLegacy extends OrderedGroupedKVInput {
     super(inputContext, numPhysicalInputs);
   }
 
-  @Private
   public TezRawKeyValueIterator getIterator() throws IOException, InterruptedException, TezException {
     // wait for input so that iterator is available
     synchronized(this) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedMergedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedMergedKVInput.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import org.apache.tez.runtime.api.ProgressFailedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.io.RawComparator;
 import org.apache.tez.runtime.api.Input;
 import org.apache.tez.runtime.api.MergedLogicalInput;
@@ -45,7 +44,6 @@ import org.apache.tez.runtime.library.api.KeyValuesReader;
  * Combiners and Secondary Sort are not implemented, so there is no guarantee on
  * the order of values.
  */
-@Public
 public class OrderedGroupedMergedKVInput extends MergedLogicalInput {
 
   private static final Logger LOG = LoggerFactory.getLogger(OrderedGroupedMergedKVInput.class);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/package-info.java
@@ -16,9 +16,5 @@
  * limitations under the License.
  */
 
-@Public
-@Evolving
 package org.apache.tez.runtime.library.input;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/package-info.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/package-info.java
@@ -16,9 +16,5 @@
  * limitations under the License.
  */
 
-@Public
-@Evolving
 package org.apache.tez.runtime.library.output;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/partitioner/HashPartitioner.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/partitioner/HashPartitioner.java
@@ -18,15 +18,11 @@
 
 package org.apache.tez.runtime.library.partitioner;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.runtime.library.api.Partitioner;
 
 /**
  * Implements a {@link Partitioner} that does hash based partitioning
  */
-@Public
-@Evolving
 public class HashPartitioner implements Partitioner {
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/processor/SimpleProcessor.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/processor/SimpleProcessor.java
@@ -20,8 +20,6 @@ package org.apache.tez.runtime.library.processor;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hadoop.classification.InterfaceAudience.Public;
-import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.tez.common.ProgressHelper;
 import org.apache.tez.runtime.api.AbstractLogicalIOProcessor;
 import org.apache.tez.runtime.api.Event;
@@ -36,8 +34,6 @@ import org.apache.tez.runtime.api.ProcessorContext;
  * This can be used to implement simple {@link Processor}s that dont need to 
  * do event handling etc.
  */
-@Public
-@Evolving
 public abstract class SimpleProcessor extends AbstractLogicalIOProcessor {
   protected Map<String, LogicalInput> inputs;
   protected Map<String, LogicalOutput> outputs;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/processor/SleepProcessor.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/processor/SleepProcessor.java
@@ -28,7 +28,6 @@ import com.google.common.base.Charsets;
 import org.apache.tez.common.ProgressHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.runtime.api.AbstractLogicalIOProcessor;
 import org.apache.tez.runtime.api.Event;
@@ -42,7 +41,6 @@ import org.apache.tez.runtime.api.ProcessorContext;
  *
  * @see SleepProcessorConfig for configuring the SleepProcessor
  */
-@Private
 public class SleepProcessor extends AbstractLogicalIOProcessor {
 
   private static final Logger LOG = LoggerFactory.getLogger(SleepProcessor.class);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/BufferUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/BufferUtils.java
@@ -20,11 +20,9 @@ package org.apache.tez.runtime.library.utils;
 
 import java.io.IOException;
 
-import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 
-@Private
 public class BufferUtils {
 
   public static int compare(DataInputBuffer buf1, DataInputBuffer buf2) {


### PR DESCRIPTION
### Motivation

- Remove direct dependencies on Hadoop classification annotations (e.g. `@InterfaceAudience`, `@InterfaceStability`, `@Public`, `@Private`, etc.) across the Tez API, runtime, mapreduce and serviceplugin modules to simplify builds and decouple from Hadoop-specific annotation usage.
- Clean up source files and package-info declarations so code readability and portability are improved without changing runtime behavior.

### Description

- Stripped imports of `org.apache.hadoop.classification.InterfaceAudience` and `InterfaceStability` from many source files and removed the corresponding `@Public`, `@Private`, `@InterfaceAudience.*` and `@InterfaceStability.*` annotations from classes, interfaces and package-info files across multiple modules (`tez-api`, `tez-common`, `tez-dag`, `tez-mapreduce`, `tez-runtime-library`, etc.).
- Removed many annotation usages from method/constructor declarations and inner types, leaving the original Java APIs and logic intact (no functional or algorithmic changes were made).
- Adjusted a few small helper/comment blocks (e.g. commented-out helper methods) where private markers were previously annotated; preserved original comments and code behavior.
- This is a non-functional refactor intended to reduce coupling to Hadoop annotation packages and to prepare the codebase for environments where those annotations are not available.

### Testing

- No automated tests were executed as part of this change; this is a large-scale annotation-only refactor with no behavioral changes, and a full build and test run is recommended (for example run `mvn -DskipTests=false test` at the repository root).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadd7c79688328a9ec3e8ff7a51c46)