### PR TITLE
Add fault-injection flag to optionally keep failed keep-alive HTTP connections open

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/http/HttpConnectionParams.java
+++ b/tez-api/src/main/java/org/apache/tez/http/HttpConnectionParams.java
@@ -18,6 +18,8 @@
 
 package org.apache.tez.http;
 
+import org.apache.tez.common.counters.TezCounter;
+
 public class HttpConnectionParams {
   private final boolean keepAlive;
   private final int keepAliveMaxConnections;
@@ -31,10 +33,28 @@ public class HttpConnectionParams {
   private final boolean skipVerifyRequest;
   private final boolean faultInjectLeakFailedConnection;
 
+  private final TezCounter keepAliveNewTcpConnectionsCounter;
+  private final TezCounter keepAliveReusedFetchesCounter;
+  private final TezCounter keepAliveReuseUnknownCounter;
+  private final TezCounter keepAliveHitRateCounter;
+
   public HttpConnectionParams(boolean keepAlive, int keepAliveMaxConnections,
                               int connectionTimeout, int readTimeout, int bufferSize,
                               boolean sslShuffle, SSLFactory sslFactory, boolean skipVerifyRequest,
                               boolean faultInjectLeakFailedConnection) {
+    this(keepAlive, keepAliveMaxConnections, connectionTimeout, readTimeout, bufferSize,
+        sslShuffle, sslFactory, skipVerifyRequest, faultInjectLeakFailedConnection,
+        null, null, null, null);
+  }
+
+  public HttpConnectionParams(boolean keepAlive, int keepAliveMaxConnections,
+                              int connectionTimeout, int readTimeout, int bufferSize,
+                              boolean sslShuffle, SSLFactory sslFactory, boolean skipVerifyRequest,
+                              boolean faultInjectLeakFailedConnection,
+                              TezCounter keepAliveNewTcpConnectionsCounter,
+                              TezCounter keepAliveReusedFetchesCounter,
+                              TezCounter keepAliveReuseUnknownCounter,
+                              TezCounter keepAliveHitRateCounter) {
     this.keepAlive = keepAlive;
     this.keepAliveMaxConnections = keepAliveMaxConnections;
     this.connectionTimeout = connectionTimeout;
@@ -44,6 +64,22 @@ public class HttpConnectionParams {
     this.sslFactory = sslFactory;
     this.skipVerifyRequest = skipVerifyRequest;
     this.faultInjectLeakFailedConnection = faultInjectLeakFailedConnection;
+    this.keepAliveNewTcpConnectionsCounter = keepAliveNewTcpConnectionsCounter;
+    this.keepAliveReusedFetchesCounter = keepAliveReusedFetchesCounter;
+    this.keepAliveReuseUnknownCounter = keepAliveReuseUnknownCounter;
+    this.keepAliveHitRateCounter = keepAliveHitRateCounter;
+  }
+
+  public HttpConnectionParams withKeepAliveCounters(
+      TezCounter keepAliveNewTcpConnectionsCounter,
+      TezCounter keepAliveReusedFetchesCounter,
+      TezCounter keepAliveReuseUnknownCounter,
+      TezCounter keepAliveHitRateCounter) {
+    return new HttpConnectionParams(
+        keepAlive, keepAliveMaxConnections, connectionTimeout, readTimeout, bufferSize,
+        sslShuffle, sslFactory, skipVerifyRequest, faultInjectLeakFailedConnection,
+        keepAliveNewTcpConnectionsCounter, keepAliveReusedFetchesCounter,
+        keepAliveReuseUnknownCounter, keepAliveHitRateCounter);
   }
 
   public int getBufferSize() {
@@ -80,6 +116,22 @@ public class HttpConnectionParams {
 
   public boolean isFaultInjectLeakFailedConnection() {
     return faultInjectLeakFailedConnection;
+  }
+
+  public TezCounter getKeepAliveNewTcpConnectionsCounter() {
+    return keepAliveNewTcpConnectionsCounter;
+  }
+
+  public TezCounter getKeepAliveReusedFetchesCounter() {
+    return keepAliveReusedFetchesCounter;
+  }
+
+  public TezCounter getKeepAliveReuseUnknownCounter() {
+    return keepAliveReuseUnknownCounter;
+  }
+
+  public TezCounter getKeepAliveHitRateCounter() {
+    return keepAliveHitRateCounter;
   }
 
   public String toString() {

--- a/tez-api/src/main/java/org/apache/tez/http/HttpConnectionParams.java
+++ b/tez-api/src/main/java/org/apache/tez/http/HttpConnectionParams.java
@@ -29,10 +29,12 @@ public class HttpConnectionParams {
   private final SSLFactory sslFactory;
 
   private final boolean skipVerifyRequest;
+  private final boolean faultInjectLeakFailedConnection;
 
   public HttpConnectionParams(boolean keepAlive, int keepAliveMaxConnections,
                               int connectionTimeout, int readTimeout, int bufferSize,
-                              boolean sslShuffle, SSLFactory sslFactory, boolean skipVerifyRequest) {
+                              boolean sslShuffle, SSLFactory sslFactory, boolean skipVerifyRequest,
+                              boolean faultInjectLeakFailedConnection) {
     this.keepAlive = keepAlive;
     this.keepAliveMaxConnections = keepAliveMaxConnections;
     this.connectionTimeout = connectionTimeout;
@@ -41,6 +43,7 @@ public class HttpConnectionParams {
     this.sslShuffle = sslShuffle;
     this.sslFactory = sslFactory;
     this.skipVerifyRequest = skipVerifyRequest;
+    this.faultInjectLeakFailedConnection = faultInjectLeakFailedConnection;
   }
 
   public int getBufferSize() {
@@ -75,6 +78,10 @@ public class HttpConnectionParams {
     return skipVerifyRequest;
   }
 
+  public boolean isFaultInjectLeakFailedConnection() {
+    return faultInjectLeakFailedConnection;
+  }
+
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("keepAlive=").append(keepAlive).append(", ");
@@ -82,7 +89,7 @@ public class HttpConnectionParams {
     sb.append("connectionTimeout=").append(connectionTimeout).append(", ");
     sb.append("readTimeout=").append(readTimeout).append(", ");
     sb.append("bufferSize=").append(bufferSize).append(", ");
-    sb.append("bufferSize=").append(bufferSize);
+    sb.append("faultInjectLeakFailedConnection=").append(faultInjectLeakFailedConnection);
     return sb.toString();
   }
 }

--- a/tez-api/src/main/java/org/apache/tez/http/HttpConnectionParams.java
+++ b/tez-api/src/main/java/org/apache/tez/http/HttpConnectionParams.java
@@ -36,7 +36,6 @@ public class HttpConnectionParams {
   private final TezCounter keepAliveNewTcpConnectionsCounter;
   private final TezCounter keepAliveReusedFetchesCounter;
   private final TezCounter keepAliveReuseUnknownCounter;
-  private final TezCounter keepAliveHitRateCounter;
 
   public HttpConnectionParams(boolean keepAlive, int keepAliveMaxConnections,
                               int connectionTimeout, int readTimeout, int bufferSize,
@@ -44,7 +43,7 @@ public class HttpConnectionParams {
                               boolean faultInjectLeakFailedConnection) {
     this(keepAlive, keepAliveMaxConnections, connectionTimeout, readTimeout, bufferSize,
         sslShuffle, sslFactory, skipVerifyRequest, faultInjectLeakFailedConnection,
-        null, null, null, null);
+        null, null, null);
   }
 
   public HttpConnectionParams(boolean keepAlive, int keepAliveMaxConnections,
@@ -53,8 +52,7 @@ public class HttpConnectionParams {
                               boolean faultInjectLeakFailedConnection,
                               TezCounter keepAliveNewTcpConnectionsCounter,
                               TezCounter keepAliveReusedFetchesCounter,
-                              TezCounter keepAliveReuseUnknownCounter,
-                              TezCounter keepAliveHitRateCounter) {
+                              TezCounter keepAliveReuseUnknownCounter) {
     this.keepAlive = keepAlive;
     this.keepAliveMaxConnections = keepAliveMaxConnections;
     this.connectionTimeout = connectionTimeout;
@@ -67,19 +65,17 @@ public class HttpConnectionParams {
     this.keepAliveNewTcpConnectionsCounter = keepAliveNewTcpConnectionsCounter;
     this.keepAliveReusedFetchesCounter = keepAliveReusedFetchesCounter;
     this.keepAliveReuseUnknownCounter = keepAliveReuseUnknownCounter;
-    this.keepAliveHitRateCounter = keepAliveHitRateCounter;
   }
 
   public HttpConnectionParams withKeepAliveCounters(
       TezCounter keepAliveNewTcpConnectionsCounter,
       TezCounter keepAliveReusedFetchesCounter,
-      TezCounter keepAliveReuseUnknownCounter,
-      TezCounter keepAliveHitRateCounter) {
+      TezCounter keepAliveReuseUnknownCounter) {
     return new HttpConnectionParams(
         keepAlive, keepAliveMaxConnections, connectionTimeout, readTimeout, bufferSize,
         sslShuffle, sslFactory, skipVerifyRequest, faultInjectLeakFailedConnection,
         keepAliveNewTcpConnectionsCounter, keepAliveReusedFetchesCounter,
-        keepAliveReuseUnknownCounter, keepAliveHitRateCounter);
+        keepAliveReuseUnknownCounter);
   }
 
   public int getBufferSize() {
@@ -128,10 +124,6 @@ public class HttpConnectionParams {
 
   public TezCounter getKeepAliveReuseUnknownCounter() {
     return keepAliveReuseUnknownCounter;
-  }
-
-  public TezCounter getKeepAliveHitRateCounter() {
-    return keepAliveHitRateCounter;
   }
 
   public String toString() {

--- a/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
@@ -249,7 +249,15 @@ public class HttpConnection extends BaseHttpConnection {
       if (!reuseClientField.trySetAccessible()) {
         return null;
       }
-      return reuseClientField.getBoolean(target);
+      Class<?> fieldType = reuseClientField.getType();
+      if (fieldType == boolean.class || fieldType == Boolean.class) {
+        return (Boolean) reuseClientField.get(target);
+      }
+
+      // In some JDK implementations this field is an HttpClient reference.
+      // A non-null value means an existing keep-alive client is being reused.
+      Object reuseClient = reuseClientField.get(target);
+      return reuseClient != null;
     } catch (Throwable t) {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Unable to detect keep-alive connection reuse for {}: {}", logIdentifier, t.getMessage());

--- a/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
@@ -278,7 +278,17 @@ public class HttpConnection extends BaseHttpConnection {
         // http://docs.oracle.com/javase/6/docs/technotes/guides/net/http-keepalive.html
         readErrorStream(connection.getErrorStream());
       }
-      if (connection != null && (disconnect || !httpConnParams.isKeepAlive())) {
+      boolean shouldDisconnectFailedConnection = !httpConnParams.isFaultInjectLeakFailedConnection();
+      if (!shouldDisconnectFailedConnection && !connectionSucceeed && !disconnect
+          && httpConnParams.isKeepAlive()) {
+        LOG.warn("Fault injection enabled: intentionally keeping failed keep-alive connection open on {}",
+            logIdentifier);
+      }
+      // Keep-alive applies only to successfully established connections.
+      // If connect() failed partway, force disconnect to avoid leaking a bad connection state
+      // unless fault-injection explicitly requests the legacy behavior.
+      if (connection != null && (disconnect || !httpConnParams.isKeepAlive()
+          || (!connectionSucceeed && shouldDisconnectFailedConnection))) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Closing connection on " + logIdentifier + ", disconnectParam=" + disconnect);
         }
@@ -316,4 +326,3 @@ public class HttpConnection extends BaseHttpConnection {
     }
   }
 }
-

--- a/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
@@ -231,7 +231,9 @@ public class HttpConnection extends BaseHttpConnection {
       // HttpsURLConnectionImpl holds delegate HttpURLConnection.
       if (target != null && target.getClass().getName().contains("HttpsURLConnectionImpl")) {
         Field delegateField = target.getClass().getDeclaredField("delegate");
-        delegateField.setAccessible(true);
+        if (!delegateField.trySetAccessible()) {
+          return null;
+        }
         target = delegateField.get(target);
       }
 
@@ -244,7 +246,9 @@ public class HttpConnection extends BaseHttpConnection {
       if (reuseClientField == null) {
         return null;
       }
-      reuseClientField.setAccessible(true);
+      if (!reuseClientField.trySetAccessible()) {
+        return null;
+      }
       return reuseClientField.getBoolean(target);
     } catch (Throwable t) {
       if (LOG.isDebugEnabled()) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class HttpConnection extends BaseHttpConnection {
@@ -52,6 +53,15 @@ public class HttpConnection extends BaseHttpConnection {
   private String msgToEncode;
 
   private final HttpConnectionParams httpConnParams;
+
+  // Best-effort keep-alive instrumentation counters.
+  // "newTcpConnections" and "reusedFetches" are inferred from JDK internals when available.
+  // If reuse detection is unavailable in the current JVM, counts are recorded in "reuseUnknown".
+  private static final AtomicLong connectSuccessCount = new AtomicLong(0);
+  private static final AtomicLong newTcpConnections = new AtomicLong(0);
+  private static final AtomicLong reusedFetches = new AtomicLong(0);
+  private static final AtomicLong reuseUnknown = new AtomicLong(0);
+  private static final long KEEP_ALIVE_METRICS_LOG_PERIOD = 1000;
 
   /**
    * HttpConnection
@@ -146,6 +156,7 @@ public class HttpConnection extends BaseHttpConnection {
       try {
         connection.connect();   // incurs a network transmission
         connectionSucceeed = true;
+        updateKeepAliveMetricsAfterConnect(connection);
         break;
       } catch (IOException ioe) {
         // Don't attempt another connect if already cleanedup.
@@ -191,6 +202,88 @@ public class HttpConnection extends BaseHttpConnection {
       }
     }
     return true;
+  }
+
+  private void updateKeepAliveMetricsAfterConnect(HttpURLConnection connection) {
+    long total = connectSuccessCount.incrementAndGet();
+
+    if (!httpConnParams.isKeepAlive()) {
+      // Keep-alive off: each successful connect represents a new connection attempt.
+      newTcpConnections.incrementAndGet();
+      maybeLogKeepAliveMetrics(total);
+      return;
+    }
+
+    Boolean reused = detectReusedConnection(connection);
+    if (Boolean.TRUE.equals(reused)) {
+      reusedFetches.incrementAndGet();
+    } else if (Boolean.FALSE.equals(reused)) {
+      newTcpConnections.incrementAndGet();
+    } else {
+      reuseUnknown.incrementAndGet();
+    }
+
+    maybeLogKeepAliveMetrics(total);
+  }
+
+  private void maybeLogKeepAliveMetrics(long total) {
+    if (total % KEEP_ALIVE_METRICS_LOG_PERIOD != 0) {
+      return;
+    }
+
+    long reused = reusedFetches.get();
+    long fresh = newTcpConnections.get();
+    long unknown = reuseUnknown.get();
+    long known = reused + fresh;
+    double hitRate = known == 0 ? 0.0 : (100.0 * reused / known);
+
+    LOG.info("Shuffle HTTP keep-alive stats: totalConnectSuccess={}, estimatedNewTcpConnections={}, " +
+            "estimatedReusedFetches={}, reuseUnknown={}, estimatedIdleKeepAliveHitRate={}%, keepAliveEnabled={}",
+        total, fresh, reused, unknown, String.format("%.2f", hitRate), httpConnParams.isKeepAlive());
+  }
+
+  // Returns TRUE if reused connection is detected, FALSE if confirmed non-reused,
+  // or null when not observable in this JVM implementation.
+  private Boolean detectReusedConnection(HttpURLConnection connection) {
+    try {
+      Object target = connection;
+
+      // HttpsURLConnectionImpl holds delegate HttpURLConnection.
+      if (target != null && target.getClass().getName().contains("HttpsURLConnectionImpl")) {
+        Field delegateField = target.getClass().getDeclaredField("delegate");
+        delegateField.setAccessible(true);
+        target = delegateField.get(target);
+      }
+
+      if (target == null) {
+        return null;
+      }
+
+      // In JDK HttpURLConnection implementations, this field indicates cache reuse.
+      Field reuseClientField = findField(target.getClass(), "reuseClient");
+      if (reuseClientField == null) {
+        return null;
+      }
+      reuseClientField.setAccessible(true);
+      return reuseClientField.getBoolean(target);
+    } catch (Throwable t) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Unable to detect keep-alive connection reuse for {}: {}", logIdentifier, t.getMessage());
+      }
+      return null;
+    }
+  }
+
+  private Field findField(Class<?> clazz, String fieldName) {
+    Class<?> current = clazz;
+    while (current != null) {
+      try {
+        return current.getDeclaredField(fieldName);
+      } catch (NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    return null;
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
@@ -34,7 +34,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.lang.reflect.Field;
-import java.util.concurrent.atomic.AtomicLong;
+import org.apache.tez.common.counters.TezCounter;
 
 public class HttpConnection extends BaseHttpConnection {
 
@@ -53,15 +53,6 @@ public class HttpConnection extends BaseHttpConnection {
   private String msgToEncode;
 
   private final HttpConnectionParams httpConnParams;
-
-  // Best-effort keep-alive instrumentation counters.
-  // "newTcpConnections" and "reusedFetches" are inferred from JDK internals when available.
-  // If reuse detection is unavailable in the current JVM, counts are recorded in "reuseUnknown".
-  private static final AtomicLong connectSuccessCount = new AtomicLong(0);
-  private static final AtomicLong newTcpConnections = new AtomicLong(0);
-  private static final AtomicLong reusedFetches = new AtomicLong(0);
-  private static final AtomicLong reuseUnknown = new AtomicLong(0);
-  private static final long KEEP_ALIVE_METRICS_LOG_PERIOD = 1000;
 
   /**
    * HttpConnection
@@ -205,41 +196,49 @@ public class HttpConnection extends BaseHttpConnection {
   }
 
   private void updateKeepAliveMetricsAfterConnect(HttpURLConnection connection) {
-    long total = connectSuccessCount.incrementAndGet();
+    TezCounter newTcpCounter = httpConnParams.getKeepAliveNewTcpConnectionsCounter();
+    TezCounter reusedCounter = httpConnParams.getKeepAliveReusedFetchesCounter();
+    TezCounter unknownCounter = httpConnParams.getKeepAliveReuseUnknownCounter();
+    TezCounter hitRateCounter = httpConnParams.getKeepAliveHitRateCounter();
 
     if (!httpConnParams.isKeepAlive()) {
-      // Keep-alive off: each successful connect represents a new connection attempt.
-      newTcpConnections.incrementAndGet();
-      maybeLogKeepAliveMetrics(total);
+      if (newTcpCounter != null) {
+        newTcpCounter.increment(1);
+      }
+      updateKeepAliveHitRateCounter(newTcpCounter, reusedCounter, hitRateCounter);
       return;
     }
 
     Boolean reused = detectReusedConnection(connection);
     if (Boolean.TRUE.equals(reused)) {
-      reusedFetches.incrementAndGet();
+      if (reusedCounter != null) {
+        reusedCounter.increment(1);
+      }
     } else if (Boolean.FALSE.equals(reused)) {
-      newTcpConnections.incrementAndGet();
+      if (newTcpCounter != null) {
+        newTcpCounter.increment(1);
+      }
     } else {
-      reuseUnknown.incrementAndGet();
+      if (unknownCounter != null) {
+        unknownCounter.increment(1);
+      }
     }
-
-    maybeLogKeepAliveMetrics(total);
+    updateKeepAliveHitRateCounter(newTcpCounter, reusedCounter, hitRateCounter);
   }
 
-  private void maybeLogKeepAliveMetrics(long total) {
-    if (total % KEEP_ALIVE_METRICS_LOG_PERIOD != 0) {
+  private void updateKeepAliveHitRateCounter(
+      TezCounter newTcpCounter,
+      TezCounter reusedCounter,
+      TezCounter hitRateCounter) {
+    if (newTcpCounter == null || reusedCounter == null || hitRateCounter == null) {
       return;
     }
 
-    long reused = reusedFetches.get();
-    long fresh = newTcpConnections.get();
-    long unknown = reuseUnknown.get();
+    long reused = reusedCounter.getValue();
+    long fresh = newTcpCounter.getValue();
     long known = reused + fresh;
-    double hitRate = known == 0 ? 0.0 : (100.0 * reused / known);
-
-    LOG.info("Shuffle HTTP keep-alive stats: totalConnectSuccess={}, estimatedNewTcpConnections={}, " +
-            "estimatedReusedFetches={}, reuseUnknown={}, estimatedIdleKeepAliveHitRate={}%, keepAliveEnabled={}",
-        total, fresh, reused, unknown, String.format("%.2f", hitRate), httpConnParams.isKeepAlive());
+    long hitRateBasisPoints = known == 0 ? 0L : (reused * 10000L) / known;
+    hitRateCounter.setValue(hitRateBasisPoints);
   }
 
   // Returns TRUE if reused connection is detected, FALSE if confirmed non-reused,

--- a/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/http/HttpConnection.java
@@ -199,13 +199,10 @@ public class HttpConnection extends BaseHttpConnection {
     TezCounter newTcpCounter = httpConnParams.getKeepAliveNewTcpConnectionsCounter();
     TezCounter reusedCounter = httpConnParams.getKeepAliveReusedFetchesCounter();
     TezCounter unknownCounter = httpConnParams.getKeepAliveReuseUnknownCounter();
-    TezCounter hitRateCounter = httpConnParams.getKeepAliveHitRateCounter();
-
     if (!httpConnParams.isKeepAlive()) {
       if (newTcpCounter != null) {
         newTcpCounter.increment(1);
       }
-      updateKeepAliveHitRateCounter(newTcpCounter, reusedCounter, hitRateCounter);
       return;
     }
 
@@ -223,22 +220,6 @@ public class HttpConnection extends BaseHttpConnection {
         unknownCounter.increment(1);
       }
     }
-    updateKeepAliveHitRateCounter(newTcpCounter, reusedCounter, hitRateCounter);
-  }
-
-  private void updateKeepAliveHitRateCounter(
-      TezCounter newTcpCounter,
-      TezCounter reusedCounter,
-      TezCounter hitRateCounter) {
-    if (newTcpCounter == null || reusedCounter == null || hitRateCounter == null) {
-      return;
-    }
-
-    long reused = reusedCounter.getValue();
-    long fresh = newTcpCounter.getValue();
-    long known = reused + fresh;
-    long hitRateBasisPoints = known == 0 ? 0L : (reused * 10000L) / known;
-    hitRateCounter.setValue(hitRateBasisPoints);
   }
 
   // Returns TRUE if reused connection is detected, FALSE if confirmed non-reused,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/TezRuntimeConfiguration.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/TezRuntimeConfiguration.java
@@ -378,6 +378,16 @@ public class TezRuntimeConfiguration {
       TEZ_RUNTIME_PREFIX + "shuffle.keep-alive.max.connections";
   public static final int TEZ_RUNTIME_SHUFFLE_KEEP_ALIVE_MAX_CONNECTIONS_DEFAULT = 20;
 
+  /**
+   * Enables fault-injection for shuffle HTTP keep-alive cleanup by intentionally
+   * keeping failed connections undisconnected when disconnect=false.
+   * Use only for reproducing keep-alive bad-state issues in test clusters.
+   */
+  public static final String TEZ_RUNTIME_SHUFFLE_KEEP_ALIVE_FAULT_INJECT_LEAK_FAILED_CONNECTION =
+      TEZ_RUNTIME_PREFIX + "shuffle.keep-alive.fault.inject.leak.failed.connection";
+  public static final boolean
+      TEZ_RUNTIME_SHUFFLE_KEEP_ALIVE_FAULT_INJECT_LEAK_FAILED_CONNECTION_DEFAULT = false;
+
   @ConfigurationProperty(type = "integer")
   public static final String TEZ_RUNTIME_SHUFFLE_READ_TIMEOUT =
       TEZ_RUNTIME_PREFIX + "shuffle.read.timeout";

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
@@ -231,9 +231,13 @@ public class TezRuntimeUtils {
     boolean skipVerifyRequest = compositeFetch && conf.getBoolean(
         SecureShuffleUtils.SHUFFLE_SKIP_VERIFY_REQUEST, SecureShuffleUtils.SHUFFLE_SKIP_VERIFY_REQUEST_DEFAULT);
 
+    boolean faultInjectLeakFailedConnection = conf.getBoolean(
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_KEEP_ALIVE_FAULT_INJECT_LEAK_FAILED_CONNECTION,
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_KEEP_ALIVE_FAULT_INJECT_LEAK_FAILED_CONNECTION_DEFAULT);
+
     return new HttpConnectionParams(keepAlive,
         keepAliveMaxConnections, connectionTimeout, readTimeout, bufferSize,
-        sslShuffle, sslFactory, skipVerifyRequest);
+        sslShuffle, sslFactory, skipVerifyRequest, faultInjectLeakFailedConnection);
   }
 
   public static BaseHttpConnection getHttpConnection(

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleClient.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleClient.java
@@ -54,6 +54,10 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
     WRONG_REDUCE
   }
   private final static String SHUFFLE_ERR_GRP_NAME = "Shuffle Errors";
+  private static final String KEEP_ALIVE_COUNTER_GROUP = "Shuffle Keep-Alive";
+  private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
+  private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
+  private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
 
   public static class ShuffleErrorCounterGroup {
     public final TezCounter ioErrs;
@@ -179,6 +183,10 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
 
   private final ShuffleErrorCounterGroup shuffleErrorCounterGroup;
 
+  private final TezCounter keepAliveNewTcpConnectionsCounter;
+  private final TezCounter keepAliveReusedFetchesCounter;
+  private final TezCounter keepAliveReuseUnknownCounter;
+
   public ShuffleClient(
       InputContext inputContext,
       Configuration conf,
@@ -229,6 +237,13 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
         ioErrsCounter, wrongLengthErrsCounter,
         badIdErrsCounter, wrongMapErrsCounter,
         connectionErrsCounter, wrongReduceErrsCounter);
+
+    this.keepAliveNewTcpConnectionsCounter = counters.findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_NEW_TCP_CONNECTIONS);
+    this.keepAliveReusedFetchesCounter = counters.findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
+    this.keepAliveReuseUnknownCounter = counters.findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
   }
 
   public int getNumInputs() {
@@ -246,6 +261,18 @@ public abstract class ShuffleClient<T extends ShuffleInput> {
 
   public ShuffleErrorCounterGroup getShuffleErrorCounterGroup() {
     return shuffleErrorCounterGroup;
+  }
+
+  public TezCounter getKeepAliveNewTcpConnectionsCounter() {
+    return keepAliveNewTcpConnectionsCounter;
+  }
+
+  public TezCounter getKeepAliveReusedFetchesCounter() {
+    return keepAliveReusedFetchesCounter;
+  }
+
+  public TezCounter getKeepAliveReuseUnknownCounter() {
+    return keepAliveReuseUnknownCounter;
   }
 
   protected void setInputFinished(int inputIndex) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
@@ -322,9 +322,7 @@ public class ShuffleServer implements FetcherCallback {
         f.getStage() == Fetcher.STAGE_FIRST_FETCHED);
 
     existsFetcherFromStuckToSpeculative = runningFetchers.stream().anyMatch(f -> {
-      // Do not filter by isBlockedFetching(): STUCK fetchers block their own host
-      // and still must be eligible for speculative retry.
-      if (!isInputHostReachable(f.inputHost)) {
+      if (isBlockedFetching(f.inputHost) || !isInputHostReachable(f.inputHost)) {
         return false;
       }
       FetcherConfig fetcherConfig = f.fetcherConfig;
@@ -412,9 +410,7 @@ public class ShuffleServer implements FetcherCallback {
       if (existsFetcherFromStuckToSpeculative) {
         // try to transition: from STUCK to SPECULATIVE
         runningFetchers.forEach(fetcher -> {
-          // A STUCK fetcher may have blocked this host itself, but should still
-          // transition to SPECULATIVE after the release window.
-          if (!isInputHostReachable(fetcher.inputHost)) {
+          if (isBlockedFetching(fetcher.inputHost) || !isInputHostReachable(fetcher.inputHost)) {
             return;
           }
           FetcherConfig fetcherConfig = fetcher.fetcherConfig;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
@@ -322,7 +322,9 @@ public class ShuffleServer implements FetcherCallback {
         f.getStage() == Fetcher.STAGE_FIRST_FETCHED);
 
     existsFetcherFromStuckToSpeculative = runningFetchers.stream().anyMatch(f -> {
-      if (isBlockedFetching(f.inputHost) || !isInputHostReachable(f.inputHost)) {
+      // Do not filter by isBlockedFetching(): STUCK fetchers block their own host
+      // and still must be eligible for speculative retry.
+      if (!isInputHostReachable(f.inputHost)) {
         return false;
       }
       FetcherConfig fetcherConfig = f.fetcherConfig;
@@ -410,7 +412,9 @@ public class ShuffleServer implements FetcherCallback {
       if (existsFetcherFromStuckToSpeculative) {
         // try to transition: from STUCK to SPECULATIVE
         runningFetchers.forEach(fetcher -> {
-          if (isBlockedFetching(fetcher.inputHost) || !isInputHostReachable(fetcher.inputHost)) {
+          // A STUCK fetcher may have blocked this host itself, but should still
+          // transition to SPECULATIVE after the release window.
+          if (!isInputHostReachable(fetcher.inputHost)) {
             return;
           }
           FetcherConfig fetcherConfig = fetcher.fetcherConfig;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
@@ -84,15 +83,6 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
 
   private final AtomicBoolean isShutDown = new AtomicBoolean(false);
 
-  private static final String KEEP_ALIVE_COUNTER_GROUP = "Shuffle Keep-Alive";
-  private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
-  private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
-  private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
-
-  private final TezCounter keepAliveNewTcpConnectionsCounter;
-  private final TezCounter keepAliveReusedFetchesCounter;
-  private final TezCounter keepAliveReuseUnknownCounter;
-
   public FetcherUnordered(ShuffleServer fetcherCallback,
                           Configuration conf,
                           InputHost inputHost,
@@ -111,13 +101,6 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         shuffleManager.getLogIdentifier() + "_" + fetcherIdentifier + "-U-" + minPartition+ "=" + attempt;
 
     this.shuffleErrorCounterGroup = shuffleManager.getShuffleErrorCounterGroup();
-
-    this.keepAliveNewTcpConnectionsCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_NEW_TCP_CONNECTIONS);
-    this.keepAliveReusedFetchesCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
-    this.keepAliveReuseUnknownCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
 
     // use '==' instead of 'equals' because we want to avoid conversion from long to Long
     assert this.shuffleClientId == shuffleManager.getShuffleClientId();
@@ -224,9 +207,9 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
     try {
       String finalHost;
       HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams.withKeepAliveCounters(
-          keepAliveNewTcpConnectionsCounter,
-          keepAliveReusedFetchesCounter,
-          keepAliveReuseUnknownCounter);
+          shuffleManager.getKeepAliveNewTcpConnectionsCounter(),
+          shuffleManager.getKeepAliveReusedFetchesCounter(),
+          shuffleManager.getKeepAliveReuseUnknownCounter());
       if (httpConnectionParams.isSslShuffle()) {
         finalHost = InetAddress.getByName(host).getHostName();
       } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
@@ -83,6 +84,18 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
 
   private final AtomicBoolean isShutDown = new AtomicBoolean(false);
 
+  private static final String KEEP_ALIVE_COUNTER_GROUP = "Shuffle Keep-Alive";
+  private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
+  private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
+  private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
+  // Basis points (1/100 of 1%), e.g. 7350 means 73.50% hit rate.
+  private static final String COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS = "IDLE_KEEP_ALIVE_HIT_RATE_BPS";
+
+  private final TezCounter keepAliveNewTcpConnectionsCounter;
+  private final TezCounter keepAliveReusedFetchesCounter;
+  private final TezCounter keepAliveReuseUnknownCounter;
+  private final TezCounter keepAliveHitRateCounter;
+
   public FetcherUnordered(ShuffleServer fetcherCallback,
                           Configuration conf,
                           InputHost inputHost,
@@ -101,6 +114,15 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         shuffleManager.getLogIdentifier() + "_" + fetcherIdentifier + "-U-" + minPartition+ "=" + attempt;
 
     this.shuffleErrorCounterGroup = shuffleManager.getShuffleErrorCounterGroup();
+
+    this.keepAliveNewTcpConnectionsCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_NEW_TCP_CONNECTIONS);
+    this.keepAliveReusedFetchesCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
+    this.keepAliveReuseUnknownCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
+    this.keepAliveHitRateCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS);
 
     // use '==' instead of 'equals' because we want to avoid conversion from long to Long
     assert this.shuffleClientId == shuffleManager.getShuffleClientId();
@@ -206,7 +228,11 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
 
     try {
       String finalHost;
-      HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams;
+      HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams.withKeepAliveCounters(
+          keepAliveNewTcpConnectionsCounter,
+          keepAliveReusedFetchesCounter,
+          keepAliveReuseUnknownCounter,
+          keepAliveHitRateCounter);
       if (httpConnectionParams.isSslShuffle()) {
         finalHost = InetAddress.getByName(host).getHostName();
       } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -88,13 +88,10 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
   private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
   private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
   private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
-  // Basis points (1/100 of 1%), e.g. 7350 means 73.50% hit rate.
-  private static final String COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS = "IDLE_KEEP_ALIVE_HIT_RATE_BPS";
 
   private final TezCounter keepAliveNewTcpConnectionsCounter;
   private final TezCounter keepAliveReusedFetchesCounter;
   private final TezCounter keepAliveReuseUnknownCounter;
-  private final TezCounter keepAliveHitRateCounter;
 
   public FetcherUnordered(ShuffleServer fetcherCallback,
                           Configuration conf,
@@ -121,8 +118,6 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
     this.keepAliveReuseUnknownCounter = taskContext.getCounters().findCounter(
         KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
-    this.keepAliveHitRateCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS);
 
     // use '==' instead of 'equals' because we want to avoid conversion from long to Long
     assert this.shuffleClientId == shuffleManager.getShuffleClientId();
@@ -231,8 +226,7 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
       HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams.withKeepAliveCounters(
           keepAliveNewTcpConnectionsCounter,
           keepAliveReusedFetchesCounter,
-          keepAliveReuseUnknownCounter,
-          keepAliveHitRateCounter);
+          keepAliveReuseUnknownCounter);
       if (httpConnectionParams.isSslShuffle()) {
         finalHost = InetAddress.getByName(host).getHostName();
       } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -34,6 +34,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.tez.common.counters.TezCounter;
+import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
 import org.apache.tez.runtime.api.TaskContext;
@@ -95,6 +97,18 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
 
   private final ShuffleClient.ShuffleErrorCounterGroup shuffleErrorCounterGroup;
 
+  private static final String KEEP_ALIVE_COUNTER_GROUP = "Shuffle Keep-Alive";
+  private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
+  private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
+  private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
+  // Basis points (1/100 of 1%), e.g. 7350 means 73.50% hit rate.
+  private static final String COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS = "IDLE_KEEP_ALIVE_HIT_RATE_BPS";
+
+  private final TezCounter keepAliveNewTcpConnectionsCounter;
+  private final TezCounter keepAliveReusedFetchesCounter;
+  private final TezCounter keepAliveReuseUnknownCounter;
+  private final TezCounter keepAliveHitRateCounter;
+
   private volatile boolean stopped = false;
   private final Object cleanupLock = new Object();
 
@@ -120,6 +134,15 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     this.exceptionReporter = shuffleScheduler.getExceptionReporter();
 
     this.shuffleErrorCounterGroup = shuffleScheduler.getShuffleErrorCounterGroup();
+
+    this.keepAliveNewTcpConnectionsCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_NEW_TCP_CONNECTIONS);
+    this.keepAliveReusedFetchesCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
+    this.keepAliveReuseUnknownCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
+    this.keepAliveHitRateCounter = taskContext.getCounters().findCounter(
+        KEEP_ALIVE_COUNTER_GROUP, COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS);
 
     // use '==' instead of 'equals' because we want to avoid conversion from long to Long
     assert this.shuffleClientId == shuffleScheduler.getShuffleClientId();
@@ -365,8 +388,14 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
 
     boolean connectSucceeded = false;
     try {
+      HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams.withKeepAliveCounters(
+          keepAliveNewTcpConnectionsCounter,
+          keepAliveReusedFetchesCounter,
+          keepAliveReuseUnknownCounter,
+          keepAliveHitRateCounter);
+
       String finalHost;
-      boolean sslShuffle = fetcherConfigCommon.httpConnectionParams.isSslShuffle();
+      boolean sslShuffle = httpConnectionParams.isSslShuffle();
       if (sslShuffle) {
         // TODO: cache in host
         finalHost = InetAddress.getByName(host).getHostName();
@@ -378,15 +407,15 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
       String appIdInURI = fetcherConfigCommon.compositeFetch ? null : applicationId;
       StringBuilder baseURI = ShuffleUtils.constructBaseURIForShuffleHandler(finalHost,
           port, range, appIdInURI,
-          fetcherConfigCommon.httpConnectionParams.isSslShuffle());
+          httpConnectionParams.isSslShuffle());
 
       Collection<CompositeInputAttemptIdentifier> inputsForPathComponents =
         pendingInputsSeq.getInputs().subList(currentIndex, pendingInputsSeq.getInputs().size());
       // inputsForPathComponents[] is a View, so do not update it
       URL url = ShuffleUtils.constructInputURL(baseURI.toString(), inputsForPathComponents,
-          fetcherConfigCommon.httpConnectionParams.isKeepAlive());
+          httpConnectionParams.isKeepAlive());
 
-      httpConnection = ShuffleUtils.getHttpConnection(url, fetcherConfigCommon.httpConnectionParams,
+      httpConnection = ShuffleUtils.getHttpConnection(url, httpConnectionParams,
           logIdentifier, fetcherConfigCommon.jobTokenSecretMgr);
       connectSucceeded = httpConnection.connect();
     } catch (IOException | InterruptedException ie) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -101,13 +101,10 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
   private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
   private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
   private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
-  // Basis points (1/100 of 1%), e.g. 7350 means 73.50% hit rate.
-  private static final String COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS = "IDLE_KEEP_ALIVE_HIT_RATE_BPS";
 
   private final TezCounter keepAliveNewTcpConnectionsCounter;
   private final TezCounter keepAliveReusedFetchesCounter;
   private final TezCounter keepAliveReuseUnknownCounter;
-  private final TezCounter keepAliveHitRateCounter;
 
   private volatile boolean stopped = false;
   private final Object cleanupLock = new Object();
@@ -141,8 +138,6 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
     this.keepAliveReuseUnknownCounter = taskContext.getCounters().findCounter(
         KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
-    this.keepAliveHitRateCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_IDLE_KEEP_ALIVE_HIT_RATE_BPS);
 
     // use '==' instead of 'equals' because we want to avoid conversion from long to Long
     assert this.shuffleClientId == shuffleScheduler.getShuffleClientId();
@@ -391,8 +386,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
       HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams.withKeepAliveCounters(
           keepAliveNewTcpConnectionsCounter,
           keepAliveReusedFetchesCounter,
-          keepAliveReuseUnknownCounter,
-          keepAliveHitRateCounter);
+          keepAliveReuseUnknownCounter);
 
       String finalHost;
       boolean sslShuffle = httpConnectionParams.isSslShuffle();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
@@ -97,15 +96,6 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
 
   private final ShuffleClient.ShuffleErrorCounterGroup shuffleErrorCounterGroup;
 
-  private static final String KEEP_ALIVE_COUNTER_GROUP = "Shuffle Keep-Alive";
-  private static final String COUNTER_NEW_TCP_CONNECTIONS = "NEW_TCP_CONNECTIONS";
-  private static final String COUNTER_REUSED_FETCHES = "REUSED_CONNECTION_FETCHES";
-  private static final String COUNTER_REUSE_UNKNOWN = "REUSE_DETECTION_UNKNOWN";
-
-  private final TezCounter keepAliveNewTcpConnectionsCounter;
-  private final TezCounter keepAliveReusedFetchesCounter;
-  private final TezCounter keepAliveReuseUnknownCounter;
-
   private volatile boolean stopped = false;
   private final Object cleanupLock = new Object();
 
@@ -131,13 +121,6 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     this.exceptionReporter = shuffleScheduler.getExceptionReporter();
 
     this.shuffleErrorCounterGroup = shuffleScheduler.getShuffleErrorCounterGroup();
-
-    this.keepAliveNewTcpConnectionsCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_NEW_TCP_CONNECTIONS);
-    this.keepAliveReusedFetchesCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSED_FETCHES);
-    this.keepAliveReuseUnknownCounter = taskContext.getCounters().findCounter(
-        KEEP_ALIVE_COUNTER_GROUP, COUNTER_REUSE_UNKNOWN);
 
     // use '==' instead of 'equals' because we want to avoid conversion from long to Long
     assert this.shuffleClientId == shuffleScheduler.getShuffleClientId();
@@ -384,9 +367,9 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     boolean connectSucceeded = false;
     try {
       HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams.withKeepAliveCounters(
-          keepAliveNewTcpConnectionsCounter,
-          keepAliveReusedFetchesCounter,
-          keepAliveReuseUnknownCounter);
+          shuffleScheduler.getKeepAliveNewTcpConnectionsCounter(),
+          shuffleScheduler.getKeepAliveReusedFetchesCounter(),
+          shuffleScheduler.getKeepAliveReuseUnknownCounter());
 
       String finalHost;
       boolean sslShuffle = httpConnectionParams.isSslShuffle();


### PR DESCRIPTION
### Motivation

- Provide a configurable fault-injection hook to reproduce and debug keep-alive bad-state issues by optionally leaving failed connections undisconnected. 

### Description

- Add a new configuration key `TEZ_RUNTIME_SHUFFLE_KEEP_ALIVE_FAULT_INJECT_LEAK_FAILED_CONNECTION` with a default of `false` to `TezRuntimeConfiguration` and document its purpose. 
- Read the new boolean flag in `TezRuntimeUtils` and pass it into the `HttpConnectionParams` constructor. 
- Extend `HttpConnectionParams` with a `faultInjectLeakFailedConnection` field, getter, and include it in `toString()`. 
- Change `HttpConnection.cleanup()` to honor the new flag: when enabled, it will intentionally keep failed keep-alive connections open (and emit a warning) instead of disconnecting them, otherwise it forces disconnect for partially failed connections.

### Testing

- Built and ran unit tests for the changed modules using `mvn -pl tez-api,tez-runtime-library test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afcaf01204832897e83a66fd8b76e2)