### PR TITLE
Consolidate TezMerger.merge overloads and MergeQueue constructors

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -781,10 +781,11 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       TezRawKeyValueIterator rIter = 
         TezMerger.merge(conf, rfs,
                        serializationContext,
-                       inMemorySegments, inMemorySegments.size(),
+                       null, inMemorySegments, inMemorySegments.size(), 0,
                        new Path(inputContext.getUniqueIdentifier()),
                        (RawComparator)ConfigUtils.getIntermediateInputKeyComparator(conf),
-                       progressable, null, null, null, null, inputContext);
+                       progressable, false, false, null, null, null, null, true,
+                       inputContext);
       TezMerger.writeFile(rIter, writer, progressable, TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);
       writer.close();
       mergedMapOutputs.setSectionLayout(writer.getSectionLayout());
@@ -871,9 +872,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         // Nothing actually materialized to disk - controlled by setting sort-factor to #segments.
         rIter = TezMerger.merge(conf, rfs,
             serializationContext,
-            inMemorySegments, inMemorySegments.size(),
+            null, inMemorySegments, inMemorySegments.size(), 0,
             tmpDir, (RawComparator)ConfigUtils.getIntermediateInputKeyComparator(conf),
-            progressable, spilledRecordsCounter, null, additionalSpillBytesRead, null, inputContext);
+            progressable, false, false, spilledRecordsCounter, null,
+            additionalSpillBytesRead, null, true, inputContext);
         // spilledRecordsCounter is tracking the number of keys that will be
         // read from each of the segments being merged - which is essentially
         // what will be written to disk.
@@ -1000,11 +1002,11 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       try {
         TezRawKeyValueIterator iter = TezMerger.merge(conf, rfs,
             serializationContext,
-            inputSegments,
-            ioSortFactor, tmpDir,
+            null, inputSegments,
+            ioSortFactor, 0, tmpDir,
             (RawComparator)ConfigUtils.getIntermediateInputKeyComparator(conf),
-            progressable, true, spilledRecordsCounter, null,
-            mergedMapOutputsCounter, null, inputContext);
+            progressable, true, false, spilledRecordsCounter, null,
+            mergedMapOutputsCounter, null, true, inputContext);
 
         // TODO Maybe differentiate between data written because of Merges and
         // the finalMerge (i.e. final mem available may be different from initial merge mem)
