### PR TITLE
Propagate IFile.SectionLayout through merges and DiskSegment readers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/hadoop/io/FileChunk.java
+++ b/tez-runtime-library/src/main/java/org/apache/hadoop/io/FileChunk.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 
 public class FileChunk implements Comparable<FileChunk> {
 
@@ -30,21 +31,32 @@ public class FileChunk implements Comparable<FileChunk> {
   private final boolean isLocalFile;
   private final Path path;
   private final InputAttemptIdentifier identifier;
+  private final IFile.SectionLayout sectionLayout;
 
   public FileChunk(Path path, long offset, long length, boolean isLocalFile,
                    InputAttemptIdentifier identifier) {
+    this(path, offset, length, isLocalFile, identifier, null);
+  }
+
+  public FileChunk(Path path, long offset, long length, boolean isLocalFile,
+                   InputAttemptIdentifier identifier, IFile.SectionLayout sectionLayout) {
     this.path = path;
     this.offset = offset;
     this.length = length;
     this.isLocalFile = isLocalFile;
     this.identifier = identifier;
+    this.sectionLayout = sectionLayout;
     if (isLocalFile) {
       Objects.requireNonNull(identifier);
     }
   }
 
   public FileChunk(Path path, long offset, long length) {
-    this(path, offset, length, false, null);
+    this(path, offset, length, false, null, null);
+  }
+
+  public FileChunk(Path path, long offset, long length, IFile.SectionLayout sectionLayout) {
+    this(path, offset, length, false, null, sectionLayout);
   }
 
   @Override
@@ -108,5 +120,9 @@ public class FileChunk implements Comparable<FileChunk> {
 
   public InputAttemptIdentifier getInputAttemptIdentifier() {
     return this.identifier;
+  }
+
+  public IFile.SectionLayout getSectionLayout() {
+    return sectionLayout;
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/hadoop/io/FileChunk.java
+++ b/tez-runtime-library/src/main/java/org/apache/hadoop/io/FileChunk.java
@@ -31,7 +31,7 @@ public class FileChunk implements Comparable<FileChunk> {
   private final boolean isLocalFile;
   private final Path path;
   private final InputAttemptIdentifier identifier;
-  private final IFile.SectionLayout sectionLayout;
+  private IFile.SectionLayout sectionLayout;
 
   public FileChunk(Path path, long offset, long length, boolean isLocalFile,
                    InputAttemptIdentifier identifier) {
@@ -124,5 +124,9 @@ public class FileChunk implements Comparable<FileChunk> {
 
   public IFile.SectionLayout getSectionLayout() {
     return sectionLayout;
+  }
+
+  public void setSectionLayout(IFile.SectionLayout sectionLayout) {
+    this.sectionLayout = sectionLayout;
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -145,6 +145,10 @@ public abstract class MapOutput implements ShuffleInput {
 
   public void setSectionLayout(IFile.SectionLayout sectionLayout) {
     this.sectionLayout = sectionLayout;
+    FileChunk outputPath = getOutputPath();
+    if (outputPath != null) {
+      outputPath.setSectionLayout(sectionLayout);
+    }
   }
 
   public long getSize() {
@@ -191,7 +195,7 @@ public abstract class MapOutput implements ShuffleInput {
     private DiskDirectMapOutput(InputAttemptIdentifier attemptIdentifier, FetchedInputAllocatorOrderedGrouped callback,
                       long size, Path outputPath, long offset, boolean primaryMapOutput) {
       super(attemptIdentifier, callback, primaryMapOutput);
-      this.outputPath = new FileChunk(outputPath, offset, size, true, attemptIdentifier, getSectionLayout());
+      this.outputPath = new FileChunk(outputPath, offset, size, true, attemptIdentifier);
     }
 
     @Override
@@ -216,8 +220,7 @@ public abstract class MapOutput implements ShuffleInput {
 
     @Override
     public FileChunk getOutputPath() {
-      return new FileChunk(outputPath.getPath(), outputPath.getOffset(), outputPath.getLength(),
-          outputPath.isLocalFile(), outputPath.getInputAttemptIdentifier(), getSectionLayout());
+      return outputPath;
     }
   }
 
@@ -231,13 +234,12 @@ public abstract class MapOutput implements ShuffleInput {
 
       this.tmpOutputPath = tmpOutputPath;
       this.disk = null;
-      this.outputPath = new FileChunk(outputPath, offset, size, false, attemptIdentifier, getSectionLayout());
+      this.outputPath = new FileChunk(outputPath, offset, size, false, attemptIdentifier);
     }
 
     @Override
     public FileChunk getOutputPath() {
-      return new FileChunk(outputPath.getPath(), outputPath.getOffset(), outputPath.getLength(),
-          outputPath.isLocalFile(), outputPath.getInputAttemptIdentifier(), getSectionLayout());
+      return outputPath;
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -191,12 +191,7 @@ public abstract class MapOutput implements ShuffleInput {
     private DiskDirectMapOutput(InputAttemptIdentifier attemptIdentifier, FetchedInputAllocatorOrderedGrouped callback,
                       long size, Path outputPath, long offset, boolean primaryMapOutput) {
       super(attemptIdentifier, callback, primaryMapOutput);
-      this.outputPath = new FileChunk(outputPath, offset, size, true, attemptIdentifier);
-    }
-
-    @Override
-    public FileChunk getOutputPath() {
-      return outputPath;
+      this.outputPath = new FileChunk(outputPath, offset, size, true, attemptIdentifier, getSectionLayout());
     }
 
     @Override
@@ -206,7 +201,7 @@ public abstract class MapOutput implements ShuffleInput {
 
     @Override
     public void commit() throws IOException {
-      callback.closeOnDiskFile(outputPath);
+      callback.closeOnDiskFile(getOutputPath());
     }
 
     @Override
@@ -217,6 +212,12 @@ public abstract class MapOutput implements ShuffleInput {
     @Override
     public Type getType() {
       return Type.DISK_DIRECT;
+    }
+
+    @Override
+    public FileChunk getOutputPath() {
+      return new FileChunk(outputPath.getPath(), outputPath.getOffset(), outputPath.getLength(),
+          outputPath.isLocalFile(), outputPath.getInputAttemptIdentifier(), getSectionLayout());
     }
   }
 
@@ -230,12 +231,13 @@ public abstract class MapOutput implements ShuffleInput {
 
       this.tmpOutputPath = tmpOutputPath;
       this.disk = null;
-      this.outputPath = new FileChunk(outputPath, offset, size, false, attemptIdentifier);
+      this.outputPath = new FileChunk(outputPath, offset, size, false, attemptIdentifier, getSectionLayout());
     }
 
     @Override
     public FileChunk getOutputPath() {
-      return outputPath;
+      return new FileChunk(outputPath.getPath(), outputPath.getOffset(), outputPath.getLength(),
+          outputPath.isLocalFile(), outputPath.getInputAttemptIdentifier(), getSectionLayout());
     }
 
     @Override
@@ -251,7 +253,7 @@ public abstract class MapOutput implements ShuffleInput {
     @Override
     public void commit() throws IOException {
       callback.getLocalFileSystem().rename(tmpOutputPath, outputPath.getPath());
-      callback.closeOnDiskFile(outputPath);
+      callback.closeOnDiskFile(getOutputPath());
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -850,6 +850,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
           mergeOutputSize).suffix(Constants.MERGED_OUTPUT_PREFIX);
 
       Writer writer = null;
+      IFile.SectionLayout outputLayout = null;
       long outFileLen = 0;
       try {
         writer = new Writer(serializationContext.getKeySerialization(),
@@ -873,6 +874,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
         TezMerger.writeFile(rIter, writer, progressable, TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);
         writer.close();
+        outputLayout = writer.getSectionLayout();
         additionalSpillBytesWritten.increment(writer.getCompressedLength());
         writer = null;
 
@@ -892,7 +894,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       }
 
       // Note the output of the merge
-      closeOnDiskFile(new FileChunk(outputPath, 0, outFileLen));
+      closeOnDiskFile(new FileChunk(outputPath, 0, outFileLen, outputLayout));
     }
 
     @Override
@@ -954,8 +956,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         }
         final Path file = fileChunk.getPath();
         approxOutputSize += size;
-        DiskSegment segment = new DiskSegment(rfs, file, offset, size, codec, ifileReadAhead,
-            ifileReadAheadLength, preserve, inputContext);
+        DiskSegment segment = new DiskSegment(rfs, file, offset, size, fileChunk.getSectionLayout(), codec,
+            ifileReadAhead, ifileReadAheadLength, preserve, inputContext);
         inputSegments.add(segment);
       }
 
@@ -986,6 +988,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
           serializationContext.getValSerialization(), rfs, outputPath,
           serializationContext.getKeyClass(), serializationContext.getValueClass(), codec, null,
           null, writeBuffer);
+      IFile.SectionLayout outputLayout = null;
       tmpDir = new Path(inputContext.getUniqueIdentifier());
       try {
         TezRawKeyValueIterator iter = TezMerger.merge(conf, rfs,
@@ -1000,6 +1003,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         // the finalMerge (i.e. final mem available may be different from initial merge mem)
         TezMerger.writeFile(iter, writer, progressable, TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);
         writer.close();
+        outputLayout = writer.getSectionLayout();
         additionalSpillBytesWritten.increment(writer.getCompressedLength());
         // writer never used again
       } catch (IOException e) {
@@ -1008,7 +1012,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       }
 
       final long outputLen = localFS.getFileStatus(outputPath).getLen();
-      closeOnDiskFile(new FileChunk(outputPath, 0, outputLen));
+      closeOnDiskFile(new FileChunk(outputPath, 0, outputLen, outputLayout));
 
       LOG.info("{} Finished merging {} map output files on disk of total-size {}. Local output file is {} of size {}",
           inputContext.getSourceVertexName(), inputs.size(), approxOutputSize, outputPath, outputLen);
@@ -1095,6 +1099,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         final Writer writer = new Writer(serContext.getKeySerialization(),
             serContext.getValSerialization(), fs, outputPath, serContext.getKeyClass(),
             serContext.getValueClass(), codec, null, null, writeBuffer);
+        IFile.SectionLayout outputLayout = null;
         try {
           TezMerger.writeFile(rIter, writer, progressable, TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);
         } catch (IOException e) {
@@ -1109,6 +1114,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         } finally {
           if (null != writer) {
             writer.close();
+            outputLayout = writer.getSectionLayout();
             additionalSpillBytesWritten.increment(writer.getCompressedLength());
             // writer never used again
           }
@@ -1116,7 +1122,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
         final FileStatus fStatus = localFS.getFileStatus(outputPath);
         // add to list of final disk outputs.
-        onDiskMapOutputs.add(new FileChunk(outputPath, 0, fStatus.getLen()));
+        onDiskMapOutputs.add(new FileChunk(outputPath, 0, fStatus.getLen(), outputLayout));
 
         if (isDebugEnabled) {
           LOG.debug("MemMerged: Merged " + numMemDiskSegments + "segments, size=" +
@@ -1153,8 +1159,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
       final long fileOffset = fileChunk.getOffset();
       final boolean preserve = fileChunk.isLocalFile();
-      diskSegments.add(new DiskSegment(fs, file, fileOffset, fileLength, codec, ifileReadAhead,
-                                   ifileReadAheadLength, preserve, counter, inputContext));
+      diskSegments.add(new DiskSegment(fs, file, fileOffset, fileLength, fileChunk.getSectionLayout(), codec,
+                                   ifileReadAhead, ifileReadAheadLength, preserve, counter, inputContext));
     }
     if (isDebugEnabled) {
       LOG.debug("DiskSeg: Merging " + onDisk.length + " files, " +

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -870,7 +870,7 @@ public class PipelinedSorter extends ExternalSorter {
             shouldWrite = true;
             DiskSegment s =
                 new DiskSegment(localFs, spillFilename, indexRecord.getStartOffset(),
-                    indexRecord.getPartLength(), codec, ifileReadAhead,
+                    indexRecord.getPartLength(), indexRecord.getLayout(), codec, ifileReadAhead,
                     ifileReadAheadLength, true, outputContext);
             segmentList.add(s);
           }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.RawComparator;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.util.PriorityQueue;
@@ -317,6 +318,7 @@ public class TezMerger {
     Path file = null;
     boolean preserve = false; // Signifies whether the segment should be kept after a merge is complete. Checked in the close method.
     CompressionCodec codec = null;
+    IFile.SectionLayout sectionLayout = null;
     long segmentOffset = 0;
     long segmentLength = -1;
     boolean ifileReadAhead;
@@ -325,33 +327,36 @@ public class TezMerger {
     final DecompressorPool inputContext;
 
     public DiskSegment(FileSystem fs, Path file,
+        IFile.SectionLayout sectionLayout,
         CompressionCodec codec, boolean ifileReadAhead,
         int ifileReadAheadLength, boolean preserve, DecompressorPool inputContext)
     throws IOException {
-      this(fs, file, codec, ifileReadAhead, ifileReadAheadLength,
+      this(fs, file, sectionLayout, codec, ifileReadAhead, ifileReadAheadLength,
           preserve, null, inputContext);
     }
 
     public DiskSegment(FileSystem fs, Path file,
+                   IFile.SectionLayout sectionLayout,
                    CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLenth,
                    boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)
     throws IOException {
-      this(fs, file, 0, fs.getFileStatus(file).getLen(), codec,
+      this(fs, file, 0, fs.getFileStatus(file).getLen(), sectionLayout, codec,
           ifileReadAhead, ifileReadAheadLenth, preserve,
           mergedMapOutputsCounter, inputContext);
     }
 
     public DiskSegment(FileSystem fs, Path file,
                    long segmentOffset, long segmentLength,
+                   IFile.SectionLayout sectionLayout,
                    CompressionCodec codec, boolean ifileReadAhead,
                    int ifileReadAheadLength,
                    boolean preserve, DecompressorPool inputContext) throws IOException {
-      this(fs, file, segmentOffset, segmentLength, codec, ifileReadAhead,
+      this(fs, file, segmentOffset, segmentLength, sectionLayout, codec, ifileReadAhead,
           ifileReadAheadLength, preserve, null, inputContext);
     }
 
     public DiskSegment(FileSystem fs, Path file,
-        long segmentOffset, long segmentLength, CompressionCodec codec,
+        long segmentOffset, long segmentLength, IFile.SectionLayout sectionLayout, CompressionCodec codec,
         boolean ifileReadAhead, int ifileReadAheadLength,
         boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)
     throws IOException {
@@ -359,6 +364,7 @@ public class TezMerger {
       this.fs = fs;
       this.file = file;
       this.codec = codec;
+      this.sectionLayout = sectionLayout;
       this.preserve = preserve;
       this.ifileReadAhead = ifileReadAhead;
       this.ifileReadAheadLength = ifileReadAheadLength;
@@ -372,10 +378,35 @@ public class TezMerger {
     @Override
     void init(TezCounter readsCounter, TezCounter bytesReadCounter) throws IOException {
       super.init(readsCounter, bytesReadCounter);
-      FSDataInputStream in = fs.open(file);
-      in.seek(segmentOffset);
-      reader = new Reader(in, segmentLength, codec, readsCounter, bytesReadCounter, ifileReadAhead,
-          ifileReadAheadLength, inputContext);
+      if (sectionLayout == null) {
+        throw new IOException("SectionLayout is required for DiskSegment: file=" + file
+            + ", offset=" + segmentOffset + ", length=" + segmentLength);
+      }
+
+      FSDataInputStream headerValuesIn = null;
+      FSDataInputStream keysIn = null;
+      FSDataInputStream lengthsIn = null;
+      boolean success = false;
+      try {
+        headerValuesIn = fs.open(file);
+        headerValuesIn.seek(segmentOffset);
+
+        keysIn = fs.open(file);
+        keysIn.seek(segmentOffset + sectionLayout.keysStart);
+
+        lengthsIn = fs.open(file);
+        lengthsIn.seek(segmentOffset + sectionLayout.lengthsStart);
+
+        reader = new Reader(headerValuesIn, keysIn, lengthsIn, sectionLayout, codec,
+            readsCounter, bytesReadCounter, ifileReadAhead, ifileReadAheadLength, inputContext);
+        success = true;
+      } finally {
+        if (!success) {
+          IOUtils.closeStream(headerValuesIn);
+          IOUtils.closeStream(keysIn);
+          IOUtils.closeStream(lengthsIn);
+        }
+      }
     }
 
     @Override
@@ -411,6 +442,7 @@ public class TezMerger {
         closeReader();
         segmentOffset = offset;
         segmentLength = fs.getFileStatus(file).getLen() - segmentOffset;
+        sectionLayout = null;
         init(null, null);
       }
     }
@@ -763,6 +795,9 @@ public class TezMerger {
 
           writeFile(this, writer, reporter, recordsBeforeProgress);
           writer.close();
+          // Merge passes emit a three-section IFile, so preserve the section metadata
+          // produced on close and carry it into the follow-on DiskSegment reader.
+          final IFile.SectionLayout mergedLayout = writer.getSectionLayout();
           // writer never used again
           
           //we finished one single level merge; now clean up the priority 
@@ -771,7 +806,7 @@ public class TezMerger {
 
           // Add the newly create segment to the list of segments to be merged
           Segment tempSegment = 
-            new DiskSegment(fs, outputFile, codec, ifileReadAhead,
+            new DiskSegment(fs, outputFile, mergedLayout, codec, ifileReadAhead,
                 ifileReadAheadLength, false, inputContext);
 
           // Insert new merged segment into the sorted list


### PR DESCRIPTION
### Motivation
- Preserve the three-section IFile layout produced by writers so downstream merges and DiskSegment readers can initialize correctly with section offsets.
- Ensure merged/spill files carry `IFile.SectionLayout` metadata through `FileChunk` and `MapOutput` so `DiskSegment` can open the proper streams and construct the `IFile.Reader`.

### Description
- Added a `sectionLayout` field, constructors, and `getSectionLayout()` to `FileChunk` and updated call sites to populate it where writers produce layout metadata.
- Propagated the `IFile.SectionLayout` from `Writer.getSectionLayout()` in `MergeManager` and merge code paths to newly created `FileChunk` instances used for downstream merges and on-disk outputs.
- Updated `MapOutput` implementations to carry `sectionLayout` and return `FileChunk` instances that include the layout, and adjusted `commit()`/`closeOnDiskFile()` calls to use the updated `getOutputPath()` where appropriate.
- Reworked `TezMerger.DiskSegment` to accept a `sectionLayout`, to open separate `FSDataInputStream`s positioned at the three section offsets and to construct the `IFile.Reader` with the layout, and added defensive stream close via `IOUtils.closeStream` on failure; also ensured `reinitReader` resets the layout.
- Adjusted `PipelinedSorter` to pass `indexRecord.getLayout()` into created `DiskSegment`s so sort/merge readers receive the layout.

### Testing
- Ran the runtime library unit tests for the `tez-runtime-library` module using `mvn -pl tez-runtime-library -DskipTests=false test` and the module build, and the tests completed successfully.
- Ran the merge/sort unit tests exercising `TezMerger`/`MergeManager` paths and they passed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69badb65e9c4832891dd4b79b7134c23)