### PR TITLE
Simplify progress reporting and remove byte-tracking in shuffle/readers

### DIFF
--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/reduce/ReduceProcessor.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/reduce/ReduceProcessor.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.tez.common.ProgressHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.RawComparator;
 import org.apache.hadoop.mapred.Counters.Counter;
 import org.apache.hadoop.mapred.JobConf;
@@ -34,7 +33,6 @@ import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.Reducer;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.util.Progress;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.tez.common.counters.TaskCounter;
@@ -282,39 +280,7 @@ public class ReduceProcessor extends MRTask {
         (org.apache.hadoop.mapreduce.Reducer)
         ReflectionUtils.newInstance(taskContext.getReducerClass(), job);
 
-    // wrap value iterator to report progress.
     final TezRawKeyValueIterator rawIter = input.getIterator();
-    TezRawKeyValueIterator rIter = new TezRawKeyValueIterator() {
-      public void close() throws IOException {
-        rawIter.close();
-      }
-      public DataInputBuffer getKey() throws IOException {
-        return rawIter.getKey();
-      }
-      public Progress getProgress() {
-        return rawIter.getProgress();
-      }
-
-      @Override
-      public boolean isSameKey() throws IOException {
-        return rawIter.isSameKey();
-      }
-
-      public DataInputBuffer getValue() throws IOException {
-        return rawIter.getValue();
-      }
-
-      @Override
-      public boolean hasNext() throws IOException {
-        return rawIter.hasNext();
-      }
-
-      public boolean next() throws IOException {
-        boolean ret = rawIter.next();
-        reporter.setProgress(rawIter.getProgress().getProgress());
-        return ret;
-      }
-    };
 
     org.apache.hadoop.mapreduce.RecordWriter trackedRW =
         new org.apache.hadoop.mapreduce.RecordWriter() {
@@ -334,7 +300,7 @@ public class ReduceProcessor extends MRTask {
     org.apache.hadoop.mapreduce.Reducer.Context reducerContext =
         createReduceContext(
             reducer, job, taskAttemptId,
-            rIter, reduceInputKeyCounter,
+            rawIter, reduceInputKeyCounter,
             reduceInputValueCounter,
             trackedRW,
             committer,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -19,8 +19,6 @@
 package org.apache.tez.runtime.library.common.readers;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.slf4j.Logger;
@@ -69,9 +67,6 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
   // TODO Remove this once per I/O counters are separated properly. Relying on
   // the counter at the moment will generate aggregate numbers. 
   private int numRecordsRead = 0;
-  private final AtomicLong totalBytesRead = new AtomicLong(0);
-  private final AtomicLong totalFileBytes = new AtomicLong(0);
-
   public UnorderedKVReader(ShuffleManager shuffleManager, Configuration conf,
       CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLength,
       TezCounter inputRecordCounter, InputContext context)
@@ -141,14 +136,7 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
   }
 
   public float getProgress() throws IOException, InterruptedException {
-    final int numInputs = shuffleManager.getNumInputs();
-    if (totalFileBytes.get() > 0 && numInputs > 0) {
-      return ((1.0f) * (totalBytesRead.get() + ((currentReader != null) ? currentReader.bytesRead :
-      0.0f)) /
-          totalFileBytes.get()) * (shuffleManager.getNumCompletedInputsFloat() /
-          (1.0f * numInputs));
-    }
-    return 0.0f;
+    return completedProcessing ? 1.0f : 0.0f;
   }
   /**
    * Tries reading the next key and value from the current reader.
@@ -180,7 +168,6 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
    */
   private boolean moveToNextInput() throws IOException {
     if (currentReader != null) { // Close the current reader.
-      totalBytesRead.getAndAdd(currentReader.bytesRead);
       currentReader.close();
       /**
        * clear reader explicitly. Otherwise this could point to stale reference when next() is
@@ -201,7 +188,6 @@ public class UnorderedKVReader<K, V> extends KeyValueReader {
       return false; // No more inputs
     } else {
       currentReader = openIFileReader(currentFetchedInput);
-      totalFileBytes.getAndAdd(currentReader.getLength());
       return true;
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
@@ -463,10 +463,6 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
     return numInputs;
   }
 
-  public float getNumCompletedInputsFloat() {
-    return numCompletedInputs.floatValue();
-  }
-
   public long getTotalSizeOfMemoryCompletedInputs() {
     return totalSizeOfMemoryCompletedInputs.get();
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -253,13 +253,11 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput {
 
   @Override
   public float getProgress() throws ProgressFailedException, InterruptedException {
-    int totalInputs = getNumPhysicalInputs();
-    if (totalInputs != 0) {
-      synchronized (this) {
-        return (rawIter != null) ? rawIter.getProgress().getProgress() : 0.0f;
-      }
-    } else {
-      return 0.0f;
+    if (getNumPhysicalInputs() == 0) {
+      return 1.0f;
+    }
+    synchronized (this) {
+      return (rawIter != null) ? 1.0f : 0.0f;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Remove fragile, fine-grained progress accounting that depended on byte counters and iterator-reported progress and simplify progress semantics to completed/not-completed to reduce overhead and unused state.

### Description
- In `ReduceProcessor` removed the wrapper `TezRawKeyValueIterator` that updated the `MRTaskReporter` and pass the raw iterator directly to `createReduceContext`.
- In `UnorderedKVReader` removed `totalBytesRead` and `totalFileBytes` tracking and eliminated per-input byte accounting in `moveToNextInput()`, and changed `getProgress()` to return `1.0f` when processing is complete and `0.0f` otherwise.
- In `ShuffleManager` removed the now-unused `getNumCompletedInputsFloat()` method.
- In `OrderedGroupedKVInput` simplified `getProgress()` to return `1.0f` when there are zero physical inputs and otherwise return `1.0f` only when the raw iterator is available, otherwise `0.0f`.

### Testing
- Ran unit tests for the modified modules via `mvn -pl tez-runtime-library,tez-mapreduce -am test` and they completed successfully.
- Executed the repository's standard test suite / integration smoke checks and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be4cce18d88328a99ca3e82dac9eb8)