### PR TITLE
Propagate IFile section layout through shuffle and use section-aware IFile readers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -144,10 +144,9 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
   public float getProgress() throws IOException, InterruptedException {
     final int numInputs = shuffleManager.getNumInputs();
     if (totalFileBytes.get() > 0 && numInputs > 0) {
-      return ((1.0f) * (totalBytesRead.get() + ((currentReader != null) ? currentReader.getPosition() :
-      0.0f)) /
-          totalFileBytes.get()) * (shuffleManager.getNumCompletedInputsFloat() /
-          (1.0f * numInputs));
+      return
+        ((totalBytesRead.get() + (currentReader != null ? currentReader.getPosition() : 0.0f)) / totalFileBytes.get()) *
+        (shuffleManager.getNumCompletedInputsFloat() / (1.0f * numInputs));
     }
     return 0.0f;
   }
@@ -215,7 +214,6 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
     }
     if (fetchedInput.getType() == Type.MEMORY) {
       MemoryFetchedInput mfi = (MemoryFetchedInput) fetchedInput;
-
       return new InMemoryReader(null, mfi.getBytes(), 0, (int) mfi.getSize(), layout, 0);
     } else {
       InputStream headerValuesIn = null;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -19,6 +19,7 @@
 package org.apache.tez.runtime.library.common.readers;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.tez.runtime.api.InputContext;
@@ -64,7 +65,7 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
   private V value;
   
   private FetchedInput currentFetchedInput;
-  private IFile.Reader currentReader;
+  private IFile.ReaderRead currentReader;
   
   // TODO Remove this once per I/O counters are separated properly. Relying on
   // the counter at the moment will generate aggregate numbers. 
@@ -143,7 +144,7 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
   public float getProgress() throws IOException, InterruptedException {
     final int numInputs = shuffleManager.getNumInputs();
     if (totalFileBytes.get() > 0 && numInputs > 0) {
-      return ((1.0f) * (totalBytesRead.get() + ((currentReader != null) ? currentReader.bytesRead :
+      return ((1.0f) * (totalBytesRead.get() + ((currentReader != null) ? currentReader.getPosition() :
       0.0f)) /
           totalFileBytes.get()) * (shuffleManager.getNumCompletedInputsFloat() /
           (1.0f * numInputs));
@@ -180,7 +181,7 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
    */
   private boolean moveToNextInput() throws IOException {
     if (currentReader != null) { // Close the current reader.
-      totalBytesRead.getAndAdd(currentReader.bytesRead);
+      totalBytesRead.getAndAdd(currentReader.getPosition());
       currentReader.close();
       /**
        * clear reader explicitly. Otherwise this could point to stale reference when next() is
@@ -206,17 +207,60 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
     }
   }
 
-  private IFile.Reader openIFileReader(FetchedInput fetchedInput)
+  private IFile.ReaderRead openIFileReader(FetchedInput fetchedInput)
       throws IOException {
+    IFile.SectionLayout layout = fetchedInput.getSectionLayout();
+    if (layout == null) {
+      throw new IOException("Missing IFile section layout for fetched input: " + fetchedInput);
+    }
     if (fetchedInput.getType() == Type.MEMORY) {
       MemoryFetchedInput mfi = (MemoryFetchedInput) fetchedInput;
 
-      return new InMemoryReader(null, mfi.getInputAttemptIdentifier(),
-          mfi.getBytes(), 0, (int) mfi.getSize(), 0);
+      return new InMemoryReader(null, mfi.getBytes(), 0, (int) mfi.getSize(), layout, 0);
     } else {
-      return new IFile.Reader(fetchedInput.getInputStream(),
-          fetchedInput.getSize(), codec, null, null,
-          ifileReadAhead, ifileReadAheadLength, context);
+      InputStream headerValuesIn = null;
+      InputStream keysIn = null;
+      InputStream lengthsIn = null;
+      boolean success = false;
+      try {
+        headerValuesIn = fetchedInput.getInputStream();
+        keysIn = fetchedInput.getInputStream();
+        skipFully(keysIn, layout.keysStart);
+        lengthsIn = fetchedInput.getInputStream();
+        skipFully(lengthsIn, layout.lengthsStart);
+
+        IFile.Reader reader = new IFile.Reader(
+            headerValuesIn, keysIn, lengthsIn, layout,
+            codec, null, null, ifileReadAhead, ifileReadAheadLength, context);
+        success = true;
+        return reader;
+      } finally {
+        if (!success) {
+          if (headerValuesIn != null) {
+            headerValuesIn.close();
+          }
+          if (keysIn != null) {
+            keysIn.close();
+          }
+          if (lengthsIn != null) {
+            lengthsIn.close();
+          }
+        }
+      }
+    }
+  }
+
+  private static void skipFully(InputStream in, long bytesToSkip) throws IOException {
+    long remaining = bytesToSkip;
+    while (remaining > 0) {
+      long skipped = in.skip(remaining);
+      if (skipped <= 0) {
+        if (in.read() < 0) {
+          throw new IOException("Premature EOF while skipping " + bytesToSkip + " bytes");
+        }
+        skipped = 1;
+      }
+      remaining -= skipped;
     }
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetchedInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetchedInput.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 
 public abstract class FetchedInput implements ShuffleInput {
   
@@ -45,6 +46,7 @@ public abstract class FetchedInput implements ShuffleInput {
   private final InputAttemptIdentifier inputAttemptIdentifier;
   private final FetchedInputCallback callback;
   private final int id;
+  private IFile.SectionLayout sectionLayout;
   private byte state;
 
   protected FetchedInput(InputAttemptIdentifier inputAttemptIdentifier,
@@ -90,6 +92,14 @@ public abstract class FetchedInput implements ShuffleInput {
 
   public InputAttemptIdentifier getInputAttemptIdentifier() {
     return this.inputAttemptIdentifier;
+  }
+
+  public IFile.SectionLayout getSectionLayout() {
+    return sectionLayout;
+  }
+
+  public void setSectionLayout(IFile.SectionLayout sectionLayout) {
+    this.sectionLayout = sectionLayout;
   }
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -118,12 +118,12 @@ public class ShuffleUtils {
   }
 
   public static void shuffleToMemory(byte[] shuffleData,
-      InputStream input, int decompressedLength, int compressedLength,
+      InputStream input, IFile.SectionLayout layout, int decompressedLength, int compressedLength,
       CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLength,
       Logger LOG, InputAttemptIdentifier identifier,
       TaskContext taskContext, boolean useThreadLocalDecompressor) throws IOException {
     try {
-      IFile.Reader.readToMemory(shuffleData, input, compressedLength, codec,
+      IFile.Reader.readToMemory(shuffleData, input, layout, codec,
           ifileReadAhead, ifileReadAheadLength, taskContext, useThreadLocalDecompressor);
       // metrics.inputBytes(shuffleData.length);
       // finished reading shuffleData.length bytes from identifier
@@ -149,13 +149,14 @@ public class ShuffleUtils {
   }
   
   public static void shuffleToDisk(OutputStream output, String hostIdentifier,
-      InputStream input, long compressedLength, long decompressedLength, Logger LOG, InputAttemptIdentifier identifier,
+      InputStream input, IFile.SectionLayout layout, long compressedLength, long decompressedLength, Logger LOG,
+      InputAttemptIdentifier identifier,
       boolean ifileReadAhead, int ifileReadAheadLength, boolean verifyChecksum) throws IOException {
     // Copy data to local-disk
     long bytesLeft = compressedLength;
     try {
       if (verifyChecksum) {
-        bytesLeft -= IFile.Reader.readToDisk(output, input, compressedLength,
+        bytesLeft -= IFile.Reader.readToDisk(output, input, layout,
             ifileReadAhead, ifileReadAheadLength);
       } else {
         final int BYTES_TO_READ = 64 * 1024;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;  // TODO: relocate
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
 import org.apache.tez.runtime.library.exceptions.FetcherReadTimeoutException;
@@ -525,6 +526,7 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         public void freeResources(FetchedInput fetchedInput) {
         }
       });
+    fetchedInput.setSectionLayout(indexRecord.getLayout());
     if (isDebugEnabled) {
       LOG.debug("fetcher" + " about to shuffle output of srcAttempt (direct disk)" + srcAttemptId
         + " decomp: " + indexRecord.getRawLength() + " len: " + indexRecord.getPartLength()
@@ -583,13 +585,16 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
     final long decompressedLength;
     final long compressedLength;
     final int forReduce;
+    final IFile.SectionLayout layout;
 
-    MapOutputStat(InputAttemptIdentifier srcAttemptId, long decompressedLength, long compressedLength, int forReduce) {
+    MapOutputStat(InputAttemptIdentifier srcAttemptId, long decompressedLength, long compressedLength,
+        int forReduce, IFile.SectionLayout layout) {
       assert srcAttemptId != null;
       this.srcAttemptId = srcAttemptId;
       this.decompressedLength = decompressedLength;
       this.compressedLength = compressedLength;
       this.forReduce = forReduce;
+      this.layout = layout;
     }
 
     @Override
@@ -655,7 +660,8 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
           }
 
           mapOutputStat = new MapOutputStat(srcAttemptId,
-              header.getUncompressedLength(), header.getCompressedLength(), header.getPartition());
+              header.getUncompressedLength(), header.getCompressedLength(), header.getPartition(),
+              header.getSectionLayout());
           mapOutputStats.add(mapOutputStat);
           responsePartition = header.getPartition();
         } catch (IllegalArgumentException e) {
@@ -704,6 +710,7 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
           fetchedInput = shuffleManager.getInputManager().allocate(
               decompressedLength, compressedLength, srcAttemptId, false);
         }
+        fetchedInput.setSectionLayout(mapOutputStat.layout);
         if (fetchedInput.getType() == Type.WAIT) {
           if (isDebugEnabled) {
             LOG.debug("Waiting for memory to be freed: {}, {}, {}",
@@ -722,12 +729,12 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
 
         if (fetchedInput.getType() == Type.MEMORY) {
           ShuffleUtils.shuffleToMemory(((MemoryFetchedInput) fetchedInput).getBytes(),
-              input, (int) decompressedLength, (int) compressedLength, codec,
+              input, mapOutputStat.layout, (int) decompressedLength, (int) compressedLength, codec,
               fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength, LOG,
               fetchedInput.getInputAttemptIdentifier(), taskContext, true);
         } else if (fetchedInput.getType() == Type.DISK) {
           ShuffleUtils.shuffleToDisk(((DiskFetchedInput) fetchedInput).getOutputStream(),
-              (host + ":" + port), input, compressedLength, decompressedLength, LOG,
+              (host + ":" + port), input, mapOutputStat.layout, compressedLength, decompressedLength, LOG,
               fetchedInput.getInputAttemptIdentifier(),
               fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength, fetcherConfigCommon.verifyDiskChecksum);
         } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleInputEventHandlerImpl.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleInputEventHandlerImpl.java
@@ -48,6 +48,7 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads.DataProto
 import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads.DataMovementEventPayloadProto;
 import org.apache.tez.runtime.library.common.shuffle.DiskFetchedInput;
 import org.apache.tez.runtime.library.common.shuffle.MemoryFetchedInput;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -207,10 +208,15 @@ public class ShuffleInputEventHandlerImpl implements ShuffleEventHandler {
 
   private void moveDataToFetchedInput(DataProto dataProto,
       FetchedInput fetchedInput, String hostIdentifier) throws IOException {
+    IFile.SectionLayout layout = new IFile.SectionLayout(
+        dataProto.getValuesStart(), dataProto.getKeysStart(), dataProto.getLengthsStart(),
+        dataProto.getCompressedLength(), dataProto.getTotalRecordsWritten(),
+        dataProto.getValuesRawLength(), dataProto.getKeysRawLength(), dataProto.getLengthsRawLength());
+    fetchedInput.setSectionLayout(layout);
     switch (fetchedInput.getType()) {
     case DISK:
       ShuffleUtils.shuffleToDisk(((DiskFetchedInput) fetchedInput).getOutputStream(),
-          hostIdentifier, dataProto.getData().newInput(),
+          hostIdentifier, dataProto.getData().newInput(), layout,
           dataProto.getCompressedLength(),
           dataProto.getUncompressedLength(), LOG,
           fetchedInput.getInputAttemptIdentifier(), ifileReadAhead,
@@ -219,7 +225,7 @@ public class ShuffleInputEventHandlerImpl implements ShuffleEventHandler {
     case MEMORY:
       // set useThreadLocalDecompressor = false because we are inside an EventHandler thread, not a Fetcher thread
       ShuffleUtils.shuffleToMemory(((MemoryFetchedInput) fetchedInput).getBytes(),
-          dataProto.getData().newInput(), dataProto.getRawLength(),
+          dataProto.getData().newInput(), layout, dataProto.getRawLength(),
           dataProto.getCompressedLength(),
           codec, ifileReadAhead, ifileReadAheadLength, LOG,
           fetchedInput.getInputAttemptIdentifier(), inputContext, false);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -49,6 +49,7 @@ import org.apache.tez.runtime.library.common.shuffle.ShuffleServer.PathPartition
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.shuffle.api.ShuffleHandlerError;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.MapOutput.Type;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
 import org.apache.tez.runtime.library.exceptions.FetcherReadTimeoutException;
@@ -68,13 +69,15 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     final long decompressedLength;
     final long compressedLength;
     final int forReduce;
+    final IFile.SectionLayout layout;
 
     MapOutputStat(InputAttemptIdentifier srcAttemptId, long decompressedLength, long compressedLength,
-        int forReduce) {
+        int forReduce, IFile.SectionLayout layout) {
       this.srcAttemptId = srcAttemptId;
       this.decompressedLength = decompressedLength;
       this.compressedLength = compressedLength;
       this.forReduce = forReduce;
+      this.layout = layout;
     }
 
     @Override
@@ -520,7 +523,8 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
               pathToAttemptMap.get(new PathPartition(header.mapId, header.forReduce)),
               header.uncompressedLength,
               header.compressedLength,
-              header.forReduce);
+              header.forReduce,
+              header.getSectionLayout());
           mapOutputStats.add(mapOutputStat);
         } catch (IllegalArgumentException e) {
           if (!stopped) {
@@ -583,6 +587,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
           }
           return EMPTY_ATTEMPT_ID_ARRAY;
         }
+        mapOutput.setSectionLayout(mapOutputStat.layout);
 
         // Check if we can shuffle *now* ...
         if (mapOutput.getType() == Type.WAIT) {
@@ -599,13 +604,14 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         }
 
         if (mapOutput.getType() == Type.MEMORY) {
-          ShuffleUtils.shuffleToMemory(mapOutput.getMemory(), input, (int) decompressedLength,
+          ShuffleUtils.shuffleToMemory(mapOutput.getMemory(), input, mapOutputStat.layout, (int) decompressedLength,
               (int) compressedLength, codec, fetcherConfig.ifileReadAhead,
               fetcherConfig.ifileReadAheadLength, LOG,
               mapOutput.getAttemptIdentifier(), taskContext, true);
         } else if (mapOutput.getType() == Type.DISK) {
           ShuffleUtils.shuffleToDisk(mapOutput.getDisk(), host,
-              input, compressedLength, decompressedLength, LOG, mapOutput.getAttemptIdentifier(),
+              input, mapOutputStat.layout, compressedLength, decompressedLength, LOG,
+              mapOutput.getAttemptIdentifier(),
               fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength,
               fetcherConfigCommon.verifyDiskChecksum);
         } else {
@@ -770,7 +776,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
   private MapOutput getMapOutputForDirectDiskFetch(InputAttemptIdentifier srcAttemptId, Path filename,
       TezIndexRecord indexRecord) throws IOException {
     return MapOutput.createLocalDiskMapOutput(srcAttemptId, allocator, filename,
-        indexRecord.getStartOffset(), indexRecord.getPartLength(), true);
+        indexRecord.getStartOffset(), indexRecord.getPartLength(), true, indexRecord.getLayout());
   }
 
   private boolean verifySanity(long compressedLength, long decompressedLength,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.FileChunk;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFiles;
 
 public abstract class MapOutput implements ShuffleInput {
@@ -45,6 +46,7 @@ public abstract class MapOutput implements ShuffleInput {
 
   private final int id;
   private InputAttemptIdentifier attemptIdentifier;
+  private IFile.SectionLayout sectionLayout;
 
   private final boolean primaryMapOutput;
   protected final FetchedInputAllocatorOrderedGrouped callback;
@@ -81,8 +83,12 @@ public abstract class MapOutput implements ShuffleInput {
 
   public static MapOutput createLocalDiskMapOutput(InputAttemptIdentifier attemptIdentifier,
                                                    FetchedInputAllocatorOrderedGrouped callback, Path path,  long offset,
-                                                   long size, boolean primaryMapOutput)  {
-    return new DiskDirectMapOutput(attemptIdentifier, callback, size, path, offset, primaryMapOutput);
+                                                   long size, boolean primaryMapOutput,
+                                                   IFile.SectionLayout sectionLayout)  {
+    DiskDirectMapOutput mapOutput =
+        new DiskDirectMapOutput(attemptIdentifier, callback, size, path, offset, primaryMapOutput);
+    mapOutput.setSectionLayout(sectionLayout);
+    return mapOutput;
   }
 
   // may throw OutOfMemoryError
@@ -132,6 +138,14 @@ public abstract class MapOutput implements ShuffleInput {
   }
 
   public abstract Type getType();
+
+  public IFile.SectionLayout getSectionLayout() {
+    return sectionLayout;
+  }
+
+  public void setSectionLayout(IFile.SectionLayout sectionLayout) {
+    this.sectionLayout = sectionLayout;
+  }
 
   public long getSize() {
     return -1;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -725,9 +725,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             }
           } else {
             mergeOutputSize += mo.getSize();
-            IFile.Reader reader = new InMemoryReader(MergeManager.this,
-                mo.getAttemptIdentifier(), mo.getMemory(), 0, mo.getMemory().length,
-                (int)mo.getUsedMemoryForMergeManager());
+            IFile.ReaderRead reader = new InMemoryReader(MergeManager.this,
+                mo.getMemory(), 0, mo.getMemory().length,
+                mo.getSectionLayout(), (int)mo.getUsedMemoryForMergeManager());
             inMemorySegments.add(new Segment(reader,
                 (mo.isPrimaryMapOutput() ? mergedMapOutputsCounter : null)));
             lastAddedMapOutput = mo;
@@ -1045,8 +1045,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       long size = data.length;
       totalSize += size;
       fullSize -= size;
-      IFile.Reader reader = new InMemoryReader(MergeManager.this, 
-          mo.getAttemptIdentifier(), data, 0, (int)size,
+      IFile.ReaderRead reader = new InMemoryReader(MergeManager.this,
+          data, 0, (int)size, mo.getSectionLayout(),
           (int)mo.getUsedMemoryForMergeManager());
       inMemorySegments.add(new Segment(reader,
           (mo.isPrimaryMapOutput() ? mergedMapOutputsCounter : null)));

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -64,11 +64,6 @@ public class ShuffleHeader implements Writable {
 
   // ShuffleHeader created used by MR3 ShuffleHandler (but not by Hadoop shuffle service)
   public ShuffleHeader(String mapId, long compressedLength,
-      long uncompressedLength, int forReduce) {
-    this(mapId, compressedLength, uncompressedLength, forReduce, null);
-  }
-
-  public ShuffleHeader(String mapId, long compressedLength,
       long uncompressedLength, int forReduce, IFile.SectionLayout sectionLayout) {
     this.mapId = mapId;
     this.compressedLength = compressedLength;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 
 /**
  * Shuffle Header information that is sent by the TaskTracker and 
@@ -48,6 +49,7 @@ public class ShuffleHeader implements Writable {
   long uncompressedLength;
   long compressedLength;
   int forReduce;
+  IFile.SectionLayout sectionLayout;
 
   private boolean compositeFetch;
 
@@ -63,10 +65,16 @@ public class ShuffleHeader implements Writable {
   // ShuffleHeader created used by MR3 ShuffleHandler (but not by Hadoop shuffle service)
   public ShuffleHeader(String mapId, long compressedLength,
       long uncompressedLength, int forReduce) {
+    this(mapId, compressedLength, uncompressedLength, forReduce, null);
+  }
+
+  public ShuffleHeader(String mapId, long compressedLength,
+      long uncompressedLength, int forReduce, IFile.SectionLayout sectionLayout) {
     this.mapId = mapId;
     this.compressedLength = compressedLength;
     this.uncompressedLength = uncompressedLength;
     this.forReduce = forReduce;
+    this.sectionLayout = sectionLayout;
   }
   
   public String getMapId() {
@@ -85,6 +93,10 @@ public class ShuffleHeader implements Writable {
     return compressedLength;
   }
 
+  public IFile.SectionLayout getSectionLayout() {
+    return sectionLayout;
+  }
+
   public void readFields(DataInput in) throws IOException {
     if (compositeFetch) {   // ShuffleHeader created by MR3 ShuffleHandler
       int length = in.readInt();  // Cf. WritableUtils.readStringSafely() calls readVInt()
@@ -99,11 +111,27 @@ public class ShuffleHeader implements Writable {
       compressedLength = in.readLong();
       uncompressedLength = in.readLong();
       forReduce = in.readInt();
+      if (compressedLength > 0) {
+        long valuesStart = in.readLong();
+        long keysStart = in.readLong();
+        long lengthsStart = in.readLong();
+        long totalNumRecordsWritten = in.readLong();
+        long valuesRawLength = in.readLong();
+        long keysRawLength = in.readLong();
+        long lengthsRawLength = in.readLong();
+        sectionLayout = new IFile.SectionLayout(
+            valuesStart, keysStart, lengthsStart,
+            compressedLength, totalNumRecordsWritten,
+            valuesRawLength, keysRawLength, lengthsRawLength);
+      } else {
+        sectionLayout = null;
+      }
     } else {  // ShuffleHeader created by Hadoop shuffle service
       mapId = WritableUtils.readStringSafely(in, MAX_ID_LENGTH);
       compressedLength = WritableUtils.readVLong(in);
       uncompressedLength = WritableUtils.readVLong(in);
       forReduce = WritableUtils.readVInt(in);
+      sectionLayout = null;
     }
   }
 
@@ -112,6 +140,9 @@ public class ShuffleHeader implements Writable {
   public int writeLength() throws IOException {
     int length = Text.encode(mapId).limit();
     length += 4 + 8 + 8 + 4;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce
+    if (compressedLength > 0) {
+      length += 7 * 8;
+    }
     return length;
   }
 
@@ -127,5 +158,17 @@ public class ShuffleHeader implements Writable {
     out.writeLong(compressedLength);
     out.writeLong(uncompressedLength);
     out.writeInt(forReduce);
+    if (compressedLength > 0) {
+      if (sectionLayout == null) {
+        throw new IOException("SectionLayout is required for non-empty shuffle header");
+      }
+      out.writeLong(sectionLayout.valuesStart);
+      out.writeLong(sectionLayout.keysStart);
+      out.writeLong(sectionLayout.lengthsStart);
+      out.writeLong(sectionLayout.totalNumRecordsWritten);
+      out.writeLong(sectionLayout.valuesRawLength);
+      out.writeLong(sectionLayout.keysRawLength);
+      out.writeLong(sectionLayout.lengthsRawLength);
+    }
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -1022,11 +1022,20 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
 
     if (canSendDataOverDME()) {
       ShuffleUserPayloads.DataProto.Builder dataProtoBuilder = ShuffleUserPayloads.DataProto.newBuilder();
+      IFile.SectionLayout layout = this.writer.getSectionLayout();
 
       // this.writer.close() was called in close() with skipBuffers = true
       dataProtoBuilder.setData(UnsafeByteOperations.unsafeWrap(readDataForDME()));
       dataProtoBuilder.setRawLength((int)this.writer.getRawLength());
       dataProtoBuilder.setCompressedLength((int)this.writer.getCompressedLength());
+      dataProtoBuilder.setUncompressedLength((int)this.writer.getRawLength());
+      dataProtoBuilder.setValuesStart(layout.valuesStart);
+      dataProtoBuilder.setKeysStart(layout.keysStart);
+      dataProtoBuilder.setLengthsStart(layout.lengthsStart);
+      dataProtoBuilder.setTotalRecordsWritten(layout.totalNumRecordsWritten);
+      dataProtoBuilder.setValuesRawLength(layout.valuesRawLength);
+      dataProtoBuilder.setKeysRawLength(layout.keysRawLength);
+      dataProtoBuilder.setLengthsRawLength(layout.lengthsRawLength);
       payloadBuilder.setData(dataProtoBuilder.build());
 
       this.shuffleDataViaEventSize.increment(this.writer.getCompressedLength());

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -1253,7 +1253,7 @@ public class ShuffleHandler {
           new DefaultFullHttpResponse(response.getProtocolVersion(), response.getStatus());
       fullResponse.headers().set(response.headers());
 
-      ShuffleHeader header = new ShuffleHeader(message, -1, -1, -1);
+      ShuffleHeader header = new ShuffleHeader(message, -1, -1, -1, null);
       DataOutputBuffer out = new DataOutputBuffer();
       // TODO: check if writing a fake partitionCount is necessary
       out.writeInt(127);  // write 127 as a fake partitionCount

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -1061,10 +1061,8 @@ public class ShuffleHandler {
         for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
           TezIndexRecord indexRecord = outputInfo.getIndex(reduce);
 
-          // contentLength += (new ShuffleHeader(mapId, indexRecord.getPartLength(), indexRecord.getRawLength(), reduce)).writeLength();
-          int length = lengthInitial;
-          length += 4 + 8 + 8 + 4;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce
-          contentLength += length;
+          contentLength += new ShuffleHeader(mapId, indexRecord.getPartLength(),
+              indexRecord.getRawLength(), reduce, indexRecord.getLayout()).writeLength();
 
           contentLength += indexRecord.getPartLength();
         }
@@ -1189,7 +1187,8 @@ public class ShuffleHandler {
           lastIndex = index;
         }
 
-        ShuffleHeader header = new ShuffleHeader(mapId, index.getPartLength(), index.getRawLength(), reduce);
+        ShuffleHeader header = new ShuffleHeader(mapId, index.getPartLength(), index.getRawLength(),
+            reduce, index.getLayout());
         DataOutputBuffer dob = new DataOutputBuffer();
         header.write(dob);
         // Free the memory needed to store the spill and index records

--- a/tez-runtime-library/src/main/proto/ShufflePayloads.proto
+++ b/tez-runtime-library/src/main/proto/ShufflePayloads.proto
@@ -39,6 +39,13 @@ message DataProto {
   optional int32 compressed_length = 2;
   optional bytes data = 3;
   optional int32 uncompressed_length = 4;
+  optional int64 values_start = 5;
+  optional int64 keys_start = 6;
+  optional int64 lengths_start = 7;
+  optional int64 total_records_written = 8;
+  optional int64 values_raw_length = 9;
+  optional int64 keys_raw_length = 10;
+  optional int64 lengths_raw_length = 11;
 }
 
 message InputInformationEventPayloadProto {


### PR DESCRIPTION
### Motivation
- Enable readers and fetchers to access section layout metadata (values/keys/lengths offsets and raw lengths) so shuffle payloads can be read as multiple streams and avoid unnecessary copying and seeks.
- Support direct memory/disk shuffle and DME payloads with exact layout info to allow section-aware `IFile.Reader` usage and accurate progress accounting.
- Fix EOF/seek/position issues by switching to a reader abstraction that exposes reader position and by opening separate input streams for header/keys/lengths.

### Description
- Added `IFile.SectionLayout` propagation across shuffle layers by adding layout fields and accessors to `FetchedInput`, `MapOutput`, and `ShuffleHeader`, and by populating layout from index/header info in all fetchers and the shuffle handler.
- Extended the `DataProto` shuffle payload (protobuf) with layout fields (`values_start`, `keys_start`, `lengths_start`, `total_records_written`, `values_raw_length`, `keys_raw_length`, `lengths_raw_length`) and populated these in `UnorderedPartitionedKVWriter` when sending DME payloads.
- Updated shuffle copy helpers in `ShuffleUtils` to accept a `IFile.SectionLayout` and forward it into `IFile.Reader.readToMemory` / `readToDisk`, and adjusted fetcher/fetcher-ordered code paths to set the layout on allocated `FetchedInput` instances and to pass the layout when copying.
- Reworked readers to use a new `IFile.ReaderRead` style reader that exposes position via `getPosition()` instead of raw `bytesRead`, open separate input streams for header/keys/lengths with `skipFully` adjustments, update progress calculation to use the reader position, and ensure resources are closed on error.

### Testing
- Ran the module unit test suite via `mvn test` and protobuf generation; all unit tests completed successfully.
- Executed shuffle-related integration tests including memory and disk fetch paths and Data Movement Event (DME) payload handling; these tests passed.
- Verified that protobuf changes compile and `ShuffleHeader`/fetcher code paths handle both legacy and extended headers without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baadf4d5e48328a887d10889b748aa)