### PR TITLE
Propagate IFile.SectionLayout through MapOutput/Fetcher/Merge and make sectionLayout immutable

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/hadoop/io/FileChunk.java
+++ b/tez-runtime-library/src/main/java/org/apache/hadoop/io/FileChunk.java
@@ -31,7 +31,7 @@ public class FileChunk implements Comparable<FileChunk> {
   private final boolean isLocalFile;
   private final Path path;
   private final InputAttemptIdentifier identifier;
-  private IFile.SectionLayout sectionLayout;
+  private final IFile.SectionLayout sectionLayout;
 
   public FileChunk(Path path, long offset, long length, IFile.SectionLayout sectionLayout) {
     this(path, offset, length, false, null, sectionLayout);
@@ -115,9 +115,5 @@ public class FileChunk implements Comparable<FileChunk> {
 
   public IFile.SectionLayout getSectionLayout() {
     return sectionLayout;
-  }
-
-  public void setSectionLayout(IFile.SectionLayout sectionLayout) {
-    this.sectionLayout = sectionLayout;
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetchedInputAllocatorOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetchedInputAllocatorOrderedGrouped.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.io.FileChunk;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.sort.impl.IFile;
 
 public interface FetchedInputAllocatorOrderedGrouped {
 
@@ -26,7 +27,8 @@ public interface FetchedInputAllocatorOrderedGrouped {
   public MapOutput reserve(InputAttemptIdentifier srcAttemptIdentifier,
                            long requestedSize,
                            long compressedLength,
-                           int fetcherId) throws IOException;
+                           int fetcherId,
+                           IFile.SectionLayout sectionLayout) throws IOException;
 
   void closeInMemoryFile(MapOutput mapOutput);
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -573,7 +573,8 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         decompressedLength = mapOutputStat.decompressedLength;
         compressedLength = mapOutputStat.compressedLength;
         try {
-          mapOutput = allocator.reserve(srcAttemptId, decompressedLength, compressedLength, fetcherIdentifier);
+          mapOutput = allocator.reserve(srcAttemptId, decompressedLength, compressedLength,
+              fetcherIdentifier, mapOutputStat.layout);
         } catch (IOException e) {
           if (!stopped) {
             // Kill the reduce attempt
@@ -587,8 +588,6 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
           }
           return EMPTY_ATTEMPT_ID_ARRAY;
         }
-        mapOutput.setSectionLayout(mapOutputStat.layout);
-
         // Check if we can shuffle *now* ...
         if (mapOutput.getType() == Type.WAIT) {
           LOG.info("{}: MergerManager returned Status.WAIT...", logIdentifier);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -46,22 +46,24 @@ public abstract class MapOutput implements ShuffleInput {
 
   private final int id;
   private InputAttemptIdentifier attemptIdentifier;
-  private IFile.SectionLayout sectionLayout;
+  private final IFile.SectionLayout sectionLayout;
 
   private final boolean primaryMapOutput;
   protected final FetchedInputAllocatorOrderedGrouped callback;
 
   private MapOutput(InputAttemptIdentifier attemptIdentifier, FetchedInputAllocatorOrderedGrouped callback,
-                    boolean primaryMapOutput) {
+                    boolean primaryMapOutput, IFile.SectionLayout sectionLayout) {
     this.id = ID.incrementAndGet();
     this.attemptIdentifier = attemptIdentifier;
     this.callback = callback;
     this.primaryMapOutput = primaryMapOutput;
+    this.sectionLayout = sectionLayout;
   }
 
   public static MapOutput createDiskMapOutput(InputAttemptIdentifier attemptIdentifier,
                                               FetchedInputAllocatorOrderedGrouped callback, long size, Configuration conf,
                                               int fetcher, boolean primaryMapOutput,
+                                              IFile.SectionLayout sectionLayout,
                                               TezTaskOutputFiles mapOutputFile) throws
       IOException {
     FileSystem fs = FileSystem.getLocal(conf).getRaw();
@@ -75,7 +77,7 @@ public abstract class MapOutput implements ShuffleInput {
     long offset = 0;
 
     DiskMapOutput mapOutput = new DiskMapOutput(attemptIdentifier, callback, size, outputPath, offset,
-        primaryMapOutput, tmpOutputPath);
+        primaryMapOutput, sectionLayout, tmpOutputPath);
     mapOutput.disk = fs.create(tmpOutputPath);
 
     return mapOutput;
@@ -86,8 +88,8 @@ public abstract class MapOutput implements ShuffleInput {
                                                    long size, boolean primaryMapOutput,
                                                    IFile.SectionLayout sectionLayout)  {
     DiskDirectMapOutput mapOutput =
-        new DiskDirectMapOutput(attemptIdentifier, callback, size, path, offset, primaryMapOutput);
-    mapOutput.setSectionLayout(sectionLayout);
+        new DiskDirectMapOutput(attemptIdentifier, callback, size, path, offset, primaryMapOutput,
+            sectionLayout);
     return mapOutput;
   }
 
@@ -96,8 +98,10 @@ public abstract class MapOutput implements ShuffleInput {
                                                 FetchedInputAllocatorOrderedGrouped callback,
                                                 long usedMemoryForMergeManger,
                                                 long size,
-                                                boolean primaryMapOutput)  {
-    return new InMemoryMapOutput(attemptIdentifier, callback, usedMemoryForMergeManger, size, primaryMapOutput);
+                                                boolean primaryMapOutput,
+                                                IFile.SectionLayout sectionLayout)  {
+    return new InMemoryMapOutput(attemptIdentifier, callback, usedMemoryForMergeManger, size,
+        primaryMapOutput, sectionLayout);
   }
 
   public static MapOutput createWaitMapOutput(InputAttemptIdentifier attemptIdentifier) {
@@ -143,14 +147,6 @@ public abstract class MapOutput implements ShuffleInput {
     return sectionLayout;
   }
 
-  public void setSectionLayout(IFile.SectionLayout sectionLayout) {
-    this.sectionLayout = sectionLayout;
-    FileChunk outputPath = getOutputPath();
-    if (outputPath != null) {
-      outputPath.setSectionLayout(sectionLayout);
-    }
-  }
-
   public long getSize() {
     return -1;
   }
@@ -193,9 +189,10 @@ public abstract class MapOutput implements ShuffleInput {
   private static class DiskDirectMapOutput extends MapOutput {
     private final FileChunk outputPath;
     private DiskDirectMapOutput(InputAttemptIdentifier attemptIdentifier, FetchedInputAllocatorOrderedGrouped callback,
-                      long size, Path outputPath, long offset, boolean primaryMapOutput) {
-      super(attemptIdentifier, callback, primaryMapOutput);
-      this.outputPath = new FileChunk(outputPath, offset, size, true, attemptIdentifier, null);
+                      long size, Path outputPath, long offset, boolean primaryMapOutput,
+                      IFile.SectionLayout sectionLayout) {
+      super(attemptIdentifier, callback, primaryMapOutput, sectionLayout);
+      this.outputPath = new FileChunk(outputPath, offset, size, true, attemptIdentifier, sectionLayout);
     }
 
     @Override
@@ -229,12 +226,13 @@ public abstract class MapOutput implements ShuffleInput {
     private final FileChunk outputPath;
     private OutputStream disk;
     private DiskMapOutput(InputAttemptIdentifier attemptIdentifier, FetchedInputAllocatorOrderedGrouped callback,
-                                long size, Path outputPath, long offset, boolean primaryMapOutput, Path tmpOutputPath) {
-      super(attemptIdentifier, callback, primaryMapOutput);
+                                long size, Path outputPath, long offset, boolean primaryMapOutput,
+                                IFile.SectionLayout sectionLayout, Path tmpOutputPath) {
+      super(attemptIdentifier, callback, primaryMapOutput, sectionLayout);
 
       this.tmpOutputPath = tmpOutputPath;
       this.disk = null;
-      this.outputPath = new FileChunk(outputPath, offset, size, false, attemptIdentifier, null);
+      this.outputPath = new FileChunk(outputPath, offset, size, false, attemptIdentifier, sectionLayout);
     }
 
     @Override
@@ -281,8 +279,9 @@ public abstract class MapOutput implements ShuffleInput {
     private InMemoryMapOutput(InputAttemptIdentifier attemptIdentifier,
                               FetchedInputAllocatorOrderedGrouped callback,
                               long usedMemoryForMergeManger,
-                              long size, boolean primaryMapOutput) {
-      super(attemptIdentifier, callback, primaryMapOutput);
+                              long size, boolean primaryMapOutput,
+                              IFile.SectionLayout sectionLayout) {
+      super(attemptIdentifier, callback, primaryMapOutput, sectionLayout);
       this.byteArray = new byte[(int)size];
       this.usedMemoryForMergeManger = usedMemoryForMergeManger;
       assert usedMemoryForMergeManger == size || usedMemoryForMergeManger == 0L;
@@ -321,7 +320,7 @@ public abstract class MapOutput implements ShuffleInput {
 
   private static class WaitMapOutput extends MapOutput {
     private WaitMapOutput(InputAttemptIdentifier attemptIdentifier) {
-      super(attemptIdentifier, null, false);
+      super(attemptIdentifier, null, false, null);
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -403,11 +403,12 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       InputAttemptIdentifier srcAttemptIdentifier,
       long requestedSize,
       long compressedLength,
-      int fetcher) throws IOException {
+      int fetcher,
+      IFile.SectionLayout sectionLayout) throws IOException {
     if (!canShuffleToMemory(requestedSize)) {
       LOG.info("Creating DiskMapOutput for {}: {} > maxSingleShuffleLimit", srcAttemptIdentifier, requestedSize);
       return MapOutput.createDiskMapOutput(srcAttemptIdentifier, this, compressedLength, conf,
-          fetcher, true, mapOutputFile);
+          fetcher, true, sectionLayout, mapOutputFile);
     }
     
     // Stall shuffle if we are above the memory limit
@@ -448,7 +449,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         }
         try {
           // usedMemoryForMergeManager = 0 because this MemoryMapOutput should not contribute to usedMemory
-          return unconditionalReserve(srcAttemptIdentifier, 0L, requestedSize, true);
+          return unconditionalReserve(srcAttemptIdentifier, 0L, requestedSize, true, sectionLayout);
         } catch (OutOfMemoryError oom) {
           LOG.error("Failed to created MemoryMapOutput, stalling instead: {}, {}",
             this.usedMemory, requestedSize, oom);
@@ -462,13 +463,14 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         }
         try {
           // usedMemoryForMergeManager == requestedSize
-          return unconditionalReserve(srcAttemptIdentifier, requestedSize, requestedSize, true);
+          return unconditionalReserve(srcAttemptIdentifier, requestedSize, requestedSize, true,
+              sectionLayout);
         } catch (OutOfMemoryError oom) {
           LOG.error("Failed to created MemoryMapOutput, returning DiskMapOutput instead: {}, {}",
             this.usedMemory, requestedSize, oom);
           // TODO: can we return stallShuffle without stalling all Fetchers?
           return MapOutput.createDiskMapOutput(srcAttemptIdentifier, this, compressedLength, conf,
-              fetcher, true, mapOutputFile);
+              fetcher, true, sectionLayout, mapOutputFile);
         }
       }
     }
@@ -484,10 +486,12 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       InputAttemptIdentifier srcAttemptIdentifier,
       long usedMemoryForMergeManager,
       long requestedSize,
-      boolean primaryMapOutput) {
+      boolean primaryMapOutput,
+      IFile.SectionLayout sectionLayout) {
     // createMemoryMapOutput() may throw OOM, so increase usedMemory only if successful
     MapOutput result = MapOutput.createMemoryMapOutput(
-        srcAttemptIdentifier, this, usedMemoryForMergeManager, requestedSize, primaryMapOutput);
+        srcAttemptIdentifier, this, usedMemoryForMergeManager, requestedSize, primaryMapOutput,
+        sectionLayout);
     this.usedMemory += usedMemoryForMergeManager;
     return result;
   }
@@ -751,7 +755,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
         try {
           // usedMemoryForMergeManager == mergeOutputSize
-          mergedMapOutputs = unconditionalReserve(dummyMapId, mergeOutputSize, mergeOutputSize, false);
+          mergedMapOutputs = unconditionalReserve(dummyMapId, mergeOutputSize, mergeOutputSize, false,
+              null);
         } catch (OutOfMemoryError err) {
           throw new IOException("Cannot perform merging in MemoryToMemoryMerger - do not use Memory-to-Memory merging", err);
         }


### PR DESCRIPTION
### Motivation

- Ensure the `IFile.SectionLayout` is known at creation time for map outputs and file chunks so the layout is consistently used during fetch/shuffle/merge operations.
- Remove mutation of section layout to avoid races and accidental later changes by making the layout field immutable.
- Thread the `SectionLayout` through allocator/fetcher APIs so the merge and shuffle paths always receive the correct layout information.

### Description

- Made `FileChunk.sectionLayout` and `MapOutput.sectionLayout` `final` and removed the `setSectionLayout` mutator to enforce immutability.
- Updated `MapOutput` constructors and factory methods (`createDiskMapOutput`, `createLocalDiskMapOutput`, `createMemoryMapOutput`) to accept and pass `IFile.SectionLayout` through to specific `MapOutput` implementations (`DiskMapOutput`, `DiskDirectMapOutput`, `InMemoryMapOutput`).
- Extended `FetchedInputAllocatorOrderedGrouped.reserve` signature to accept `IFile.SectionLayout` and updated `MergeManager` to pass the layout into `unconditionalReserve` and `create*MapOutput` calls.
- Updated `FetcherOrderedGrouped` to pass `mapOutputStat.layout` when reserving map outputs and removed subsequent calls to `setSectionLayout`.

### Testing

- Built the runtime library module with `mvn -pl tez-runtime-library -am test` to validate compilation of the changed APIs and call sites, and the build completed successfully.
- Ran the module unit tests for `tez-runtime-library` via Maven and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae7feeb408328bf583466e20d497b)