### PR TITLE
Consolidate MergeQueue constructors and centralize TezMerger.merge delegation

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -93,10 +93,9 @@ public class TezMerger {
                             TezCounter bytesReadCounter,
                             Progress mergePhase, DecompressorPool inputContext)
       throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-                           sortSegments, false).merge(serializationContext, mergeFactor, tmpDir,
-                                               readsCounter, writesCounter,
-                                               bytesReadCounter, mergePhase, inputContext);
+    return merge(conf, fs, serializationContext, null, segments, mergeFactor, tmpDir,
+        comparator, reporter, sortSegments, false, readsCounter, writesCounter,
+        bytesReadCounter, mergePhase, true, inputContext);
   }
 
   public static TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
@@ -109,10 +108,9 @@ public class TezMerger {
       TezCounter writesCounter,
       TezCounter bytesReadCounter,
       Progress mergePhase, DecompressorPool inputContext) throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-        false, codec, false, false)
-        .merge(serializationContext, mergeFactor, tmpDir,
-            readsCounter, writesCounter, bytesReadCounter, mergePhase, inputContext);
+    return merge(conf, fs, serializationContext, codec, segments, mergeFactor, tmpDir,
+        comparator, reporter, false, false, readsCounter, writesCounter,
+        bytesReadCounter, mergePhase, false, inputContext);
   }
 
   public static <K extends Object, V extends Object>
@@ -129,13 +127,10 @@ public class TezMerger {
       TezCounter bytesReadCounter,
       Progress mergePhase, boolean checkForSameKeys, DecompressorPool inputContext)
       throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-        sortSegments, codec, considerFinalMergeForProgress, checkForSameKeys).
-        merge(serializationContext,
-            mergeFactor, tmpDir,
-            readsCounter, writesCounter,
-            bytesReadCounter,
-            mergePhase, inputContext);
+    return merge(conf, fs, serializationContext, codec, segments, mergeFactor, 0,
+        tmpDir, comparator, reporter, sortSegments,
+        considerFinalMergeForProgress, readsCounter, writesCounter,
+        bytesReadCounter, mergePhase, checkForSameKeys, inputContext);
   }
 
   public static <K extends Object, V extends Object>
@@ -152,12 +147,10 @@ public class TezMerger {
                             TezCounter bytesReadCounter,
                             Progress mergePhase, DecompressorPool inputContext)
       throws IOException, InterruptedException {
-    return new MergeQueue(conf, fs, segments, comparator, reporter,
-                           sortSegments, codec, considerFinalMergeForProgress).
-                                         merge(serializationContext, mergeFactor, tmpDir,
-                                             readsCounter, writesCounter,
-                                             bytesReadCounter,
-                                             mergePhase, inputContext);
+    return merge(conf, fs, serializationContext, codec, segments, mergeFactor, tmpDir,
+        comparator, reporter, sortSegments, considerFinalMergeForProgress,
+        readsCounter, writesCounter, bytesReadCounter, mergePhase, true,
+        inputContext);
   }
 
   public static <K extends Object, V extends Object>
@@ -173,14 +166,33 @@ public class TezMerger {
                           TezCounter bytesReadCounter,
                           Progress mergePhase, InputContext inputContext)
       throws IOException, InterruptedException {
-  return new MergeQueue(conf, fs, segments, comparator, reporter,
-                         sortSegments, codec, false).merge(serializationContext,
-                                             mergeFactor, inMemSegments,
-                                             tmpDir,
-                                             readsCounter, writesCounter,
-                                             bytesReadCounter,
-                                             mergePhase, inputContext);
-}
+    return merge(conf, fs, serializationContext, codec, segments, mergeFactor,
+        inMemSegments, tmpDir, comparator, reporter, sortSegments, false,
+        readsCounter, writesCounter, bytesReadCounter, mergePhase, true,
+        inputContext);
+  }
+
+  private static <K extends Object, V extends Object>
+  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
+      SerializationContext serializationContext,
+      CompressionCodec codec,
+      List<Segment> segments,
+      int mergeFactor, int inMemSegments, Path tmpDir,
+      RawComparator comparator, Progressable reporter,
+      boolean sortSegments,
+      boolean considerFinalMergeForProgress,
+      TezCounter readsCounter,
+      TezCounter writesCounter,
+      TezCounter bytesReadCounter,
+      Progress mergePhase, boolean checkForSameKeys,
+      DecompressorPool inputContext)
+      throws IOException, InterruptedException {
+    return new MergeQueue(conf, fs, segments, comparator, reporter,
+        sortSegments, codec, considerFinalMergeForProgress, checkForSameKeys)
+        .merge(serializationContext, mergeFactor, inMemSegments, tmpDir,
+            readsCounter, writesCounter, bytesReadCounter, mergePhase,
+            inputContext);
+  }
 
   public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppend writer,
       Progressable progressable, long recordsBeforeProgress)
@@ -473,7 +485,7 @@ public class TezMerger {
         List<Segment> segments, RawComparator comparator,
         Progressable reporter, boolean sortSegments, boolean considerFinalMergeForProgress) {
       this(conf, fs, segments, comparator, reporter, sortSegments, null,
-          considerFinalMergeForProgress);
+          considerFinalMergeForProgress, true);
     }
 
     public MergeQueue(Configuration conf, FileSystem fs,


### PR DESCRIPTION
### Motivation
- Reduce duplication and centralize default-flag handling for merging logic by routing all constructor and `merge` overloads through the most general implementations.
- Make it easier to maintain and reason about `checkForSameKeys`, `CompressionCodec`, `sortSegments`, and final-merge progress defaults across the merging code paths.

### Description
- Updated `MergeQueue` convenience constructors to delegate to the single most-general constructor that accepts `CompressionCodec` and `checkForSameKeys` so all construction flows go through one implementation.  
- Reworked the public `TezMerger.merge(...)` overloads to all delegate into a single private, most-general `merge(...)` helper that accepts `inMemSegments` and `checkForSameKeys`, preserving the previous default values when callers use simpler overloads.  
- Added a private generic helper `merge(...)` that constructs the `MergeQueue` using the generalized flags and invokes the instance `merge` method, centralizing `MergeQueue` creation.  
- Preserved existing behavior for default values (codec, sort, consider-final-merge-for-progress, in-memory segment handling, and same-key handling) while reducing repeated `new MergeQueue(...)` sites.

### Testing
- Ran `git diff --check` and there were no whitespace or patch-format issues.  
- Attempted `mvn -pl tez-runtime-library -DskipTests compile`, but the build failed in this environment due to an external Maven plugin resolution error (unrelated repository returned HTTP 403), so a full compile could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be25a5b7288328a1e47e24a5363774)