### PR TITLE
Remove RLE repeat-key encoding and simplify IFile reader/writer logic

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import java.io.DataInput;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -26,7 +25,6 @@ import java.io.IOException;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
-import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 
 /**
@@ -150,8 +148,6 @@ public class InMemoryReader extends Reader {
 
   private final MergeManager merger;
   private final InputAttemptIdentifier taskAttemptId;
-  private int originalKeyPos;
-
   private byte[] buffer = null;
   private final int bufferSize;
   private final ByteArrayDataInput memDataIn;
@@ -216,13 +212,6 @@ public class InMemoryReader extends Reader {
     }
   }
 
-  protected void readKeyValueLength(DataInput dIn) throws IOException {
-    super.readKeyValueLength(dIn);
-    if (currentKeyLength != IFile.RLE_MARKER) {
-      originalKeyPos = memDataIn.getPosition();
-    }
-  }
-
   public KeyState readRawKey(DataInputBuffer key) throws IOException {
     try {
       if (!positionToNextRecord(memDataIn)) {
@@ -231,11 +220,6 @@ public class InMemoryReader extends Reader {
       // Setup the key
       int pos = memDataIn.getPosition();
       byte[] data = memDataIn.getData();
-      if (currentKeyLength == IFile.RLE_MARKER) {
-        // get key length from original key
-        key.reset(data, originalKeyPos, originalKeyLength);
-        return KeyState.SAME_KEY;
-      }
       key.reset(data, pos, currentKeyLength);
       // Position for the next value
       long skipped = memDataIn.skip(currentKeyLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -37,8 +37,6 @@ public class InMemoryWriter implements IFile.WriterAppend {
 
   private DataOutputStream out;
 
-  private Object prevKey = null;
-
   // InMemoryWriter does not use another byte[] buffer, unlike IFile.Writer
   public InMemoryWriter(byte[] array) {
     BoundedByteArrayOutputStream arrayStream = new InMemoryBoundedByteArrayOutputStream(array);
@@ -49,41 +47,14 @@ public class InMemoryWriter implements IFile.WriterAppend {
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
-      boolean sameKey = (key == IFile.REPEAT_KEY);
+      long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
+      out.writeLong(combined);
 
-      if (!sameKey) {
-          // Normal key-value pair
-          // Write V_END_MARKER if needed (if previous was a REPEAT_KEY)
-          if (prevKey == IFile.REPEAT_KEY) {
-              out.writeInt(IFile.V_END_MARKER);
-          }
-
-          long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
-          out.writeLong(combined);
-
-          out.write(key.getData(), key.getPosition(), keyLength);
-          out.write(value.getData(), value.getPosition(), valueLength);
-      } else {
-          // Repeated key
-          if (prevKey != IFile.REPEAT_KEY) {
-              // First repeated key, write RLE marker
-              out.writeInt(IFile.RLE_MARKER);
-          }
-
-          // Write just the value length and value
-          out.writeInt(valueLength);
-          out.write(value.getData(), value.getPosition(), valueLength);
-      }
-
-      prevKey = sameKey ? IFile.REPEAT_KEY : key;
+      out.write(key.getData(), key.getPosition(), keyLength);
+      out.write(value.getData(), value.getPosition(), valueLength);
   }
 
   public void close() throws IOException {
-      // Write V_END_MARKER if needed
-      if (prevKey == IFile.REPEAT_KEY) {
-          out.writeInt(IFile.V_END_MARKER);
-      }
-
       // Write EOF_MARKER for key/value length
       long combined = ((long) IFile.EOF_MARKER << 32) | (IFile.EOF_MARKER & 0xFFFFFFFFL);
       out.writeLong(combined);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1074,7 +1074,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         final int klen = kb.getLength() - kp;
         key.reset(kb.getData(), kp, klen);
         bytesRead += klen;
-        return kvIter.isSameKey() ? KeyState.SAME_KEY : KeyState.NEW_KEY;
+        return KeyState.NEW_KEY;
       }
       return KeyState.NO_KEY;
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.apache.tez.runtime.library.utils.BufferUtils;
 import org.apache.tez.runtime.library.utils.CodecUtils;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.compress.CodecPool;
@@ -64,10 +63,6 @@ public class IFile {
   private static final boolean isDebugEnabled = LOG.isDebugEnabled();
 
   public static final int EOF_MARKER = -1; // End of File Marker
-  public static final int RLE_MARKER = -2; // Repeat same key marker
-  public static final int V_END_MARKER = -3; // End of values marker
-
-  public static final DataInputBuffer REPEAT_KEY = new DataInputBuffer();
   static final byte[] HEADER = new byte[] { (byte) 'T', (byte) 'I',
     (byte) 'F' , (byte) 0};
 
@@ -230,9 +225,7 @@ public class IFile {
     protected void writeKVPair(byte[] keyData, int keyPos, int keyLength,
         byte[] valueData, int valPos, int valueLength) throws IOException {
       if (!bufferFull) {
-        // Compute actual payload size: write RLE marker, length info and then entire data.
-        totalSize += ((prevKey == REPEAT_KEY) ? V_END_MARKER_SIZE : 0)
-            + INT_SIZE + keyLength
+        totalSize += INT_SIZE + keyLength
             + INT_SIZE + valueLength;
 
         if (shouldWriteToDisk()) {
@@ -240,18 +233,6 @@ public class IFile {
         }
       }
       super.writeKVPair(keyData, keyPos, keyLength, valueData, valPos, valueLength);
-    }
-
-    @Override
-    protected void writeValue(byte[] data, int offset, int length) throws IOException {
-      if (!bufferFull) {
-        totalSize += ((prevKey != REPEAT_KEY) ? RLE_MARKER_SIZE : 0) + INT_SIZE + length;
-
-        if (shouldWriteToDisk()) {
-          resetToFileBasedWriter();
-        }
-      }
-      super.writeValue(data, offset, length);
     }
 
     /**
@@ -308,8 +289,6 @@ public class IFile {
 
     // Count records written to disk
     private long numRecordsWritten = 0;
-    private long rleWritten = 0; //number of RLE markers written
-    private long totalKeySaving = 0; //number of keys saved due to multi KV writes + RLE
     private final TezCounter writtenRecordsCounter;
     private final TezCounter serializedUncompressedBytes;
 
@@ -318,15 +297,7 @@ public class IFile {
     private Serializer valueSerializer = null;
 
     private final DataOutputBuffer buffer = new DataOutputBuffer();
-    private final DataOutputBuffer previous = new DataOutputBuffer();
-    protected Object prevKey = null;
     protected boolean headerWritten = false;
-
-    final int RLE_MARKER_SIZE = INT_SIZE;
-    final int V_END_MARKER_SIZE = INT_SIZE;
-
-    // de-dup keys or not
-    protected final boolean rle;
 
     // We use writeBuffer[] to reduce the number of writes to 'out' and thus
     // to reduce the number of writes to 'compressedOut'.
@@ -360,8 +331,6 @@ public class IFile {
       this.writtenRecordsCounter = writesCounter;
       this.serializedUncompressedBytes = serializedBytesCounter;
       this.start = this.rawOut.getPos();
-      this.rle = rle;
-
       this.writeBuffer = writeBuffer;
       this.writeBufferLength = writeBuffer.length;
       this.writeByteBuffer = ByteBuffer.wrap(writeBuffer).order(ByteOrder.BIG_ENDIAN);
@@ -426,9 +395,6 @@ public class IFile {
         valueSerializer.close();
       }
 
-      // write V_END_MARKER as needed
-      writeValueMarker();
-
       // Write EOF_MARKER for key/value length
       // bufferWriteInt(EOF_MARKER);
       // bufferWriteInt(EOF_MARKER);
@@ -471,109 +437,41 @@ public class IFile {
         writtenRecordsCounter.increment(numRecordsWritten);
       }
       if (isDebugEnabled) {
-        LOG.debug("Total keys written=" + numRecordsWritten + "; rleEnabled=" + rle + "; Savings" +
-            "(due to multi-kv/rle)=" + totalKeySaving + "; number of RLEs written=" +
-            rleWritten + "; compressedLen=" + compressedBytesWritten + "; rawLen="
-            + decompressedBytesWritten);
+        LOG.debug("Total keys written=" + numRecordsWritten + "; compressedLen=" +
+            compressedBytesWritten + "; rawLen=" + decompressedBytesWritten);
       }
     }
 
-    /**
-     * Send key/value to be appended to IFile. To represent same key as previous
-     * one, send IFile.REPEAT_KEY as key parameter.  Should not call this method with
-     * IFile.REPEAT_KEY as the first key. It is caller's responsibility to ensure that correct
-     * key/value type checks and key/value length (non-negative) checks are done properly.
-     *
-     * @param key
-     * @param value
-     * @throws IOException
-     */
     public void append(Object key, Object value) throws IOException {
-      int keyLength = 0;
-      boolean sameKey = (key == REPEAT_KEY);
-      if (!sameKey) {
-        keySerializer.serialize(key);
-        keyLength = buffer.getLength();
-        assert(keyLength >= 0);
-        if (rle && (keyLength == previous.getLength())) {
-          sameKey = BufferUtils.compareEqual(previous, buffer);
-        }
-      }
+      keySerializer.serialize(key);
+      int keyLength = buffer.getLength();
+      assert(keyLength >= 0);
 
       // Append the 'value'
       valueSerializer.serialize(value);
       int valueLength = buffer.getLength() - keyLength;
       assert(valueLength >= 0);
-      if (!sameKey) {
-        //dump entire key value pair
-        writeKVPair(buffer.getData(), 0, keyLength, buffer.getData(),
-            keyLength, buffer.getLength() - keyLength);
-        if (rle) {
-          previous.reset();
-          previous.write(buffer.getData(), 0, keyLength); //store the key
-        }
-      } else {
-        writeValue(buffer.getData(), keyLength, valueLength);
-      }
+      writeKVPair(buffer.getData(), 0, keyLength, buffer.getData(),
+          keyLength, valueLength);
 
-      prevKey = sameKey ? REPEAT_KEY : key;
       // Reset
       buffer.reset();
       ++numRecordsWritten;
     }
 
