### PR TITLE
Use ConcurrentHashMap and per-input locks to avoid global synchronization on shuffleInfoEventsMap

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleClient.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleClient.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.BitSet;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -149,9 +148,12 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
 
   protected final int maxNumFetchers;
 
-  // to track shuffleInfo events when finalMerge is disabled in source or pipelined shuffle is enabled in source
-  // Invariant: guard with this.synchronized in ShuffleScheduler
-  //            guard with: synchronized (shuffleInfoEventsMap) in ShuffleManager
+  // to track shuffleInfo events when finalMerge is disabled in source or pipelined shuffle is enabled in source.
+  // NOTE: ConcurrentHashMap removes the need for a single global map monitor
+  // (synchronized(shuffleInfoEventsMap)), but NOT the need for this map itself.
+  // We still need per-input ShuffleEventInfo state to validate attempts/spills and detect completion.
+  // Invariant: guard multi-step decisions with caller lock (this.synchronized in ShuffleScheduler,
+  //            lockForInput(inputIdentifier) in ShuffleManager).
   protected final Map<Integer, ShuffleEventInfo> shuffleInfoEventsMap;
 
   private int numFetchers = 0;
@@ -193,7 +195,7 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_PARALLEL_COPIES,
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_PARALLEL_COPIES_DEFAULT);
 
-    this.shuffleInfoEventsMap = new HashMap<Integer, ShuffleEventInfo>();
+    this.shuffleInfoEventsMap = new ConcurrentHashMap<Integer, ShuffleEventInfo>();
 
     this.shuffleClientId = shuffleServer.register(this);
 
@@ -399,8 +401,8 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
     }
   }
 
-  // Invariant: shuffleInfoEventsMap[] is guarded
-  // The result of checkCommitRegister() is valid only while shuffleInfoEventsMap[] is guarded.
+  // Invariant: this method is part of a multi-step transaction and must run under caller-side lock.
+  // The result of checkCommitRegister() is valid only while that caller lock is held.
   protected CommitRegister checkCommitRegister(InputAttemptIdentifier srcAttemptIdentifier) {
     int inputIdentifier = srcAttemptIdentifier.getInputIdentifier();
     // assert !isInputFinished(inputIdentifier);
@@ -431,7 +433,7 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
     return new CommitRegister(isPipelined, commitAndRegister, killBecauseDifferentSpillAttemptInPipelined);
   }
 
-  // Invariant: shuffleInfoEventsMap[] is guarded
+  // Invariant: called while caller-side lock for the input is held.
   // Invariant: input.canRetrieveInputInChunks() == true
   protected boolean validateInputAttemptForPipelinedShuffleCommon(
       InputAttemptIdentifier input) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleClient.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleClient.java
@@ -156,6 +156,10 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
   //            lockForInput(inputIdentifier) in ShuffleManager).
   protected final Map<Integer, ShuffleEventInfo> shuffleInfoEventsMap;
 
+  // Striped per-input locks for subclasses that need per-input transactions without global contention.
+  private static final int NUM_INPUT_LOCKS = 64;
+  private final Object[] inputLocks;
+
   private int numFetchers = 0;
   private int numPartitionRanges = 0;
   private final Object lock = new Object();
@@ -188,6 +192,11 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
 
     this.numInputs = numInputs;
     this.completedInputSet = new BitSet(numInputs);
+
+    this.inputLocks = new Object[Math.min(NUM_INPUT_LOCKS, Math.max(1, numInputs))];
+    for (int i = 0; i < inputLocks.length; i++) {
+      inputLocks[i] = new Object();
+    }
 
     this.obsoletedInputs = Collections.newSetFromMap(new ConcurrentHashMap<InputAttemptIdentifier, Boolean>());
 