@@ -1100,8 +1102,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         final Path outputPath = mapOutputFile.getInputFileForWrite(
             srcTaskId, Integer.MAX_VALUE, inMemToDiskBytes).suffix(Constants.MERGED_OUTPUT_PREFIX);
         final TezRawKeyValueIterator rIter = TezMerger.merge(job, fs, serContext,
-            memDiskSegments, numMemDiskSegments, tmpDir, comparator, progressable,
-            spilledRecordsCounter, null, additionalSpillBytesRead, null, inputContext);
+            null, memDiskSegments, numMemDiskSegments, 0, tmpDir, comparator, progressable,
+            false, false, spilledRecordsCounter, null, additionalSpillBytesRead, null,
+            true, inputContext);
         final byte[] writeBuffer = IFile.allocateWriteBuffer();
         final Writer writer = new Writer(serContext.getKeySerialization(),
             serContext.getValSerialization(), fs, outputPath, serContext.getKeyClass(),
@@ -1197,7 +1200,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       TezRawKeyValueIterator diskMerge = TezMerger.merge(
           job, fs, serContext, codec, diskSegments,
           ioSortFactor, numInMemSegments, tmpDir, comparator,
-          progressable, false, spilledRecordsCounter, null, additionalSpillBytesRead, null, inputContext);
+          progressable, false, false, spilledRecordsCounter, null, additionalSpillBytesRead,
+          null, true, inputContext);
       diskSegments.clear();
       if (finalSegments.isEmpty()) {
         return diskMerge;
@@ -1207,9 +1211,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     }
     // This is doing nothing but creating an iterator over the segments.
     return TezMerger.merge(job, fs, serContext, codec,
-        finalSegments, finalSegments.size(), tmpDir,
-        comparator, progressable, spilledRecordsCounter, null,
-      additionalSpillBytesRead, null, inputContext);
+        finalSegments, finalSegments.size(), 0, tmpDir,
+        comparator, progressable, false, false, spilledRecordsCounter, null,
+      additionalSpillBytesRead, null, false, inputContext);
   }
 
   private void logFinalMergeStart(List<MapOutput> inMemoryMapOutputs,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -883,7 +883,7 @@ public class PipelinedSorter extends ExternalSorter {
         //merge
         TezRawKeyValueIterator kvIter = TezMerger.merge(conf, localFs,
             serializationContext, codec,
-            segmentList, mergeFactor,
+            segmentList, mergeFactor, 0,
             new Path(uniqueIdentifier),
             (RawComparator) ConfigUtils.getIntermediateOutputKeyComparator(conf),
             progressable, sortSegments, true,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.tez.runtime.api.DecompressorPool;
-import org.apache.tez.runtime.api.InputContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -65,63 +64,12 @@ public class TezMerger {
     new LocalDirAllocator(TezRuntimeFrameworkConfigs.LOCAL_DIRS);
 
   // Used by the in-memory merger.
-  public static
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs, 
-                            SerializationContext serializationContext,
-                            List<Segment> segments, 
-                            int mergeFactor, Path tmpDir,
-                            RawComparator comparator, Progressable reporter,
-                            TezCounter readsCounter,
-                            TezCounter writesCounter,
-                            TezCounter bytesReadCounter,
-                            Progress mergePhase, DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    // Get rid of this ?
-    return merge(conf, fs, serializationContext, segments, mergeFactor, tmpDir,
-                 comparator, reporter, false, readsCounter, writesCounter, bytesReadCounter,
-                 mergePhase, inputContext);
-  }
-
-  public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-                            SerializationContext serializationContext,
-                            List<Segment> segments,
-                            int mergeFactor, Path tmpDir,
-                            RawComparator comparator, Progressable reporter,
-                            boolean sortSegments,
-                            TezCounter readsCounter,
-                            TezCounter writesCounter,
-                            TezCounter bytesReadCounter,
-                            Progress mergePhase, DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-                           sortSegments, false).merge(serializationContext, mergeFactor, tmpDir,
-                                               readsCounter, writesCounter,
-                                               bytesReadCounter, mergePhase, inputContext);
-  }
-
-  public static TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-      SerializationContext serializationContext,
-      CompressionCodec codec,
-      List<Segment> segments,
-      int mergeFactor, Path tmpDir,
-      RawComparator comparator, Progressable reporter,
-      TezCounter readsCounter,
-      TezCounter writesCounter,
-      TezCounter bytesReadCounter,
-      Progress mergePhase, DecompressorPool inputContext) throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-        false, codec, false, false)
-        .merge(serializationContext, mergeFactor, tmpDir,
-            readsCounter, writesCounter, bytesReadCounter, mergePhase, inputContext);
-  }
-
   public static <K extends Object, V extends Object>
   TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
       SerializationContext serializationContext,
       CompressionCodec codec,
       List<Segment> segments,
-      int mergeFactor, Path tmpDir,
+      int mergeFactor, int inMemSegments, Path tmpDir,
       RawComparator comparator, Progressable reporter,
       boolean sortSegments,
       boolean considerFinalMergeForProgress,
@@ -131,57 +79,10 @@ public class TezMerger {
       Progress mergePhase, boolean checkForSameKeys, DecompressorPool inputContext)
       throws IOException, InterruptedException {
     return new MergeQueue(conf, fs, segments, comparator, reporter,
-        sortSegments, codec, considerFinalMergeForProgress, checkForSameKeys).
-        merge(serializationContext,
-            mergeFactor, tmpDir,
-            readsCounter, writesCounter,
-            bytesReadCounter,
-            mergePhase, inputContext);
+        sortSegments, codec, considerFinalMergeForProgress, checkForSameKeys)
+        .merge(serializationContext, mergeFactor, inMemSegments, tmpDir,
+            readsCounter, writesCounter, bytesReadCounter, mergePhase, inputContext);
   }
