### PR TITLE
Add key/length section offsets to shuffle index records and headers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
@@ -28,7 +28,7 @@ public class Constants {
   public static final String MAP_OUTPUT_INDEX_SUFFIX_STRING = ".index";
   public static final String REDUCE_INPUT_FILE_FORMAT_STRING = "%s/map_%d.out";
 
-  public static final int MAP_OUTPUT_INDEX_RECORD_LENGTH = 24;
+  public static final int MAP_OUTPUT_INDEX_RECORD_LENGTH = 40;
   public static final String MERGED_OUTPUT_PREFIX = ".merged";
 
   public static final long DEFAULT_COMBINE_RECORDS_BEFORE_PROGRESS = 10000;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -47,6 +47,8 @@ public class ShuffleHeader implements Writable {
   String mapId;
   long uncompressedLength;
   long compressedLength;
+  long keySectionOffset;
+  long lengthSectionOffset;
   int forReduce;
 
   private boolean compositeFetch;
@@ -63,10 +65,18 @@ public class ShuffleHeader implements Writable {
   // ShuffleHeader created used by MR3 ShuffleHandler (but not by Hadoop shuffle service)
   public ShuffleHeader(String mapId, long compressedLength,
       long uncompressedLength, int forReduce) {
+    this(mapId, compressedLength, uncompressedLength, forReduce, -1, -1);
+  }
+
+  public ShuffleHeader(String mapId, long compressedLength,
+      long uncompressedLength, int forReduce,
+      long keySectionOffset, long lengthSectionOffset) {
     this.mapId = mapId;
     this.compressedLength = compressedLength;
     this.uncompressedLength = uncompressedLength;
     this.forReduce = forReduce;
+    this.keySectionOffset = keySectionOffset;
+    this.lengthSectionOffset = lengthSectionOffset;
   }
   
   public String getMapId() {
@@ -85,6 +95,14 @@ public class ShuffleHeader implements Writable {
     return compressedLength;
   }
 
+  public long getKeySectionOffset() {
+    return keySectionOffset;
+  }
+
+  public long getLengthSectionOffset() {
+    return lengthSectionOffset;
+  }
+
   public void readFields(DataInput in) throws IOException {
     if (compositeFetch) {   // ShuffleHeader created by MR3 ShuffleHandler
       int length = in.readInt();  // Cf. WritableUtils.readStringSafely() calls readVInt()
@@ -99,11 +117,15 @@ public class ShuffleHeader implements Writable {
       compressedLength = in.readLong();
       uncompressedLength = in.readLong();
       forReduce = in.readInt();
+      keySectionOffset = in.readLong();
+      lengthSectionOffset = in.readLong();
     } else {  // ShuffleHeader created by Hadoop shuffle service
       mapId = WritableUtils.readStringSafely(in, MAX_ID_LENGTH);
       compressedLength = WritableUtils.readVLong(in);
       uncompressedLength = WritableUtils.readVLong(in);
       forReduce = WritableUtils.readVInt(in);
+      keySectionOffset = -1;
+      lengthSectionOffset = -1;
     }
   }
 
@@ -111,7 +133,7 @@ public class ShuffleHeader implements Writable {
   // do not use WritableUtils.writeVLong/Int()
   public int writeLength() throws IOException {
     int length = Text.encode(mapId).limit();
-    length += 4 + 8 + 8 + 4;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce
+    length += 4 + 8 + 8 + 4 + 8 + 8;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce, keySectionOffset, lengthSectionOffset
     return length;
   }
 
@@ -127,5 +149,7 @@ public class ShuffleHeader implements Writable {
     out.writeLong(compressedLength);
     out.writeLong(uncompressedLength);
     out.writeInt(forReduce);
+    out.writeLong(keySectionOffset);
+    out.writeLong(lengthSectionOffset);
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezIndexRecord.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezIndexRecord.java
@@ -22,6 +22,8 @@ public class TezIndexRecord {
   private long startOffset;
   private long rawLength;
   private long partLength;
+  private long keySectionOffset;
+  private long lengthSectionOffset;
 
   /**
    * @param startOffset start offset within the data file
@@ -29,9 +31,23 @@ public class TezIndexRecord {
    * @param partLength actual data length in file - factors in checksums and compression
    */
   public TezIndexRecord(long startOffset, long rawLength, long partLength) {
+    this(startOffset, rawLength, partLength, -1, -1);
+  }
+
+  /**
+   * @param startOffset start offset within the data file
+   * @param rawLength raw data length - typically uncompressed
+   * @param partLength actual data length in file - factors in checksums and compression
+   * @param keySectionOffset absolute file offset where the keys section begins
+   * @param lengthSectionOffset absolute file offset where the lengths section begins
+   */
+  public TezIndexRecord(long startOffset, long rawLength, long partLength,
+                        long keySectionOffset, long lengthSectionOffset) {
     this.startOffset = startOffset;
     this.rawLength = rawLength;
     this.partLength = partLength;
+    this.keySectionOffset = keySectionOffset;
+    this.lengthSectionOffset = lengthSectionOffset;
   }
 
   public long getStartOffset() {
@@ -44,6 +60,14 @@ public class TezIndexRecord {
 
   public long getPartLength() {
     return partLength;
+  }
+
+  public long getKeySectionOffset() {
+    return keySectionOffset;
+  }
+
+  public long getLengthSectionOffset() {
+    return lengthSectionOffset;
   }
 
   public boolean hasData() {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezSpillRecord.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezSpillRecord.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.util.functional.FutureIO;
 import org.apache.tez.runtime.library.common.Constants;
 
 public class TezSpillRecord {
+  private static final int LONGS_PER_ENTRY = Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / Long.BYTES;
   public static final FsPermission SPILL_FILE_PERMS = new FsPermission((short) 0640);
 
   /** Backing store */
@@ -101,25 +102,28 @@ public class TezSpillRecord {
    * Return number of IndexRecord entries in this spill.
    */
   public int size() {
-    return entries.capacity() / (Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / 8);
+    return entries.capacity() / LONGS_PER_ENTRY;
   }
 
   /**
    * Get spill offsets for given partition.
    */
   public TezIndexRecord getIndex(int partition) {
-    final int pos = partition * Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / 8;
-    return new TezIndexRecord(entries.get(pos), entries.get(pos + 1), entries.get(pos + 2));
+    final int pos = partition * LONGS_PER_ENTRY;
+    return new TezIndexRecord(entries.get(pos), entries.get(pos + 1), entries.get(pos + 2),
+        entries.get(pos + 3), entries.get(pos + 4));
   }
 
   /**
    * Set spill offsets for given partition.
    */
   public void putIndex(TezIndexRecord rec, int partition) {
-    final int pos = partition * Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / 8;
+    final int pos = partition * LONGS_PER_ENTRY;
     entries.put(pos, rec.getStartOffset());
     entries.put(pos + 1, rec.getRawLength());
     entries.put(pos + 2, rec.getPartLength());
+    entries.put(pos + 3, rec.getKeySectionOffset());
+    entries.put(pos + 4, rec.getLengthSectionOffset());
   }
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -1190,7 +1190,8 @@ public class ShuffleHandler {
           lastIndex = index;
         }
 
-        ShuffleHeader header = new ShuffleHeader(mapId, index.getPartLength(), index.getRawLength(), reduce);
+        ShuffleHeader header = new ShuffleHeader(mapId, index.getPartLength(), index.getRawLength(), reduce,
+            index.getKeySectionOffset(), index.getLengthSectionOffset());
         dob.reset();
         header.write(dob);
         // Free the memory needed to store the spill and index records


### PR DESCRIPTION
### Motivation

- Expose absolute file offsets for the keys and lengths sections so MR3-style composite fetchers can locate sub-sections inside map output files.
- Increase the on-disk spill/index record size to store the two additional 64-bit offsets for each partition.

### Description

- Bumped `MAP_OUTPUT_INDEX_RECORD_LENGTH` from `24` to `40` in `Constants` to account for two extra `long` fields per index entry.
- Added `keySectionOffset` and `lengthSectionOffset` fields to `TezIndexRecord` with constructors and getters, and preserved backward-compatible constructors that default offsets to `-1`.
- Extended `TezSpillRecord` to compute `LONGS_PER_ENTRY` from the updated record length, read/write the two extra `long` values for each partition, and updated `size()`, `getIndex()` and `putIndex()` accordingly.
- Extended `ShuffleHeader` to carry the two offset fields, updated `readFields()`, `writeLength()` and `write()` to include them for MR3-style headers, and added constructors and getters.
- Updated `ShuffleHandler` to populate the new offsets when constructing `ShuffleHeader` for each partition before sending map output across the network.

### Testing

- Compiled the runtime library with `mvn -DskipTests=true package` to validate API and compilation changes and the build succeeded.
- Ran unit tests with `mvn -DskipTests=false test` against the modified modules and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b74f2774b08328bcc4f2b098c66fb8)