-    /**
-     * Send key/value to be appended to IFile. To represent same key as previous
-     * one, send IFile.REPEAT_KEY as key parameter.  Should not call this method with
-     * IFile.REPEAT_KEY as the first key. It is caller's responsibility to pass non-negative
-     * key/value lengths. Otherwise,IndexOutOfBoundsException could be thrown at runtime.
-     *
-     *
-     * @param key
-     * @param value
-     * @throws IOException
-     */
     public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
-      assert(key == REPEAT_KEY || keyLength >=0);
+      assert(keyLength >= 0);
 
       int valueLength = value.getLength() - value.getPosition();
       assert(valueLength >= 0);
-
-      boolean sameKey = (key == REPEAT_KEY);
-      if (!sameKey && rle) {
-        sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
-      }
-
-      if (!sameKey) {
-        writeKVPair(key.getData(), key.getPosition(), keyLength,
-            value.getData(), value.getPosition(), valueLength);
-        if (rle) {
-          BufferUtils.copy(key, previous);
-        }
-      } else {
-        writeValue(value.getData(), value.getPosition(), valueLength);
-      }
-      prevKey = sameKey ? REPEAT_KEY : key;
+      writeKVPair(key.getData(), key.getPosition(), keyLength,
+          value.getData(), value.getPosition(), valueLength);
       ++numRecordsWritten;
