### PR TITLE
Implement three-section IFile.Writer (values/keys/lengths) with independent section encoding

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -147,7 +147,7 @@ public class IFile {
         TezCounter serializedBytesCounter, int cacheSize, byte[] writeBuffer) throws IOException {
       super(keySerialization, valSerialization,
           new FSDataOutputStream(createBoundedBuffer(cacheSize), null),
-          keyClass, valueClass, codec,
+          keyClass, valueClass, null,
           writesCounter, serializedBytesCounter, false, writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
@@ -213,7 +213,7 @@ public class IFile {
       int sPos = HEADER.length;
       int len = (bout.size() - checksumSize - HEADER.length);
       if (len > 0) {
-        newRawOut.write(bout.getBuffer(), sPos, len);
+        bufferWriteBytes(bout.getBuffer(), sPos, len);
       }
 
       bufferFull = true;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -92,12 +92,12 @@ public class IFile {
   private static final int checksumSize = IFileOutputStream.getCheckSumSize();
 
   /**
-   * For basic cache size checks: header + checksum + EOF marker
+   * For basic cache size checks: header + one section checksum trailer.
    *
    * @return size of the base cache needed
    */
   static int getBaseCacheSize() {
-    return (HEADER.length + checksumSize + (2 * INT_SIZE));
+    return (HEADER.length + checksumSize);
   }
 
   /**
@@ -129,9 +129,6 @@ public class IFile {
     private final BoundedByteArrayOutputStream cacheStream;
 
     /**
-     * Note that we do not allow compression in in-mem stream.
-     * When spilled over to file, compression gets enabled.
-     *
      * @param keySerialization
      * @param valSerialization
      * @param fs
@@ -150,13 +147,13 @@ public class IFile {
         TezCounter serializedBytesCounter, int cacheSize, byte[] writeBuffer) throws IOException {
       super(keySerialization, valSerialization,
           new FSDataOutputStream(createBoundedBuffer(cacheSize), null),
-          keyClass, valueClass, null,
+          keyClass, valueClass, codec,
           writesCounter, serializedBytesCounter, false, writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
       this.taskOutput = taskOutput;
       this.bufferFull = (cacheStream == null);
-      this.totalSize = getBaseCacheSize();
+      this.totalSize = HEADER.length + (3 * checksumSize);
       this.fileCodec = codec;
     }
 
@@ -191,7 +188,7 @@ public class IFile {
       // Close out stream, so that data checksums are written.
       // Buf contents = HEADER + (uncompressed) real data + CHECKSUM
       flushWriteBuffer();
-      this.out.close();
+      finishValuesSectionForSpill();
 
       // Get the buffer which contains data in memory
       BoundedByteArrayOutputStream bout =
@@ -206,16 +203,18 @@ public class IFile {
       this.rawOut = newRawOut;
       this.ownOutputStream = true;  // because of fs.create(outputPath)
 
-      setupOutputStream(fileCodec);
+      resetValuesSectionOutput(fileCodec);
 
       // Write header to file
       headerWritten = false;
       writeHeader(newRawOut);
 
-      // write real data
+      // write values section payload produced so far (without header and checksum)
       int sPos = HEADER.length;
       int len = (bout.size() - checksumSize - HEADER.length);
-      bufferWriteBytes(bout.getBuffer(), sPos, len);
+      if (len > 0) {
+        newRawOut.write(bout.getBuffer(), sPos, len);
+      }
 
       bufferFull = true;
       bout.reset();
@@ -265,16 +264,17 @@ public class IFile {
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static class Writer implements WriterAppend {
-    // DataOutput: rawOut <-- checksumOut <-- compressedOut <-- out <-- [writeBuffer]
-
-    protected DataOutputStream out;
+    // Values section output (written during append):
+    // rawOut <-- valuesChecksumOut <-- valuesCompressedOut <-- valuesOut <-- [writeBuffer]
+    protected DataOutputStream valuesOut;
     private long start = 0;
 
-    private CompressionOutputStream compressedOut;
-    private Compressor compressor;
+    private CompressionOutputStream valuesCompressedOut;
+    private Compressor valuesCompressor;
     private boolean compressOutput = false;
 
-    private IFileOutputStream checksumOut;
+    private IFileOutputStream valuesChecksumOut;
+    private final CompressionCodec codec;
 
     protected FSDataOutputStream rawOut;
     // true iff this Writer created and owns rawOut
@@ -283,8 +283,11 @@ public class IFile {
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
-    private long decompressedBytesWritten = 0;
+    private long decompressedBytesWritten = HEADER.length;
     private long compressedBytesWritten = 0;
+    private long logicalValueBytesWritten = 0;
+    private long logicalKeyBytesWritten = 0;
+    private long logicalLengthBytesWritten = 0;
 
     // Count records written to disk
     private long numRecordsWritten = 0;
@@ -296,6 +299,8 @@ public class IFile {
     private Serializer valueSerializer = null;
 
     private final DataOutputBuffer buffer = new DataOutputBuffer();
+    private final DataOutputBuffer keySectionBuffer = new DataOutputBuffer();
+    private final DataOutputBuffer lengthsSectionBuffer = new DataOutputBuffer();
     protected boolean headerWritten = false;
 
     // We use writeBuffer[] to reduce the number of writes to 'out' and thus
@@ -336,6 +341,7 @@ public class IFile {
       this.writeOffset = 0;
 
       this.compressorExternal = compressorExternal;
+      this.codec = codec;
 
       setupOutputStream(codec);
       writeHeader(outputStream);
@@ -352,25 +358,37 @@ public class IFile {
     }
 
     void setupOutputStream(CompressionCodec codec) throws IOException {
-      this.checksumOut = new IFileOutputStream(this.rawOut);
+      this.valuesChecksumOut = new IFileOutputStream(this.rawOut);
       if (codec != null) {
         if (compressorExternal != null) {
-          this.compressor = compressorExternal;
+          this.valuesCompressor = compressorExternal;
         } else {
-          this.compressor = CodecUtils.getCompressor(codec);
+          this.valuesCompressor = CodecUtils.getCompressor(codec);
         }
-        if (this.compressor != null) {
-          this.compressor.reset();
-          this.compressedOut = CodecUtils.createOutputStream(codec, checksumOut, compressor);
-          this.out = new DataOutputStream(this.compressedOut);
+        if (this.valuesCompressor != null) {
+          this.valuesCompressor.reset();
+          this.valuesCompressedOut = CodecUtils.createOutputStream(codec, valuesChecksumOut, valuesCompressor);
+          this.valuesOut = new DataOutputStream(this.valuesCompressedOut);
           this.compressOutput = true;
         } else {
-          LOG.warn("Could not obtain compressor from CodecPool");
-          this.out = new DataOutputStream(checksumOut);
+          throw new IOException("Could not obtain compressor from CodecPool for values section");
         }
       } else {
-        this.out = new DataOutputStream(checksumOut);
+        this.valuesOut = new DataOutputStream(valuesChecksumOut);
       }
+    }
+
+
+    protected void resetValuesSectionOutput(CompressionCodec codec) throws IOException {
+      if (compressOutput && compressorExternal == null && valuesCompressor != null) {
+        CodecPool.returnCompressor(valuesCompressor);
+      }
+      this.valuesOut = null;
+      this.valuesCompressedOut = null;
+      this.valuesChecksumOut = null;
+      this.valuesCompressor = null;
+      this.compressOutput = false;
+      setupOutputStream(codec);
     }
 
     protected void writeHeader(OutputStream outputStream) throws IOException {
@@ -394,29 +412,13 @@ public class IFile {
         valueSerializer.close();
       }
 
-      // Write EOF_MARKER for key/value length
-      // bufferWriteInt(EOF_MARKER);
-      // bufferWriteInt(EOF_MARKER);
-      long combined = ((long) EOF_MARKER << 32) | (EOF_MARKER & 0xFFFFFFFFL);
-      bufferWriteLong(combined);
-
-      decompressedBytesWritten += 2 * INT_SIZE;
-      //account for header bytes
-      decompressedBytesWritten += HEADER.length;
-
-      flushWriteBuffer();   // Ensure all buffered data is written to 'out'
+      finishValuesSection();
+      writeBufferedSection(keySectionBuffer);
+      writeBufferedSection(lengthsSectionBuffer);
 
       // Close the underlying stream iff we own it
       if (ownOutputStream) {
-        out.close();
-      } else {
-        if (compressOutput) {
-          // Flush
-          compressedOut.finish();
-          compressedOut.resetState();
-        }
-        // Write the checksum and flush the buffer
-        checksumOut.finish();
+        rawOut.close();
       }
       //header bytes are already included in rawOut
       compressedBytesWritten = rawOut.getPos() - start;
@@ -426,12 +428,12 @@ public class IFile {
         // if compressorExternal != null, this Writer does not own compressor, so do not return it to CodecPool
         if (compressorExternal == null) {
           // this Writer owns compressor
-          CodecPool.returnCompressor(compressor);
+          CodecPool.returnCompressor(valuesCompressor);
         }
-        compressor = null;
+        valuesCompressor = null;
       }
 
-      out = null;
+      valuesOut = null;
       if (writtenRecordsCounter != null) {
         writtenRecordsCounter.increment(numRecordsWritten);
       }
@@ -471,16 +473,21 @@ public class IFile {
 
     protected void writeKVPair(byte[] keyData, int keyPos, int keyLength,
         byte[] valueData, int valPos, int valueLength) throws IOException {
-      // bufferWriteInt(keyLength);
-      // bufferWriteLong(valueLength);
-      long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
-      bufferWriteLong(combined);
+      if (keyLength < 0 || valueLength < 0) {
+        throw new IOException("Negative key/value lengths are not allowed. keyLength=" + keyLength
+            + ", valueLength=" + valueLength);
+      }
 
-      bufferWriteBytes(keyData, keyPos, keyLength);
+      keySectionBuffer.write(keyData, keyPos, keyLength);
+      lengthsSectionBuffer.writeInt(keyLength);
+      lengthsSectionBuffer.writeInt(valueLength);
       bufferWriteBytes(valueData, valPos, valueLength);
 
       // Update bytes written
-      decompressedBytesWritten += keyLength + valueLength + INT_SIZE + INT_SIZE;
+      logicalKeyBytesWritten += keyLength;
+      logicalValueBytesWritten += valueLength;
+      logicalLengthBytesWritten += (2L * INT_SIZE);
+      decompressedBytesWritten += keyLength + valueLength + (2L * INT_SIZE);
       if (serializedUncompressedBytes != null) {
         serializedUncompressedBytes.increment(keyLength + valueLength);
       }
@@ -511,7 +518,7 @@ public class IFile {
       if (len > remaining) {
         flushWriteBuffer();
         if (len >= writeBufferLength) {
-          out.write(data, off, len);
+          valuesOut.write(data, off, len);
           return;
         }
       }
@@ -521,9 +528,63 @@ public class IFile {
 
     protected void flushWriteBuffer() throws IOException {
       if (writeOffset > 0) {
-        out.write(writeBuffer, 0, writeOffset);
+        valuesOut.write(writeBuffer, 0, writeOffset);
         writeOffset = 0;
       }
+    }
+
+    private void finishValuesSection() throws IOException {
+      flushWriteBuffer();
+      if (compressOutput) {
+        valuesCompressedOut.finish();
+        valuesCompressedOut.resetState();
+      }
+      valuesChecksumOut.finish();
+    }
+
+    private void writeBufferedSection(DataOutputBuffer sectionBuffer) throws IOException {
+      IFileOutputStream sectionChecksumOut = new IFileOutputStream(rawOut);
+      DataOutputStream sectionOut = new DataOutputStream(sectionChecksumOut);
+      CompressionOutputStream sectionCompressedOut = null;
+      Compressor sectionCompressor = null;
+      if (compressOutput) {
+        sectionCompressor = CodecUtils.getCompressor(codec);
+        if (sectionCompressor == null) {
+          throw new IOException("Could not obtain compressor from CodecPool for section write");
+        }
+        sectionCompressor.reset();
+        sectionCompressedOut = CodecUtils.createOutputStream(codec, sectionChecksumOut, sectionCompressor);
+        sectionOut = new DataOutputStream(sectionCompressedOut);
+      }
+      try {
+        sectionOut.write(sectionBuffer.getData(), 0, sectionBuffer.getLength());
+        sectionOut.flush();
+        if (sectionCompressedOut != null) {
+          sectionCompressedOut.finish();
+          sectionCompressedOut.resetState();
+        }
+        sectionChecksumOut.finish();
+      } finally {
+        if (sectionCompressor != null) {
+          CodecPool.returnCompressor(sectionCompressor);
+        }
+      }
+    }
+
+    protected long getLogicalValueBytesWritten() {
+      return logicalValueBytesWritten;
+    }
+
+    protected long getLogicalKeyBytesWritten() {
+      return logicalKeyBytesWritten;
+    }
+
+    protected long getLogicalLengthBytesWritten() {
+      return logicalLengthBytesWritten;
+    }
+
+    protected void finishValuesSectionForSpill() throws IOException {
+      finishValuesSection();
     }
 
     public long getRawLength() {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -101,6 +101,14 @@ public class IFile {
   }
 
   /**
+   * Base size estimate used by FileBackedInMemIFileWriter spill accounting for
+   * a full partition: header + checksums for values, keys and lengths sections.
+   */
+  static int getBasePartitionSizeEstimate() {
+    return HEADER.length + (3 * checksumSize);
+  }
+
+  /**
    * IFileWriter which stores data in memory for specified limit, beyond
    * which it falls back to file based writer. It creates files lazily on
    * need basis and avoids any disk hit (in cases, where data fits entirely in mem).
@@ -108,12 +116,10 @@ public class IFile {
    * This class should not make any changes to IFile logic and should just flip streams
    * from mem to disk on need basis.
    *
-   * During write, it verifies whether uncompressed payload can fit in memory. If so, it would
-   * store in buffer. Otherwise, it falls back to file based writer. Note that data stored
-   * internally would be in compressed format (if codec is provided). However, for easier
-   * comparison and spill over, uncompressed payload check is done. This is
-   * done intentionally, as it is not possible to know compressed data length
-   * upfront.
+   * During write, it verifies whether the final logical partition can fit in memory.
+   * The bounded in-memory stream stores only values-section bytes (header + values +
+   * values checksum). Spill decision is based on an estimated final partition size
+   * (header + values/keys/lengths logical bytes + section checksum overhead).
    */
   public static class FileBackedInMemIFileWriter extends Writer {
 
@@ -153,7 +159,7 @@ public class IFile {
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
       this.taskOutput = taskOutput;
       this.bufferFull = (cacheStream == null);
-      this.totalSize = HEADER.length + (3 * checksumSize);
+      this.totalSize = getBasePartitionSizeEstimate();
       this.fileCodec = codec;
     }
 
@@ -162,7 +168,8 @@ public class IFile {
     }
 
     /**
-     * Create in mem stream. In it is too small, adjust it's size
+     * Create in-memory values buffer. If requested size is too small, adjust to
+     * the minimum needed for header + values-section checksum trailer.
      *
      * @param size
      * @return in memory stream
@@ -175,8 +182,7 @@ public class IFile {
     /**
      * Flip over from memory to file based writer.
      *
-     * 1. Content format: HEADER + real data + CHECKSUM. Checksum is for real
-     * data.
+     * 1. Values buffer format at spill time: HEADER + values payload + CHECKSUM.
      * 2. Before flipping, close checksum stream, so that checksum is written
      * out.
      * 3. Create relevant file based writer.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -416,12 +416,13 @@ public class IFile {
       writeBufferedSection(keySectionBuffer);
       writeBufferedSection(lengthsSectionBuffer);
 
+      // header bytes are already included in rawOut
+      compressedBytesWritten = rawOut.getPos() - start;
+
       // Close the underlying stream iff we own it
       if (ownOutputStream) {
         rawOut.close();
       }
-      //header bytes are already included in rawOut
-      compressedBytesWritten = rawOut.getPos() - start;
 
       if (compressOutput) {
         // Return back the compressor

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -17,6 +17,7 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl;
 
+import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -153,7 +154,7 @@ public class IFile {
         TezCounter serializedBytesCounter, int cacheSize, byte[] writeBuffer) throws IOException {
       super(keySerialization, valSerialization,
           new FSDataOutputStream(createBoundedBuffer(cacheSize), null),
-          keyClass, valueClass, null,
+          keyClass, valueClass, codec,
           writesCounter, serializedBytesCounter, false, writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
@@ -218,12 +219,46 @@ public class IFile {
       // write values section payload produced so far (without header and checksum)
       int sPos = HEADER.length;
       int len = (bout.size() - checksumSize - HEADER.length);
-      if (len > 0) {
-        bufferWriteBytes(bout.getBuffer(), sPos, len);
-      }
+      replayValuesPayload(bout.getBuffer(), sPos, len);
 
       bufferFull = true;
       bout.reset();
+    }
+
+    private void replayValuesPayload(byte[] data, int offset, int length) throws IOException {
+      if (length <= 0) {
+        return;
+      }
+      if (fileCodec == null) {
+        bufferWriteBytes(data, offset, length);
+        return;
+      }
+
+      Decompressor sectionDecompressor = null;
+      InputStream replayIn = null;
+      byte[] replayBuffer = allocateWriteBuffer();
+      try {
+        sectionDecompressor = CodecUtils.getDecompressor(fileCodec);
+        if (sectionDecompressor == null) {
+          throw new IOException("Could not obtain decompressor from CodecPool for spill replay");
+        }
+        sectionDecompressor.reset();
+        replayIn = CodecUtils.createInputStream(fileCodec,
+            new ByteArrayInputStream(data, offset, length), sectionDecompressor);
+        int bytesRead;
+        while ((bytesRead = replayIn.read(replayBuffer)) != -1) {
+          if (bytesRead > 0) {
+            bufferWriteBytes(replayBuffer, 0, bytesRead);
+          }
+        }
+      } finally {
+        if (replayIn != null) {
+          replayIn.close();
+        }
+        if (sectionDecompressor != null) {
+          CodecPool.returnDecompressor(sectionDecompressor);
+        }
+      }
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -17,7 +17,6 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl;
 
-import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -154,7 +153,7 @@ public class IFile {
         TezCounter serializedBytesCounter, int cacheSize, byte[] writeBuffer) throws IOException {
       super(keySerialization, valSerialization,
           new FSDataOutputStream(createBoundedBuffer(cacheSize), null),
-          keyClass, valueClass, codec,
+          keyClass, valueClass, null,
           writesCounter, serializedBytesCounter, false, writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
@@ -193,7 +192,7 @@ public class IFile {
      */
     private void resetToFileBasedWriter() throws IOException {
       // Close out stream, so that data checksums are written.
-      // Buf contents = HEADER + (uncompressed) real data + CHECKSUM
+      // Temporary in-memory values section = HEADER + (uncompressed) values payload + CHECKSUM
       flushWriteBuffer();
       finishValuesSectionForSpill();
 
@@ -226,38 +225,8 @@ public class IFile {
     }
 
     private void replayValuesPayload(byte[] data, int offset, int length) throws IOException {
-      if (length <= 0) {
-        return;
-      }
-      if (fileCodec == null) {
+      if (length > 0) {
         bufferWriteBytes(data, offset, length);
-        return;
-      }
-
-      Decompressor sectionDecompressor = null;
-      InputStream replayIn = null;
-      byte[] replayBuffer = allocateWriteBuffer();
-      try {
-        sectionDecompressor = CodecUtils.getDecompressor(fileCodec);
-        if (sectionDecompressor == null) {
-          throw new IOException("Could not obtain decompressor from CodecPool for spill replay");
-        }
-        sectionDecompressor.reset();
-        replayIn = CodecUtils.createInputStream(fileCodec,
-            new ByteArrayInputStream(data, offset, length), sectionDecompressor);
-        int bytesRead;
-        while ((bytesRead = replayIn.read(replayBuffer)) != -1) {
-          if (bytesRead > 0) {
-            bufferWriteBytes(replayBuffer, 0, bytesRead);
-          }
-        }
-      } finally {
-        if (replayIn != null) {
-          replayIn.close();
-        }
-        if (sectionDecompressor != null) {
-          CodecPool.returnDecompressor(sectionDecompressor);
-        }
       }
     }
 


### PR DESCRIPTION
### Motivation
- Migrate IFile.Writer to a new physical layout with three independently encoded sections: `HEADER`, values payload, keys payload, and lengths payload, so read/write can later be separated per-section.
- Ensure values are streamed incrementally during `append()` while keys and `(keyLength, valueLength)` metadata are buffered for emission at `close()`.
- Preserve the existing header format and single compression flag semantics while making each section independently compressed/finalized when a codec is present.
- Keep public APIs (`append(...)`, constructors, `getRawLength()`, `getCompressedLength()`) unchanged and avoid modifying `Reader` or callers in this change.

### Description
- Reworked `IFile.Writer` internals to create three logical sections: values section (streamed during `append()`), key section (buffered in `keySectionBuffer`), and lengths section (buffered in `lengthsSectionBuffer`).
- Values are written immediately to a dedicated values pipeline (`valuesOut` -> `valuesCompressedOut` -> `valuesChecksumOut` -> `rawOut`) using the existing checksum/compression helpers, while keys and lengths are accumulated in memory and emitted in `close()` via independent section pipelines each with their own checksum and (if enabled) compressor.
- Implemented per-record behavior: `append(Object,Object)` and `append(DataInputBuffer,DataInputBuffer)` now compute `keyLength` and `valueLength`, validate non-negative lengths, append key bytes to key buffer, append the two 4-byte big-endian lengths into lengths buffer, and write value bytes immediately to the values section; also updated counters (`logicalValueBytesWritten`, `logicalKeyBytesWritten`, `logicalLengthBytesWritten`, `decompressedBytesWritten`, and `serializedUncompressedBytes`).
- Removed EOF marker writes from the writer close path and adjusted `getBaseCacheSize()` to reflect header + one-section checksum base; `FileBackedInMemIFileWriter` now makes spill decisions based on the full logical per-record contribution and, on spill, finalizes the in-memory values section and copies only the produced values payload to disk (keeping key/length buffers in memory for close-time emission).
- Added helpers `finishValuesSection()` and `writeBufferedSection(...)` to finalize per-section encoders/checksums independently and to return compressors to `CodecPool` where owned; retained original header bytes and single compression flag semantics.

### Testing
- Attempted to compile the modified module with `mvn -pl tez-runtime-library -DskipTests compile`, but the build did not complete in this environment due to external Maven plugin/repository resolution returning HTTP 403 (an environment artifact), not due to local compilation diagnostics.
- Performed local code inspection and lightweight static checks (searches and `sed`/`rg` checks) to verify inserted symbols, helper methods, and that `append()`/`close()` code paths now follow the three-section design and that the spill path copies only values payload.
- No automated unit tests were added or executed as part of this PR; reader-side changes and full integration tests are expected in a follow-up to validate cross-format compatibility.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7841616088328995acb361c3a207d)