### PR TITLE
Record full IFile.SectionLayout in map-output index and adapt spill/index handling

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
@@ -28,7 +28,8 @@ public class Constants {
   public static final String MAP_OUTPUT_INDEX_SUFFIX_STRING = ".index";
   public static final String REDUCE_INPUT_FILE_FORMAT_STRING = "%s/map_%d.out";
 
-  public static final int MAP_OUTPUT_INDEX_RECORD_LENGTH = 24;
+  // startOffset + IFile.SectionLayout
+  public static final int MAP_OUTPUT_INDEX_RECORD_LENGTH = 72;
   public static final String MERGED_OUTPUT_PREFIX = ".merged";
 
   public static final long DEFAULT_COMBINE_RECORDS_BEFORE_PROGRESS = 10000;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.util.Progress;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
+import org.apache.tez.runtime.library.common.Constants;
 import org.apache.tez.runtime.library.common.ConfigUtils;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
@@ -73,7 +74,7 @@ public class PipelinedSorter extends ExternalSorter {
   /**
    * The size of each record in the index file for the map-outputs.
    */
-  public static final int MAP_OUTPUT_INDEX_RECORD_LENGTH = 24;
+  public static final int MAP_OUTPUT_INDEX_RECORD_LENGTH = Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH;
   private final static int APPROX_HEADER_LENGTH = 150;
 
   private final int partitionBits;
@@ -527,15 +528,19 @@ public class PipelinedSorter extends ExternalSorter {
           }
           long rawLength = 0;
           long partLength = 0;
+          IFile.SectionLayout layout = null;
           if (writer != null) {
             writer.close();
             rawLength = writer.getRawLength();
             partLength = writer.getCompressedLength();
+            layout = writer.getSectionLayout();
             writer = null;
           }
           adjustSpillCounters(rawLength, partLength);
           // record offsets
-          final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
+          final TezIndexRecord rec = layout == null
+              ? TezIndexRecord.empty(segmentStart)
+              : new TezIndexRecord(segmentStart, layout);
           spillRec.putIndex(rec, i);
         } finally {
           if (null != writer) {
@@ -642,17 +647,21 @@ public class PipelinedSorter extends ExternalSorter {
 
         long rawLength = 0;
         long partLength = 0;
+        IFile.SectionLayout layout = null;
         if (writer != null) {
           writer.close();
           rawLength = writer.getRawLength();
           partLength = writer.getCompressedLength();
+          layout = writer.getSectionLayout();
           // writer never used again
         }
         adjustSpillCounters(rawLength, partLength);
         sumPartLength += partLength;
 
         // record offsets
-        final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
+        final TezIndexRecord rec = layout == null
+            ? TezIndexRecord.empty(segmentStart)
+            : new TezIndexRecord(segmentStart, layout);
         spillRec.putIndex(rec, i);
         if (!isFinalMergeEnabled && reportPartitionStats()) {
           partitionStats[i] += rawLength;
@@ -885,6 +894,7 @@ public class PipelinedSorter extends ExternalSorter {
         long segmentStart = finalOut.getPos();
         long rawLength = 0;
         long partLength = 0;
+        IFile.SectionLayout layout = null;
         if (shouldWrite) {
           Writer writer = new Writer(
               serializationContext.getKeySerialization(), serializationContext.getValSerialization(),
@@ -899,12 +909,15 @@ public class PipelinedSorter extends ExternalSorter {
           writer.close();
           rawLength = writer.getRawLength();
           partLength = writer.getCompressedLength();
+          layout = writer.getSectionLayout();
           // writer never used again
         }
         outputBytesWithOverheadCounter.increment(rawLength);
 
         // record offsets
-        final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
+        final TezIndexRecord rec = layout == null
+            ? TezIndexRecord.empty(segmentStart)
+            : new TezIndexRecord(segmentStart, layout);
         spillRec.putIndex(rec, parts);
         if (reportPartitionStats()) {
           partitionStats[parts] += rawLength;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezIndexRecord.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezIndexRecord.java
@@ -19,36 +19,39 @@
 package org.apache.tez.runtime.library.common.sort.impl;
 
 public class TezIndexRecord {
-  private long startOffset;
-  private long rawLength;
-  private long partLength;
+  private final long startOffset;
+  private final IFile.SectionLayout layout;
 
   /**
    * @param startOffset start offset within the data file
-   * @param rawLength raw data length - typically uncompressed
-   * @param partLength actual data length in file - factors in checksums and compression
+   * @param layout IFile section layout, or null for omitted empty partitions
    */
-  public TezIndexRecord(long startOffset, long rawLength, long partLength) {
+  public TezIndexRecord(long startOffset, IFile.SectionLayout layout) {
     this.startOffset = startOffset;
-    this.rawLength = rawLength;
-    this.partLength = partLength;
+    this.layout = layout;
+  }
+
+  public static TezIndexRecord empty(long startOffset) {
+    return new TezIndexRecord(startOffset, null);
   }
 
   public long getStartOffset() {
     return startOffset;
   }
 
+  public IFile.SectionLayout getLayout() {
+    return layout;
+  }
+
   public long getRawLength() {
-    return rawLength;
+    return layout == null ? 0 : layout.totalRawLength;
   }
 
   public long getPartLength() {
-    return partLength;
+    return layout == null ? 0 : layout.totalLength;
   }
 
   public boolean hasData() {
-    //TEZ-941 - Avoid writing out empty partitions
-    //EOF_MARKER + Header bytes
-    return !(rawLength <= (IFile.HEADER.length + 2));
+    return layout != null && layout.totalNumRecordsWritten > 0;
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezSpillRecord.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezSpillRecord.java
@@ -109,7 +109,16 @@ public class TezSpillRecord {
    */
   public TezIndexRecord getIndex(int partition) {
     final int pos = partition * Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / 8;
-    return new TezIndexRecord(entries.get(pos), entries.get(pos + 1), entries.get(pos + 2));
+    long startOffset = entries.get(pos);
+    long totalLength = entries.get(pos + 1);
+    if (totalLength == 0) {
+      return TezIndexRecord.empty(startOffset);
+    }
+    return new TezIndexRecord(startOffset, new IFile.SectionLayout(
+        entries.get(pos + 2), entries.get(pos + 3), entries.get(pos + 4),
+        totalLength,
+        entries.get(pos + 5),
+        entries.get(pos + 6), entries.get(pos + 7), entries.get(pos + 8)));
   }
 
   /**
@@ -118,8 +127,21 @@ public class TezSpillRecord {
   public void putIndex(TezIndexRecord rec, int partition) {
     final int pos = partition * Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / 8;
     entries.put(pos, rec.getStartOffset());
-    entries.put(pos + 1, rec.getRawLength());
-    entries.put(pos + 2, rec.getPartLength());
+    IFile.SectionLayout layout = rec.getLayout();
+    if (layout == null) {
+      for (int i = 1; i < Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH / 8; i++) {
+        entries.put(pos + i, 0L);
+      }
+      return;
+    }
+    entries.put(pos + 1, layout.totalLength);
+    entries.put(pos + 2, layout.valuesStart);
+    entries.put(pos + 3, layout.keysStart);
+    entries.put(pos + 4, layout.lengthsStart);
+    entries.put(pos + 5, layout.totalNumRecordsWritten);
+    entries.put(pos + 6, layout.valuesRawLength);
+    entries.put(pos + 7, layout.keysRawLength);
+    entries.put(pos + 8, layout.lengthsRawLength);
   }
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -684,8 +684,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
               }
               writer.close();   // write does not own fsOutput, so fsOutput.close() is not called
               compressedLength += writer.getCompressedLength();
-              TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getRawLength(),
-                  writer.getCompressedLength());
+              TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getSectionLayout());
               spillRecord.putIndex(indexRecord, i);
               writer = null;
             }
@@ -844,7 +843,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
 
           if (!canSendDataOverDME()) {
             // the final data was written to disk, so increment fileOutputBytesCounter
-            TezIndexRecord rec = new TezIndexRecord(0, rawLen, compLen);
+            TezIndexRecord rec = new TezIndexRecord(0, this.writer.getSectionLayout());
             TezSpillRecord sr = new TezSpillRecord(1);
             sr.putIndex(rec, 0);
             if (writeSpillRecord) {
@@ -1212,8 +1211,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
           writer.close();
           // written to local disk, so increment fileOutputBytesCounter
           fileOutputBytesCounter.increment(writer.getCompressedLength());
-          TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getRawLength(),
-              writer.getCompressedLength());
+          TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getSectionLayout());
           writer = null;
           finalSpillRecord.putIndex(indexRecord, i);
         } finally {
@@ -1315,8 +1313,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
                 additionalSpillBytesWrittenCounter.increment(writer.getCompressedLength());
               }
             }
-            TezIndexRecord indexRecord = new TezIndexRecord(recordStart, writer.getRawLength(),
-                writer.getCompressedLength());
+            TezIndexRecord indexRecord = new TezIndexRecord(recordStart, writer.getSectionLayout());
             spillRecord.putIndex(indexRecord, i);
             outSize = writer.getCompressedLength();
             writer = null;


### PR DESCRIPTION
### Motivation

- Capture and persist the full `IFile.SectionLayout` for map outputs instead of only raw/compressed lengths so index entries include detailed layout (offsets, raw lengths, record counts) and empty partitions can be represented without fake lengths.
- Update the index record size to accommodate the additional layout fields and propagate the change through sort/spill/writer code paths.

### Description

- Increase `Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH` from `24` to `72` and reference it from `PipelinedSorter`.
- Replace `TezIndexRecord` fields with a single `IFile.SectionLayout` member, add `empty(long)` factory, and update `getRawLength()`, `getPartLength()` and `hasData()` to derive values from the layout.
- Update `TezSpillRecord` to pack/unpack the expanded layout fields into the `entries` buffer, and compute `size()` using the new `Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH`.
- Modify producers of index records (`PipelinedSorter`, `UnorderedPartitionedKVWriter`, and other spill code) to use `writer.getSectionLayout()` when creating `TezIndexRecord` and to create empty records when layout is null.

### Testing

- Built the project and ran unit tests with `mvn -DskipTests=false test` on the runtime library and sorting modules.
- Unit tests covering the modified packages completed successfully.
- Verified that the modified producers/consumers of index records compile and the basic pipelined spill/merge scenarios execute in a local smoke run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba631d0668832894cb3d5d8626472a)