### PR TITLE
Refactor DiskSegment to use a single general constructor

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -961,8 +961,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         }
         final Path file = fileChunk.getPath();
         approxOutputSize += size;
-        DiskSegment segment = new DiskSegment(rfs, file, offset, size, fileChunk.getSectionLayout(), codec,
-            ifileReadAhead, ifileReadAheadLength, preserve, inputContext);
+        DiskSegment segment = new DiskSegment(rfs, file, offset, size,
+            fileChunk.getSectionLayout(), codec, ifileReadAhead, ifileReadAheadLength,
+            preserve, null, inputContext);
         inputSegments.add(segment);
       }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -871,7 +871,7 @@ public class PipelinedSorter extends ExternalSorter {
             DiskSegment s =
                 new DiskSegment(localFs, spillFilename, indexRecord.getStartOffset(),
                     indexRecord.getPartLength(), indexRecord.getLayout(), codec, ifileReadAhead,
-                    ifileReadAheadLength, true, outputContext);
+                    ifileReadAheadLength, true, null, outputContext);
             segmentList.add(s);
           }
         }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -327,35 +327,6 @@ public class TezMerger {
     final DecompressorPool inputContext;
 
     public DiskSegment(FileSystem fs, Path file,
-        IFile.SectionLayout sectionLayout,
-        CompressionCodec codec, boolean ifileReadAhead,
-        int ifileReadAheadLength, boolean preserve, DecompressorPool inputContext)
-    throws IOException {
-      this(fs, file, sectionLayout, codec, ifileReadAhead, ifileReadAheadLength,
-          preserve, null, inputContext);
-    }
-
-    public DiskSegment(FileSystem fs, Path file,
-                   IFile.SectionLayout sectionLayout,
-                   CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLenth,
-                   boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)
-    throws IOException {
-      this(fs, file, 0, fs.getFileStatus(file).getLen(), sectionLayout, codec,
-          ifileReadAhead, ifileReadAheadLenth, preserve,
-          mergedMapOutputsCounter, inputContext);
-    }
-
-    public DiskSegment(FileSystem fs, Path file,
-                   long segmentOffset, long segmentLength,
-                   IFile.SectionLayout sectionLayout,
-                   CompressionCodec codec, boolean ifileReadAhead,
-                   int ifileReadAheadLength,
-                   boolean preserve, DecompressorPool inputContext) throws IOException {
-      this(fs, file, segmentOffset, segmentLength, sectionLayout, codec, ifileReadAhead,
-          ifileReadAheadLength, preserve, null, inputContext);
-    }
-
-    public DiskSegment(FileSystem fs, Path file,
         long segmentOffset, long segmentLength, IFile.SectionLayout sectionLayout, CompressionCodec codec,
         boolean ifileReadAhead, int ifileReadAheadLength,
         boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)
@@ -806,8 +777,9 @@ public class TezMerger {
 
           // Add the newly create segment to the list of segments to be merged
           Segment tempSegment = 
-            new DiskSegment(fs, outputFile, mergedLayout, codec, ifileReadAhead,
-                ifileReadAheadLength, false, inputContext);
+            new DiskSegment(fs, outputFile, 0, fs.getFileStatus(outputFile).getLen(),
+                mergedLayout, codec, ifileReadAhead, ifileReadAheadLength, false, null,
+                inputContext);
 
           // Insert new merged segment into the sorted list
           int pos = Collections.binarySearch(segments, tempSegment,


### PR DESCRIPTION
### Motivation
- Simplify `TezMerger.DiskSegment` API by removing redundant convenience constructors and force all call sites to use the most general constructor with explicit offsets and counters.

### Description
- Remove the shorter `DiskSegment` overloads in `tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java` so only the general constructor with `segmentOffset`, `segmentLength`, `sectionLayout`, `codec`, `ifileReadAhead`, `ifileReadAheadLength`, `preserve`, `mergedMapOutputsCounter`, and `inputContext` remains.
- Update `TezMerger` to construct follow-on merged segments with explicit file-length lookup via `0, fs.getFileStatus(outputFile).getLen()` and an explicit `null` `mergedMapOutputsCounter` where appropriate.
- Update call sites in `PipelinedSorter` and `MergeManager` to pass the full argument list to the general constructor, making previously implicit `mergedMapOutputsCounter` values explicit (passing `null` when needed).
- Changes affect `TezMerger.java`, `PipelinedSorter.java`, and `MergeManager.java` and preserve the existing merged-section layout flow by carrying the `IFile.SectionLayout` through into the general constructor.

### Testing
- Ran the repository search commands `rg -n "public DiskSegment\("` and `rg -n "new DiskSegment\("` to verify the removed constructors and updated call sites, and these reflected only the single general constructor and updated usages.
- Attempted `mvn -pl tez-runtime-library -am -DskipTests compile`, which executed but failed due to external Maven plugin resolution (HTTP 403 fetching `org.codehaus.mojo:buildnumber-maven-plugin:1.1` from `https://maven.atlassian.com/repository/public`), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6641ee9c8328a92a9807e8e1a010)