### PR TITLE
Track per-section compressed byte counts and expose getters in IFile.Writer

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -293,6 +293,9 @@ public class IFile {
     // initialized to HEADER.length because the header is already part of that logical length from the start
     private long decompressedBytesWritten = HEADER.length;
     private long compressedBytesWritten = 0;
+    private long compressedValueBytesWritten = 0;
+    private long compressedKeyBytesWritten = 0;
+    private long compressedLengthBytesWritten = 0;
     private long logicalValueBytesWritten = 0;
     private long logicalKeyBytesWritten = 0;
     private long logicalLengthBytesWritten = 0;
@@ -414,14 +417,17 @@ public class IFile {
       }
 
       finishValuesSection();
+      compressedValueBytesWritten = extractSectionPayloadLength(rawOut.getPos() - (start + HEADER.length));
 
       // values section is complete; compressor object can now be reused
       valuesOut = null;
       valuesCompressedOut = null;
       valuesChecksumOut = null;
 
-      writeBufferedSection(keySectionBuffer, compressOutput ? valuesCompressor : null);
-      writeBufferedSection(lengthsSectionBuffer, compressOutput ? valuesCompressor : null);
+      compressedKeyBytesWritten = writeBufferedSection(keySectionBuffer,
+          compressOutput ? valuesCompressor : null);
+      compressedLengthBytesWritten = writeBufferedSection(lengthsSectionBuffer,
+          compressOutput ? valuesCompressor : null);
 
       // header bytes are already included in rawOut
       compressedBytesWritten = rawOut.getPos() - start;
@@ -550,9 +556,11 @@ public class IFile {
       valuesChecksumOut.finish();
     }
 
-    private void writeBufferedSection(DataOutputBuffer sectionBuffer, @Nullable Compressor compressor)
+    private long writeBufferedSection(DataOutputBuffer sectionBuffer, @Nullable Compressor compressor)
         throws IOException {
       assert (compressOutput && compressor != null) || (!compressOutput && compressor == null);
+
+      final long sectionStart = rawOut.getPos();
 
       IFileOutputStream sectionChecksumOut = new IFileOutputStream(rawOut);
       DataOutputStream sectionOut = new DataOutputStream(sectionChecksumOut);
@@ -571,6 +579,17 @@ public class IFile {
         sectionCompressedOut.resetState();
       }
       sectionChecksumOut.finish();
+
+      return extractSectionPayloadLength(rawOut.getPos() - sectionStart);
+    }
+
+    private long extractSectionPayloadLength(long sectionTotalLength) throws IOException {
+      final long checksumLength = IFileOutputStream.getCheckSumSize();
+      if (sectionTotalLength < checksumLength) {
+        throw new IOException("Invalid section length " + sectionTotalLength
+            + ": must be at least checksum length " + checksumLength);
+      }
+      return sectionTotalLength - checksumLength;
     }
 
     protected long getLogicalValueBytesWritten() {
@@ -591,6 +610,18 @@ public class IFile {
 
     public long getCompressedLength() {
       return compressedBytesWritten;
+    }
+
+    public long getCompressedValueBytes() {
+      return compressedValueBytesWritten;
+    }
+
+    public long getCompressedKeyBytes() {
+      return compressedKeyBytesWritten;
+    }
+
+    public long getCompressedLengthBytes() {
+      return compressedLengthBytesWritten;
     }
   }
 


### PR DESCRIPTION
### Motivation

- Record compressed payload sizes separately for values, keys, and lengths to provide more accurate metrics and diagnostics when writing IFile sections. 
- Ensure the reported compressed sizes exclude the per-section checksum bytes and validate section lengths before exposing them.

### Description

- Added fields `compressedValueBytesWritten`, `compressedKeyBytesWritten`, and `compressedLengthBytesWritten` to `IFile.Writer` and corresponding getters `getCompressedValueBytes()`, `getCompressedKeyBytes()`, and `getCompressedLengthBytes()`.
- Compute `compressedValueBytesWritten` after finishing the values section and compute `compressedKeyBytesWritten` and `compressedLengthBytesWritten` from `writeBufferedSection(...)` return values.
- Changed `writeBufferedSection(...)` to return the section payload length and introduced `extractSectionPayloadLength(...)` to subtract the checksum size and validate the section length.
- Minor refactor to compute section start positions and return validated payload lengths while preserving existing compressor handling and checksum finishing logic.

### Testing

- Performed a project build and unit test run using `mvn test` for the module containing `IFile`, and the test suite completed successfully. 
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7d6f944508328b65e33cb8c303c59)