@@ -228,6 +237,11 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
 
   public String getLogIdentifier() {
     return logIdentifier;
+  }
+
+  protected Object lockForInput(int inputIdentifier) {
+    int idx = (inputIdentifier & Integer.MAX_VALUE) % inputLocks.length;
+    return inputLocks[idx];
   }
 
   public ShuffleErrorCounterGroup getShuffleErrorCounterGroup() {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
@@ -99,6 +99,8 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
   // Note: completedInputSet itself is ALWAYS guarded with synchronized(completedInputSet).
   // lockForInput(inputIdentifier) protects cross-variable atomicity for one inputIdentifier,
   // not raw access to completedInputSet.
+  // This per-input locking model also replaces the old global map monitor
+  // (synchronized(shuffleInfoEventsMap)) for pipelined completion paths.
   private static final int NUM_INPUT_LOCKS = 64;
   private final Object[] inputLocks;
 
@@ -146,7 +148,7 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
   // can run in ShuffleServer.call() thread, ShuffleInputEventHandler thread
   protected boolean validateInputAttemptForPipelinedShuffle(InputAttemptIdentifier input) {
     if (input.canRetrieveInputInChunks()) {   // for pipelined shuffle only
-      synchronized (shuffleInfoEventsMap) {
+      synchronized (lockForInput(input.getInputIdentifier())) {
         return validateInputAttemptForPipelinedShuffleCommon(input);
       }
     } else {
@@ -193,9 +195,7 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
         if (!srcAttemptIdentifier.canRetrieveInputInChunks()) {
           registerCompletedInput(fetchedInput);
         } else {
-          synchronized (shuffleInfoEventsMap) {
-            registerCompletedInputForPipelinedShuffle(srcAttemptIdentifier, fetchedInput);
-          }
+          registerCompletedInputForPipelinedShuffle(srcAttemptIdentifier, fetchedInput);
         }
       }
     }
@@ -248,35 +248,33 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
           updateStats = true;
           registerCompletedInput(fetchedInput);
         } else {
-          synchronized (shuffleInfoEventsMap) {
-            CommitRegister cr = checkCommitRegister(srcAttemptIdentifier);
-            boolean commitAndRegister = cr.commitAndRegister;
-            boolean killInPipelined = cr.killInPipelined;   // killBecauseDifferentSpillAttemptInPipelined
-            assert cr.isPipelined;
-            assert !(commitAndRegister && killInPipelined);
+          CommitRegister cr = checkCommitRegister(srcAttemptIdentifier);
+          boolean commitAndRegister = cr.commitAndRegister;
+          boolean killInPipelined = cr.killInPipelined;   // killBecauseDifferentSpillAttemptInPipelined
+          assert cr.isPipelined;
+          assert !(commitAndRegister && killInPipelined);
 
-            // 1. call fetchedInput.commit() or fetchedInput.abort() if necessary
-            // consider commitAndRegister only
-            if (commitAndRegister) {
-              fetchedInput.commit();  // may fail with IOException
-              updateStats = true;
-              // 2. register completed input for pipelined shuffle
-              registerCompletedInputForPipelinedShuffle(srcAttemptIdentifier, fetchedInput);
-            } else {
-              LOG.warn("Duplicate fetch of unordered input for {} ({}/{} completed): {}",
+          // 1. call fetchedInput.commit() or fetchedInput.abort() if necessary
+          // consider commitAndRegister only
+          if (commitAndRegister) {
+            fetchedInput.commit();  // may fail with IOException
+            updateStats = true;
+            // 2. register completed input for pipelined shuffle
+            registerCompletedInputForPipelinedShuffle(srcAttemptIdentifier, fetchedInput);
+          } else {
+            LOG.warn("Duplicate fetch of unordered input for {} ({}/{} completed): {}",
+              inputContext.getUniqueIdentifier(), numCompletedInputs.get(), numInputs, srcAttemptIdentifier);
+            shuffleNumDuplicateInputsCounter.increment(1);
+            fetchedInput.abort();
+
+            if (!killInPipelined) {
+              LOG.info("Unordered spill already processed for {} ({}/{} completed): {}",
                 inputContext.getUniqueIdentifier(), numCompletedInputs.get(), numInputs, srcAttemptIdentifier);
-              shuffleNumDuplicateInputsCounter.increment(1);
-              fetchedInput.abort();
-
-              if (!killInPipelined) {
-                LOG.info("Unordered spill already processed for {} ({}/{} completed): {}",
-                  inputContext.getUniqueIdentifier(), numCompletedInputs.get(), numInputs, srcAttemptIdentifier);
-              } else {
-                String message = "Killing self as previous attempt unordered data could have been consumed in pipelined shuffling";
-                IOException exception = new IOException(
-                    message + ": " + inputContext.getUniqueIdentifier() + ", " + srcAttemptIdentifier);
-                killSelf(exception, message);
-              }
+            } else {
+              String message = "Killing self as previous attempt unordered data could have been consumed in pipelined shuffling";
+              IOException exception = new IOException(
+                  message + ": " + inputContext.getUniqueIdentifier() + ", " + srcAttemptIdentifier);
+              killSelf(exception, message);
             }
           }
         }
@@ -310,7 +308,7 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
   }
 
   // called from ShuffleInputEventHandler thread, Fetcher thread
-  // Called only while holding lockForInput(inputIdentifier) and synchronized (shuffleInfoEventsMap).
+  // Called only while holding lockForInput(inputIdentifier).
   private void registerCompletedInputForPipelinedShuffle(
       InputAttemptIdentifier srcAttemptIdentifier, FetchedInput fetchedInput) {
     // The input has been successfully fetched for inputIdentifier + spillId, so srcAttemptIdentifier can be obsolete.
@@ -415,7 +413,7 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
     inputContext.sendEvents(failedEvents);
 
     if (srcAttemptIdentifier.canRetrieveInputInChunks()) {
-      synchronized (shuffleInfoEventsMap) {
+      synchronized (lockForInput(inputIdentifier)) {
         ShuffleEventInfo eventInfo = shuffleInfoEventsMap.get(inputIdentifier);
         if (eventInfo != null && srcAttemptIdentifier.getAttemptNumber() == eventInfo.attemptNum) {
           // some spills with the same attempt number have been downloaded, so this TaskAttempt cannot succeed

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
@@ -101,8 +101,6 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
   // not raw access to completedInputSet.
   // This per-input locking model also replaces the old global map monitor
   // (synchronized(shuffleInfoEventsMap)) for pipelined completion paths.
-  private static final int NUM_INPUT_LOCKS = 64;
-  private final Object[] inputLocks;
 
   public ShuffleManager(InputContext inputContext, Configuration conf, int numInputs,
       FetchedInputAllocator inputAllocator, String srcNameTrimmed) throws IOException {
@@ -118,10 +116,6 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
     // In case of pipelined shuffle, it is possible to get multiple FetchedInput per attempt.
     // We do not know upfront the number of spills from source.
     completedInputs = new LinkedBlockingDeque<FetchedInput>();
-    inputLocks = new Object[Math.min(NUM_INPUT_LOCKS, Math.max(1, numInputs))];
-    for (int i = 0; i < inputLocks.length; i++) {
-      inputLocks[i] = new Object();
-    }
 
     LOG.info("ShuffleManager for {}/{}: shuffleClientId={}, numInputs={}",
         inputContext.getUniqueIdentifier(), srcNameTrimmed, shuffleClientId, numInputs);
@@ -485,9 +479,6 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
     return totalSizeOfMemoryCompletedInputs.get();
   }
 
-  private Object lockForInput(int inputIdentifier) {
-    return inputLocks[inputIdentifier % inputLocks.length];
-  }
 
   /////////////////// End of methods for walking the available inputs
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleScheduler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleScheduler.java
@@ -50,8 +50,6 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
 
   private final AtomicInteger remainingMaps;
 
-  private static final int NUM_INPUT_LOCKS = 64;
-  private final Object[] inputLocks;
 
   private final FetchedInputAllocatorOrderedGrouped allocator;
   private final ExceptionReporter exceptionReporter;
@@ -75,10 +73,6 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     this.mergeManager = mergeManager;
 
     remainingMaps = new AtomicInteger(numInputs);
-    inputLocks = new Object[Math.min(NUM_INPUT_LOCKS, Math.max(1, numInputs))];
-    for (int i = 0; i < inputLocks.length; i++) {
-      inputLocks[i] = new Object();
-    }
 
     this.shuffleNumSkippedOrderedInputCounter = inputContext.getCounters().findCounter(TaskCounter.SHUFFLE_NUM_SKIPPED_ORDERED_INPUTS);
 
@@ -363,10 +357,6 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     exceptionReporter.killSelf(exception, message);
   }
 
-  private Object lockForInput(int inputIdentifier) {
-    int idx = (inputIdentifier & Integer.MAX_VALUE) % inputLocks.length;
-    return inputLocks[idx];
-  }
 
   private void logProgress() {
     int inputsDone = numInputs - remainingMaps.get();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleScheduler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleScheduler.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
@@ -42,12 +43,15 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
 
   private final long startTime;
 
-  private int numFetchedSpills = 0;
-  private long totalBytesShuffledTillNow = 0;
+  private final AtomicInteger numFetchedSpills = new AtomicInteger(0);
+  private final AtomicLong totalBytesShuffledTillNow = new AtomicLong(0);
 
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
   private final AtomicInteger remainingMaps;
+
+  private static final int NUM_INPUT_LOCKS = 64;
+  private final Object[] inputLocks;
 
   private final FetchedInputAllocatorOrderedGrouped allocator;
   private final ExceptionReporter exceptionReporter;
@@ -71,6 +75,10 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     this.mergeManager = mergeManager;
 
     remainingMaps = new AtomicInteger(numInputs);
+    inputLocks = new Object[Math.min(NUM_INPUT_LOCKS, Math.max(1, numInputs))];
+    for (int i = 0; i < inputLocks.length; i++) {
+      inputLocks[i] = new Object();
+    }
 
     this.shuffleNumSkippedOrderedInputCounter = inputContext.getCounters().findCounter(TaskCounter.SHUFFLE_NUM_SKIPPED_ORDERED_INPUTS);
 
@@ -134,7 +142,7 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     shuffleServer.addKnownInput(this, hostName, containerId, port, srcAttempt, partitionId);
   }
 
-  public synchronized void fetchSucceeded(
+  public void fetchSucceeded(
       InputAttemptIdentifier srcAttemptIdentifier,
       MapOutput output,
       long bytesCompressed,
@@ -143,77 +151,81 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     int inputIdentifier = srcAttemptIdentifier.getInputIdentifier();
 
     boolean updateStats = false;
-    if (!isInputFinished(inputIdentifier)) {
-      // guard shuffleInfoEventsMap[], already covered by this.synchronized
-      // The result of checkCommitRegister() is valid in this.synchronized, so inside fetchSucceeded()
-      CommitRegister cr = checkCommitRegister(srcAttemptIdentifier);
-      boolean isPipelined = cr.isPipelined;
-      boolean commitAndRegister = cr.commitAndRegister;
-      boolean killInPipelined = cr.killInPipelined;   // killBecauseDifferentSpillAttemptInPipelined
-      assert !(!isPipelined) || commitAndRegister;
-      assert !(isPipelined && commitAndRegister) || !killInPipelined;
-      assert !(isPipelined && killInPipelined) || !commitAndRegister;
+    boolean allInputsFetched = false;
+    synchronized (lockForInput(inputIdentifier)) {
+      if (!isInputFinished(inputIdentifier)) {
+        // The result of checkCommitRegister() is valid while lockForInput(inputIdentifier) is held.
+        CommitRegister cr = checkCommitRegister(srcAttemptIdentifier);
+        boolean isPipelined = cr.isPipelined;
+        boolean commitAndRegister = cr.commitAndRegister;
+        boolean killInPipelined = cr.killInPipelined;   // killBecauseDifferentSpillAttemptInPipelined
+        assert !(!isPipelined) || commitAndRegister;
+        assert !(isPipelined && commitAndRegister) || !killInPipelined;
+        assert !(isPipelined && killInPipelined) || !commitAndRegister;
 
-      // 1. call output.commit() or output.abort() if necessary
-      // consider commitAndRegister only
-      if (output != null) {
-        if (commitAndRegister) {
-          output.commit();
-          updateStats = true;
-        } else {
-          LOG.warn("Duplicate fetch of ordered input for {} ({} remaining): {}",
-            inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
-          shuffleNumDuplicateInputsCounter.increment(1);
-          // free the resource - especially memory
-          output.abort();
-        }
-      } else {
-        // cannot call output.commit()/abort()
-        // Output null implies that a physical input completion is being registered without needing to fetch data
-        shuffleNumSkippedOrderedInputCounter.increment(1);
-      }
-
-      // 2. register completed input if necessary
-      // consider isPipelined, commitAndRegister, killInPipelined
-      if (!isPipelined) {
-        // commitAndRegister == true
-        registerCompletedInput(srcAttemptIdentifier);
-      } else {
-        if (commitAndRegister) {
-          // killInPipelined == false
-          registerCompletedInputForPipelinedShuffle(srcAttemptIdentifier);
-        } else {
-          if (!killInPipelined) {
-            LOG.info("Ordered spill already processed for {} (remaining={}): {}",
-                inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
+        // 1. call output.commit() or output.abort() if necessary
+        // consider commitAndRegister only
+        if (output != null) {
+          if (commitAndRegister) {
+            output.commit();
+            updateStats = true;
           } else {
-            String message = "Killing self as previous attempt ordered data could have been consumed in pipelined shuffling";
-            IOException exception = new IOException(
-                message + ": " + inputContext.getUniqueIdentifier() + ", " + srcAttemptIdentifier);
-            killSelf(exception, message);
+            LOG.warn("Duplicate fetch of ordered input for {} ({} remaining): {}",
+              inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
+            shuffleNumDuplicateInputsCounter.increment(1);
+            // free the resource - especially memory
+            output.abort();
+          }
+        } else {
+          // cannot call output.commit()/abort()
+          // Output null implies that a physical input completion is being registered without needing to fetch data
+          shuffleNumSkippedOrderedInputCounter.increment(1);
+        }
+
+        // 2. register completed input if necessary
+        // consider isPipelined, commitAndRegister, killInPipelined
+        if (!isPipelined) {
+          // commitAndRegister == true
+          allInputsFetched = registerCompletedInput(srcAttemptIdentifier);
+        } else {
+          if (commitAndRegister) {
+            // killInPipelined == false
+            allInputsFetched = registerCompletedInputForPipelinedShuffle(srcAttemptIdentifier);
+          } else {
+            if (!killInPipelined) {
+              LOG.info("Ordered spill already processed for {} (remaining={}): {}",
+                  inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
+            } else {
+              String message = "Killing self as previous attempt ordered data could have been consumed in pipelined shuffling";
+              IOException exception = new IOException(
+                  message + ": " + inputContext.getUniqueIdentifier() + ", " + srcAttemptIdentifier);
+              killSelf(exception, message);
+            }
           }
         }
-      }
 
-      if (remainingMaps.get() == 0) {
-        notifyAll();
-        LOG.info("All inputs fetched for ShuffleScheduler {}", shuffleClientId);
-      }
-
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Source done for {} ({} remaining): {}",
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Source done for {} ({} remaining): {}",
+              inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
+        }
+      } else {
+        // input is already finished. duplicate fetch.
+        LOG.warn("Fetch of ordered input after completion for {} ({} remaining): {}",
             inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
+        // free the resource - especially memory
+        // If the source does not generate data, output will be null.
+        if (output != null) {
+          shuffleNumDuplicateInputsCounter.increment(1);
+          output.abort();
+        }
       }
-    } else {
-      // input is already finished. duplicate fetch.
-      LOG.warn("Fetch of ordered input after completion for {} ({} remaining): {}",
-          inputContext.getUniqueIdentifier(), remainingMaps.get(), srcAttemptIdentifier);
-      // free the resource - especially memory
-      // If the source does not generate data, output will be null.
-      if (output != null) {
-        shuffleNumDuplicateInputsCounter.increment(1);
-        output.abort();
+    }
+
+    if (allInputsFetched) {
+      synchronized (this) {
+        notifyAll();
       }
+      LOG.info("All inputs fetched for ShuffleScheduler {}", shuffleClientId);
     }
 
     if (updateStats) {
@@ -221,20 +233,21 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
           output.getType().toString(),
           output.getType() == Type.DISK,
           output.getType() == Type.DISK_DIRECT);
-      totalBytesShuffledTillNow += bytesCompressed;
+      totalBytesShuffledTillNow.addAndGet(bytesCompressed);
       logProgress();
     }
   }
 
-  // inside synchronized (this)
-  private void registerCompletedInput(InputAttemptIdentifier srcAttemptIdentifier) {
-    remainingMaps.decrementAndGet();
+  // Called only while holding lockForInput(inputIdentifier).
+  private boolean registerCompletedInput(InputAttemptIdentifier srcAttemptIdentifier) {
+    int remaining = remainingMaps.decrementAndGet();
     setInputFinished(srcAttemptIdentifier.getInputIdentifier());
-    numFetchedSpills++;
+    numFetchedSpills.incrementAndGet();
+    return remaining == 0;
   }
 
-  // inside synchronized (this), covering synchronize (shuffleInfoEventsMap)
-  private void registerCompletedInputForPipelinedShuffle(
+  // Called only while holding lockForInput(inputIdentifier).
+  private boolean registerCompletedInputForPipelinedShuffle(
       InputAttemptIdentifier srcAttemptIdentifier) {
     // The input has been successfully fetched for inputIdentifier + spillId, so srcAttemptIdentifier can be obsolete.
     // srcAttemptIdentifier is already validated.
@@ -250,7 +263,7 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     // spill not processed yet, so register
     assert !eventInfo.getEventsProcessed().get(srcAttemptIdentifier.getSpillEventId());
     eventInfo.spillProcessed(srcAttemptIdentifier.getSpillEventId());
-    numFetchedSpills++;
+    numFetchedSpills.incrementAndGet();
     if (srcAttemptIdentifier.getFetchTypeInfo() == InputAttemptIdentifier.SPILL_INFO.FINAL_UPDATE) {
       eventInfo.setFinalEventId(srcAttemptIdentifier.getSpillEventId());
     }
@@ -258,9 +271,11 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     eventInfoIsDone = eventInfo.isDone();
     if (eventInfoIsDone) {
       shuffleInfoEventsMap.remove(inputIdentifier);
-      remainingMaps.decrementAndGet();
+      int remaining = remainingMaps.decrementAndGet();
       setInputFinished(inputIdentifier);
+      return remaining == 0;
     }
+    return false;
   }
 
   public void fetchFailed(CompositeInputAttemptIdentifier srcAttemptIdentifier,
@@ -288,7 +303,7 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     // Unlike in the original implementation, we do not check the number of fetch failures for srcAttemptIdentifier
     // and fail the current TaskAttempt immediately.
     if (srcAttemptIdentifier.canRetrieveInputInChunks()) {
-      synchronized (this) {
+      synchronized (lockForInput(inputIdentifier)) {
         ShuffleEventInfo eventInfo = shuffleInfoEventsMap.get(inputIdentifier);
         if (eventInfo != null && srcAttemptIdentifier.getAttemptNumber() == eventInfo.attemptNum) {
           // Some spills with the same attempt number have been downloaded, so this TaskAttempt cannot succeed.
@@ -334,8 +349,7 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
   // can run in ShuffleServer.call() thread, ShuffleInputEventHandler thread
   protected boolean validateInputAttemptForPipelinedShuffle(InputAttemptIdentifier input) {
     if (input.canRetrieveInputInChunks()) {   // for pipelined shuffle only
-      // synchronized (this) covers synchronized (shuffleInfoEventsMap)
-      synchronized (this) {
+      synchronized (lockForInput(input.getInputIdentifier())) {
         return validateInputAttemptForPipelinedShuffleCommon(input);
       }
     } else {
@@ -349,17 +363,22 @@ public class ShuffleScheduler extends ShuffleClient<MapOutput> {
     exceptionReporter.killSelf(exception, message);
   }
 
+  private Object lockForInput(int inputIdentifier) {
+    int idx = (inputIdentifier & Integer.MAX_VALUE) % inputLocks.length;
+    return inputLocks[idx];
+  }
+
   private void logProgress() {
     int inputsDone = numInputs - remainingMaps.get();
     if (inputsDone == numInputs || isShutdown.get()) {
-      long kbs = totalBytesShuffledTillNow / 1024;
+      long kbs = totalBytesShuffledTillNow.get() / 1024;
       long secsSinceStart = (System.currentTimeMillis() - startTime) / 1000 + 1;
       long transferRate = kbs / secsSinceStart;
 
       StringBuilder s = new StringBuilder();
       s.append("ShuffleScheduler " + shuffleClientId);
       s.append(", copy=" + inputsDone);
-      s.append(", numFetchedSpills=" + numFetchedSpills);
+      s.append(", numFetchedSpills=" + numFetchedSpills.get());
       s.append(", numInputs=" + numInputs);
       s.append(", transfer rate (KB/s) = " + transferRate);
       LOG.info(s.toString());


### PR DESCRIPTION
### Motivation

- Remove contention on a single global monitor (`synchronized(shuffleInfoEventsMap)`) and make pipelined shuffle event handling safer and more concurrent.
- Ensure per-input state (spill/event validation and completion) is protected by fine-grained locks while the events map itself is concurrently accessible.

### Description

- Replace `HashMap<Integer, ShuffleEventInfo>` with `ConcurrentHashMap<Integer, ShuffleEventInfo>` for `shuffleInfoEventsMap` and remove the `HashMap` import. 
- Update comments and invariants to document that the map no longer requires a global monitor and that multi-step decisions must be guarded by the caller-side per-input lock (`lockForInput(inputIdentifier)`).
- Replace usages of `synchronized(shuffleInfoEventsMap)` with synchronization on `lockForInput(inputIdentifier)` (or ensure the caller-side lock is held) in `validateInputAttemptForPipelinedShuffle`, `addCompletedInputWithNoData`, `fetchSucceeded`, and `fetchFailed` code paths, and adjust related comments/invariants.
- Keep per-input lifecycle logic intact but move duplicate fetch handling and killing logic to run under the per-input lock, and document the new locking model in `ShuffleManager`.

### Testing

- Ran the project's unit test suite with `mvn test` and the shuffle-related unit tests, and they completed successfully. 
- Verified compilation of the modified modules with the standard build which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6196bd2c8328b7d742a3b1922914)