-    }
-
-    protected void writeValue(byte[] data, int offset, int length) throws IOException {
-      writeRLE();
-      bufferWriteInt(length); // value length
-      bufferWriteBytes(data, offset, length);
-      // Update bytes written
-      decompressedBytesWritten += length + INT_SIZE;
-      if (serializedUncompressedBytes != null) {
-        serializedUncompressedBytes.increment(length);
-      }
-      totalKeySaving++;
     }
 
     protected void writeKVPair(byte[] keyData, int keyPos, int keyLength,
         byte[] valueData, int valPos, int valueLength) throws IOException {
-      writeValueMarker();
-
       // bufferWriteInt(keyLength);
       // bufferWriteLong(valueLength);
       long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
@@ -586,33 +484,6 @@ public class IFile {
       decompressedBytesWritten += keyLength + valueLength + INT_SIZE + INT_SIZE;
       if (serializedUncompressedBytes != null) {
         serializedUncompressedBytes.increment(keyLength + valueLength);
-      }
-    }
-
-    private void writeRLE() throws IOException {
-      /**
-       * To strike a balance between 2 use cases (lots of unique KV in stream
-       * vs lots of identical KV in stream), we start off by writing KV pair.
-       * If subsequent KV is identical, we write RLE marker along with V_END_MARKER
-       * {KL1, VL1, K1, V1}
-       * {RLE, VL2, V2, VL3, V3, ...V_END_MARKER}
-       */
-      if (prevKey != REPEAT_KEY) {
-        bufferWriteInt(RLE_MARKER);
-        decompressedBytesWritten += RLE_MARKER_SIZE;
-        rleWritten++;
-      }
-    }
-
-    protected void writeValueMarker() throws IOException {
-      /**
-       * Write V_END_MARKER only in RLE scenario. This will
-       * save space in conditions where lots of unique KV pairs are found in the
-       * stream.
-       */
-      if (prevKey == REPEAT_KEY) {
-        bufferWriteInt(V_END_MARKER);
-        decompressedBytesWritten += V_END_MARKER_SIZE;
       }
     }
 
@@ -670,7 +541,7 @@ public class IFile {
    */
   public static class Reader {
 
-    public enum KeyState {NO_KEY, NEW_KEY, SAME_KEY}
+    public enum KeyState {NO_KEY, NEW_KEY}
 
     private static final int MAX_BUFFER_SIZE
             = Integer.MAX_VALUE - 8;  // The maximum array size is a little less than the
@@ -693,8 +564,6 @@ public class IFile {
     protected DataInputStream dataIn = null;
 
     protected int recNo = 1;
-    protected int originalKeyLength;
-    protected int prevKeyLength;
     byte keyBytes[] = new byte[0];
 
     protected int currentKeyLength;
@@ -916,25 +785,12 @@ public class IFile {
       return len;
     }
 
-    protected void readValueLength(DataInput dIn) throws IOException {
-      currentValueLength = dIn.readInt();
-      bytesRead += INT_SIZE;
-      if (currentValueLength == V_END_MARKER) {
-        readKeyValueLength(dIn);
-      }
-    }
-
     protected void readKeyValueLength(DataInput dIn) throws IOException {
       currentKeyLength = dIn.readInt();
       currentValueLength = dIn.readInt();
       // long combined = dIn.readLong();
       // currentKeyLength = (int) (combined >> 32);
       // currentValueLength = (int) combined;
-
-      if (currentKeyLength != RLE_MARKER) {
-        // original key length
-        originalKeyLength = currentKeyLength;
-      }
       bytesRead += INT_SIZE + INT_SIZE;
     }
 
@@ -951,14 +807,7 @@ public class IFile {
       if (eof) {
         throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
       }
-      prevKeyLength = currentKeyLength;
-
-      if (prevKeyLength == RLE_MARKER) {
-        // Same key as previous one. Just read value length alone
-        readValueLength(dIn);
-      } else {
-        readKeyValueLength(dIn);
-      }
+      readKeyValueLength(dIn);
 
       // Check for EOF
       if (currentKeyLength == EOF_MARKER && currentValueLength == EOF_MARKER) {
@@ -967,9 +816,9 @@ public class IFile {
       }
 
       // Sanity check
-      if (currentKeyLength != RLE_MARKER && currentKeyLength < 0) {
+      if (currentKeyLength < 0) {
         throw new IOException("Rec# " + recNo + ": Negative key-length: " +
-                              currentKeyLength + " PreviousKeyLen: " + prevKeyLength);
+                              currentKeyLength);
       }
       if (currentValueLength < 0) {
         throw new IOException("Rec# " + recNo + ": Negative value-length: " +
@@ -1006,11 +855,6 @@ public class IFile {
               ", length=" + fileLength);
         }
         return KeyState.NO_KEY;
-      }
-      if(currentKeyLength == RLE_MARKER) {
-        // get key length from original key
-        key.reset(keyBytes, originalKeyLength);
-        return KeyState.SAME_KEY;
       }
       if (keyBytes.length < currentKeyLength) {
         keyBytes = createLargerArray(currentKeyLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -186,14 +186,8 @@ public class TezMerger {
       Progressable progressable, long recordsBeforeProgress)
       throws IOException, InterruptedException {
     long recordCtr = 0;
-    // long count = 0;
     while (records.next()) {
-      if (records.isSameKey()) {
-        writer.append(IFile.REPEAT_KEY, records.getValue());
-        // count++;
-      } else {
-        writer.append(records.getKey(), records.getValue());
-      }
+      writer.append(records.getKey(), records.getValue());
       
       if (((recordCtr++) % recordsBeforeProgress) == 0) {
         progressable.progress();
@@ -208,9 +202,6 @@ public class TezMerger {
         }
       }
     }
-    /* if ((count > 0) && LOG.isTraceEnabled()) {
-      LOG.trace("writeFile SAME_KEY count=" + count);
-    } */
   }
 
   static class KeyValueBuffer {
@@ -467,6 +458,7 @@ public class TezMerger {
     };
 
     KeyState hasNext;
+    boolean sameKey = false;
     DataOutputBuffer prevKey = new DataOutputBuffer();
 
     public MergeQueue(Configuration conf, FileSystem fs,
@@ -521,29 +513,23 @@ public class TezMerger {
       BufferUtils.copy(key, prevKey);
     }
 
+    private void compareKeyWithNextTopKey() throws IOException {
+      sameKey = false;
+      if (!checkForSameKeys || size() == 0) {
+        return;
+      }
+
+      KeyValueBuffer nextTopKey = top().getKey();
+      int compare = compare(nextTopKey, prevKey);
+      if (compare == 0) {
+        sameKey = true;
+      }
+    }
+
     private void adjustPriorityQueue(Segment reader) throws IOException{
       long startPos = reader.getPosition();
       if (checkForSameKeys) {
-        if (hasNext == null) {
-          /**
-           * hasNext can be null during first iteration & prevKey is initialized here.
-           * In cases of NO_KEY/NEW_KEY, we readjust the queue later. If new segment/file is found
-           * during this process, we need to compare keys for RLE across segment boundaries.
-           * prevKey can't be empty at that time (e.g custom comparators)
-           */
-          populatePreviousKey();
-        } else {
-          //indicates a key has been read already
-          if (hasNext != KeyState.SAME_KEY) {
-            /**
-             * Store previous key before reading next for later key comparisons.
-             * If all keys in a segment are unique, it would always hit this code path and key copies
-             * are wasteful in such condition, as these comparisons are mainly done for RLE.
-             * TODO: When better stats are available, this condition can be avoided.
-             */
-            populatePreviousKey();
-          }
-        }
+        populatePreviousKey();
       }
       hasNext = reader.readRawKey(nextKey);
       long endPos = reader.getPosition();
@@ -551,34 +537,22 @@ public class TezMerger {
       mergeProgress.set(totalBytesProcessed * progPerByte);
       if (hasNext == KeyState.NEW_KEY) {
         adjustTop();
-        compareKeyWithNextTopKey(reader);
+        compareKeyWithNextTopKey();
       } else if(hasNext == KeyState.NO_KEY) {
         pop();
         reader.close();
-        compareKeyWithNextTopKey(null);
-      } else if(hasNext == KeyState.SAME_KEY) {
-        // do not rebalance the priority queue
+        compareKeyWithNextTopKey();
       }
     }
 
-    /**
-     * Check if the previous key is same as the next top segment's key.
-     * This would be useful to compute whether same key is spread across multiple segments.
-     *
-     * @param current
-     * @throws IOException
-     */
-    void compareKeyWithNextTopKey(Segment current) throws IOException {
-      Segment nextTop = top();
-      if (checkForSameKeys && nextTop != current) {
-        //we have a different file. Compare it with previous key
-        KeyValueBuffer nextKey = nextTop.getKey();
-        int compare = compare(nextKey, prevKey);
-        if (compare == 0) {
-          //Same key is available in the next segment.
-          hasNext = KeyState.SAME_KEY;
-        }
-      }
+    int compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
+      byte[] b1 = nextKey.getData();
+      byte[] b2 = buf2.getData();
+      int s1 = nextKey.getPosition();
+      int s2 = 0;
+      int l1 = nextKey.getLength();
+      int l2 = buf2.getLength();
+      return comparator.compare(b1, s1, l1, b2, s2, l2);
     }
 
     public boolean next() throws IOException {
@@ -610,16 +584,6 @@ public class TezMerger {
       mergeProgress.set(totalBytesProcessed * progPerByte);
 
       return true;
-    }
-
-    int compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
-      byte[] b1 = nextKey.getData();
-      byte[] b2 = buf2.getData();
-      int s1 = nextKey.getPosition();
-      int s2 = 0;
-      int l1 = nextKey.getLength();
-      int l2 = buf2.getLength();
-      return comparator.compare(b1, s1, l1, b2, s2, l2);
     }
 
     protected boolean lessThan(Object a, Object b) {
@@ -969,7 +933,7 @@ public class TezMerger {
 
     @Override
     public boolean isSameKey() throws IOException {
-      return (hasNext != null) && (hasNext == KeyState.SAME_KEY);
+      return sameKey;
     }
 
     public boolean hasNext() throws IOException {


### PR DESCRIPTION
### Motivation

- Remove the run-length encoding (RLE) / REPEAT_KEY special casing across the intermediate IFile format and simplify key/value read/write paths to reduce complexity and eliminate BufferUtils/RLE bookkeeping.
- Simplify in-memory reader/writer and merge logic so map-output handling no longer needs special SAME_KEY markers and multiple marker types.

### Description

- Removed RLE marker constants, `REPEAT_KEY`, `V_END_MARKER` and associated bookkeeping from `IFile`, and simplified the wire format to always write combined key/value length plus raw bytes via a single `writeLong` length header.
- Simplified `IFile.Writer` and `InMemoryWriter` to always append full key+value pairs and always write the EOF combined marker on close, removing prior RLE/value-marker branches and related fields and counters.
- Simplified `IFile.Reader` and `InMemoryReader` by removing SAME_KEY handling and RLE-specific reads; `readKeyValueLength`/`positionToNextRecord` always read full key and value lengths and `readRawKey` always returns `NEW_KEY` when a key is available.
- Updated merge components (`TezMerger`, `MergeManager`, and `RawKVIteratorReader`) to remove encoding-based SAME_KEY paths and instead perform explicit key comparisons where needed, replacing `KeyState.SAME_KEY` with a `sameKey` boolean and refactoring `compareKeyWithNextTopKey` logic.

### Testing

- Built the project and executed the project's unit tests with `mvn -DskipTests=false test`, and the test suite for the modified modules completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6da8485608328845e143d2d271989)