### PR TITLE
Use resolved connect host for SSL shuffle and cache hostname resolutions

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/InputHost.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/InputHost.java
@@ -113,15 +113,22 @@ public class InputHost {
   private final static AtomicInteger numHostBlocked = new AtomicInteger(0);
 
   private final HostPort hostPort;
+  private final String connectHost;
 
-  public InputHost(HostPort hostPort) {
+  public InputHost(HostPort hostPort, String connectHost) {
     this.hasPendingInput = false;
     this.blockingFetchers = new HashSet<Fetcher<?>>();
     this.hostPort = hostPort;
+    this.connectHost = connectHost;
   }
 
   public HostPort getHostPort() {
     return hostPort;
+  }
+
+  // Hostname/address used by fetchers to connect to ShuffleHandler.
+  public String getConnectHost() {
+    return connectHost;
   }
 
   public void addHostBlocked(Fetcher<?> fetcher) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.conf.Configuration;
+
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
@@ -42,6 +43,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -141,6 +144,8 @@ public class ShuffleServer implements FetcherCallback {
 
   private final ListeningExecutorService fetcherExecutor;
   private final FetcherConfigCommon fetcherConfigCommon;
+  private final boolean sslShuffle;
+  private final ConcurrentMap<String, String> resolvedHosts;
 
   private final int maxTaskOutputAtOnce;
   private final RangesScheme rangesScheme;
@@ -195,6 +200,7 @@ public class ShuffleServer implements FetcherCallback {
         .build());
     this.fetcherExecutor = MoreExecutors.listeningDecorator(fetcherRawExecutor);
     this.fetcherConfigCommon = CodecUtils.constructFetcherConfigCommon(conf, taskContext);
+    this.sslShuffle = fetcherConfigCommon.httpConnectionParams.isSslShuffle();
 
     /**
      * Setting to very high val can lead to Http 400 error. Cap it to 75; every attempt id would
@@ -213,6 +219,7 @@ public class ShuffleServer implements FetcherCallback {
         RangesScheme.SCHEME_PRIORITY;
 
     knownSrcHosts = new ConcurrentHashMap<HostPort, InputHost>();
+    resolvedHosts = new ConcurrentHashMap<String, String>();
 
     shuffleClients = new ConcurrentHashMap<Long, ShuffleClient<?>>();
     pendingHosts = new LinkedBlockingQueue<InputHost>();
@@ -676,7 +683,25 @@ public class ShuffleServer implements FetcherCallback {
     HostPort identifier = new HostPort(hostName, containerId, port);
     InputHost host = knownSrcHosts.get(identifier);
     if (host == null) {
-      host = new InputHost(identifier);
+      String connectHost = hostName;
+      if (sslShuffle) {
+        String resolved = resolvedHosts.get(hostName);
+        if (resolved == null) {
+          try {
+            resolved = InetAddress.getByName(hostName).getHostName();
+          } catch (UnknownHostException e) {
+            LOG.warn("Failed to resolve host {} for SSL shuffle. Using original host.", hostName, e);
+            resolved = hostName;
+          }
+          String prev = resolvedHosts.putIfAbsent(hostName, resolved);
+          if (prev != null) {
+            resolved = prev;
+          }
+        }
+        connectHost = resolved;
+      }
+
+      host = new InputHost(identifier, connectHost);
       InputHost old = knownSrcHosts.putIfAbsent(identifier, host);
       if (old != null) {
         host = old;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -20,7 +20,6 @@ package org.apache.tez.runtime.library.common.shuffle.impl;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.AbstractMap;
@@ -205,13 +204,8 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
     assert currentIndex < pendingInputsSeq.getInputs().size();
 
     try {
-      String finalHost;
       HttpConnectionParams httpConnectionParams = fetcherConfigCommon.httpConnectionParams;
-      if (httpConnectionParams.isSslShuffle()) {
-        finalHost = InetAddress.getByName(host).getHostName();
-      } else {
-        finalHost = host;
-      }
+      String finalHost = inputHost.getConnectHost();
 
       InputHost.PartitionRange range = pendingInputsSeq.getPartitionRange();
       String appIdInURI = fetcherConfigCommon.compositeFetch ? null : applicationId;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -19,7 +19,6 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
 import java.io.DataInputStream;
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.net.URL;
 import java.util.AbstractMap;
@@ -365,14 +364,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
 
     boolean connectSucceeded = false;
     try {
-      String finalHost;
-      boolean sslShuffle = fetcherConfigCommon.httpConnectionParams.isSslShuffle();
-      if (sslShuffle) {
-        // TODO: cache in host
-        finalHost = InetAddress.getByName(host).getHostName();
-      } else {
-        finalHost = host;
-      }
+      String finalHost = inputHost.getConnectHost();
 
       InputHost.PartitionRange range = pendingInputsSeq.getPartitionRange();
       String appIdInURI = fetcherConfigCommon.compositeFetch ? null : applicationId;


### PR DESCRIPTION
### Motivation

- Ensure fetchers use a stable, TLS-correct hostname when `sslShuffle` is enabled to avoid repeated `InetAddress` lookups and potential SSL hostname mismatches.
- Reduce repeated DNS resolution overhead by caching the resolved hostnames.

### Description

- Add a `connectHost` field to `InputHost` with a new constructor `InputHost(HostPort, String)` and a `getConnectHost()` accessor to expose the hostname fetchers should use when connecting.
- Introduce `sslShuffle` flag and a `resolvedHosts` `ConcurrentMap<String,String>` cache in `ShuffleServer`, and resolve/cache hostnames in `addKnownInput()` when `sslShuffle` is true, falling back to the original host on resolution failure.
- Update `FetcherUnordered` and `FetcherOrderedGrouped` to use `inputHost.getConnectHost()` when constructing the shuffle handler URL instead of calling `InetAddress.getByName(...).getHostName()` directly.
- Add necessary imports and remove direct per-fetcher `InetAddress` resolution to centralize and cache resolution logic in `ShuffleServer`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2e609e93c8328aa2d9f9cdc61c688)