-
-  public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-                            SerializationContext serializationContext,
-                            CompressionCodec codec,
-                            List<Segment> segments,
-                            int mergeFactor, Path tmpDir,
-                            RawComparator comparator, Progressable reporter,
-                            boolean sortSegments,
-                            boolean considerFinalMergeForProgress,
-                            TezCounter readsCounter,
-                            TezCounter writesCounter,
-                            TezCounter bytesReadCounter,
-                            Progress mergePhase, DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-                           sortSegments, codec, considerFinalMergeForProgress).
-                                         merge(serializationContext, mergeFactor, tmpDir,
-                                             readsCounter, writesCounter,
-                                             bytesReadCounter,
-                                             mergePhase, inputContext);
-  }
-
-  public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-                          SerializationContext serializationContext,
-                          CompressionCodec codec,
-                          List<Segment> segments,
-                          int mergeFactor, int inMemSegments, Path tmpDir,
-                          RawComparator comparator, Progressable reporter,
-                          boolean sortSegments,
-                          TezCounter readsCounter,
-                          TezCounter writesCounter,
-                          TezCounter bytesReadCounter,
-                          Progress mergePhase, InputContext inputContext)
-      throws IOException, InterruptedException {
-  return new MergeQueue(conf, fs, segments, comparator, reporter,
-                         sortSegments, codec, false).merge(serializationContext,
-                                             mergeFactor, inMemSegments,
-                                             tmpDir,
-                                             readsCounter, writesCounter,
-                                             bytesReadCounter,
-                                             mergePhase, inputContext);
-}
 
   public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppend writer,
       Progressable progressable, long recordsBeforeProgress)
@@ -429,21 +330,6 @@ public class TezMerger {
     KeyState hasNext;
     boolean sameKey = false;
     DataOutputBuffer prevKey = new DataOutputBuffer();
-
-    public MergeQueue(Configuration conf, FileSystem fs,
-        List<Segment> segments, RawComparator comparator,
-        Progressable reporter, boolean sortSegments, boolean considerFinalMergeForProgress) {
-      this(conf, fs, segments, comparator, reporter, sortSegments, null,
-          considerFinalMergeForProgress);
-    }
-
-    public MergeQueue(Configuration conf, FileSystem fs,
-        List<Segment> segments, RawComparator comparator,
-        Progressable reporter, boolean sortSegments, CompressionCodec codec,
-        boolean considerFinalMergeForProgress) {
-      this(conf, fs, segments, comparator, reporter, sortSegments, codec,
-          considerFinalMergeForProgress, true);
-    }
 
     public MergeQueue(Configuration conf, FileSystem fs,
         List<Segment> segments, RawComparator comparator,


### PR DESCRIPTION
### Motivation
- Reduce duplication by keeping a single, most-general `TezMerger.merge(...)` entrypoint and a single fully-parameterized `MergeQueue` constructor to simplify maintenance and make caller behavior explicit.
- Make callers pass explicit defaults instead of relying on multiple overloaded helpers so the merge behavior is more visible and easier to reason about.

### Description
- Removed redundant `MergeQueue` constructor overloads and left only the fully-parameterized constructor that includes `CompressionCodec`, `considerFinalMergeForProgress`, and `checkForSameKeys` parameters so all construction goes through one implementation path.
- Collapsed `TezMerger.merge(...)` static overloads into one most-general overload (adds `codec`, `inMemSegments`, `considerFinalMergeForProgress`, `checkForSameKeys`, etc.) and made it the single implementation target.
- Updated call sites in `MergeManager` and `PipelinedSorter` to call the new general `TezMerger.merge(...)` and pass explicit default values to preserve previous behavior.
- Removed an unused `InputContext` import from `TezMerger`.

### Testing
- Ran code searches (`rg`) to verify all `TezMerger.merge(...)` call sites were updated and `MergeQueue` constructors removed, which succeeded.
- Ran `git diff --check` to ensure no whitespace/patch errors, which succeeded.
- Attempted to compile the module with `mvn -pl tez-runtime-library -am -DskipTests compile` (and with `-Dbuildnumber.skip=true`), but the Maven build failed in this environment due to external plugin resolution: `org.codehaus.mojo:buildnumber-maven-plugin:1.1` could not be fetched from the configured Atlassian repository (HTTP 403), so a full compile could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba408263c8328806eac40d65e5f86)