### PR TITLE
Collapse TezMerger.merge overloads into single general implementation

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -773,13 +773,12 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       // Nothing will be materialized to disk because the sort factor is being
       // set to the number of in memory segments.
       // TODO Is this doing any combination ?
-      TezRawKeyValueIterator rIter = 
-        TezMerger.merge(conf, rfs,
-                       serializationContext,
-                       inMemorySegments, inMemorySegments.size(),
-                       new Path(inputContext.getUniqueIdentifier()),
-                       (RawComparator)ConfigUtils.getIntermediateInputKeyComparator(conf),
-                       progressable, null, null, null, inputContext);
+      TezRawKeyValueIterator rIter =
+        TezMerger.merge(conf, rfs, serializationContext, null, inMemorySegments,
+            inMemorySegments.size(), 0,
+            new Path(inputContext.getUniqueIdentifier()),
+            (RawComparator) ConfigUtils.getIntermediateInputKeyComparator(conf),
+            progressable, false, null, null, null, true, inputContext);
       TezMerger.writeFile(rIter, writer, progressable, TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);
       writer.close();
 
@@ -861,11 +860,11 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
         tmpDir = new Path(inputContext.getUniqueIdentifier());
         // Nothing actually materialized to disk - controlled by setting sort-factor to #segments.
-        rIter = TezMerger.merge(conf, rfs,
-            serializationContext,
-            inMemorySegments, inMemorySegments.size(),
-            tmpDir, (RawComparator)ConfigUtils.getIntermediateInputKeyComparator(conf),
-            progressable, spilledRecordsCounter, null, additionalSpillBytesRead, inputContext);
+        rIter = TezMerger.merge(conf, rfs, serializationContext, null,
+            inMemorySegments, inMemorySegments.size(), 0, tmpDir,
+            (RawComparator) ConfigUtils.getIntermediateInputKeyComparator(conf),
+            progressable, false, spilledRecordsCounter, null,
+            additionalSpillBytesRead, true, inputContext);
         // spilledRecordsCounter is tracking the number of keys that will be
         // read from each of the segments being merged - which is essentially
         // what will be written to disk.
@@ -987,12 +986,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       tmpDir = new Path(inputContext.getUniqueIdentifier());
       try {
         TezRawKeyValueIterator iter = TezMerger.merge(conf, rfs,
-            serializationContext,
-            inputSegments,
-            ioSortFactor, tmpDir,
-            (RawComparator)ConfigUtils.getIntermediateInputKeyComparator(conf),
+            serializationContext, null, inputSegments, ioSortFactor, 0, tmpDir,
+            (RawComparator) ConfigUtils.getIntermediateInputKeyComparator(conf),
             progressable, true, spilledRecordsCounter, null,
-            mergedMapOutputsCounter, inputContext);
+            mergedMapOutputsCounter, true, inputContext);
 
         // TODO Maybe differentiate between data written because of Merges and
         // the finalMerge (i.e. final mem available may be different from initial merge mem)
@@ -1132,9 +1129,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         // Cannot use spill id in final merge as it would clobber with other files, hence using Integer.MAX_VALUE
         final Path outputPath = mapOutputFile.getInputFileForWrite(
             srcTaskId, Integer.MAX_VALUE, inMemToDiskBytes).suffix(Constants.MERGED_OUTPUT_PREFIX);
-        final TezRawKeyValueIterator rIter = TezMerger.merge(job, fs, serContext,
-            memDiskSegments, numMemDiskSegments, tmpDir, comparator, progressable,
-            spilledRecordsCounter, null, additionalSpillBytesRead, inputContext);
+        final TezRawKeyValueIterator rIter = TezMerger.merge(job, fs,
+            serContext, null, memDiskSegments, numMemDiskSegments, 0, tmpDir,
+            comparator, progressable, false, spilledRecordsCounter, null,
+            additionalSpillBytesRead, true, inputContext);
         final byte[] writeBuffer = IFile.allocateWriteBuffer();
         final Writer writer = new Writer(serContext.getKeySerialization(),
             serContext.getValSerialization(), fs, outputPath, serContext.getKeyClass(),
@@ -1224,10 +1222,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       final int numInMemSegments = memDiskSegments.size();
       diskSegments.addAll(0, memDiskSegments);
       memDiskSegments.clear();
-      TezRawKeyValueIterator diskMerge = TezMerger.merge(
-          job, fs, serContext, codec, diskSegments,
-          ioSortFactor, numInMemSegments, tmpDir, comparator,
-          progressable, false, spilledRecordsCounter, null, additionalSpillBytesRead, inputContext);
+      TezRawKeyValueIterator diskMerge = TezMerger.merge(job, fs, serContext,
+          codec, diskSegments, ioSortFactor, numInMemSegments, tmpDir,
+          comparator, progressable, false, spilledRecordsCounter, null,
+          additionalSpillBytesRead, true, inputContext);
       diskSegments.clear();
       if (0 == finalSegments.size()) {
         return diskMerge;
@@ -1236,10 +1234,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             new RawKVIteratorReader(diskMerge, onDiskBytes), null));
     }
     // This is doing nothing but creating an iterator over the segments.
-    return TezMerger.merge(job, fs, serContext, codec,
-        finalSegments, finalSegments.size(), tmpDir,
-        comparator, progressable, spilledRecordsCounter, null,
-      additionalSpillBytesRead, inputContext);
+    return TezMerger.merge(job, fs, serContext, codec, finalSegments,
+        finalSegments.size(), 0, tmpDir, comparator, progressable, false,
+        spilledRecordsCounter, null, additionalSpillBytesRead, false,
+        inputContext);
   }
 
   private void logFinalMergeStart(List<MapOutput> inMemoryMapOutputs,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -870,13 +870,11 @@ public class PipelinedSorter extends ExternalSorter {
         boolean sortSegments = segmentList.size() > mergeFactor;
         //merge
         TezRawKeyValueIterator kvIter = TezMerger.merge(conf, localFs,
-            serializationContext, codec,
-            segmentList, mergeFactor,
+            serializationContext, codec, segmentList, mergeFactor, 0,
             new Path(uniqueIdentifier),
             (RawComparator) ConfigUtils.getIntermediateOutputKeyComparator(conf),
-            progressable, sortSegments,
-            null, spilledRecordsCounter, additionalSpillBytesReadCounter,
-            merger.needsRLE(), outputContext);
+            progressable, sortSegments, null, spilledRecordsCounter,
+            additionalSpillBytesReadCounter, merger.needsRLE(), outputContext);
         //write merged output to disk
         long segmentStart = finalOut.getPos();
         long rawLength = 0;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.tez.runtime.api.DecompressorPool;
-import org.apache.tez.runtime.api.InputContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -60,112 +59,7 @@ public class TezMerger {
   private static LocalDirAllocator lDirAlloc = 
     new LocalDirAllocator(TezRuntimeFrameworkConfigs.LOCAL_DIRS);
 
-  // Used by the in-memory merger.
-  public static
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs, 
-                            SerializationContext serializationContext,
-                            List<Segment> segments, 
-                            int mergeFactor, Path tmpDir,
-                            RawComparator comparator, Progressable reporter,
-                            TezCounter readsCounter,
-                            TezCounter writesCounter,
-                            TezCounter bytesReadCounter,
-                            DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    // Get rid of this ?
-    return merge(conf, fs, serializationContext, segments, mergeFactor, tmpDir,
-                 comparator, reporter, false, readsCounter, writesCounter, bytesReadCounter,
-                 inputContext);
-  }
-
   public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-                            SerializationContext serializationContext,
-                            List<Segment> segments,
-                            int mergeFactor, Path tmpDir,
-                            RawComparator comparator, Progressable reporter,
-                            boolean sortSegments,
-                            TezCounter readsCounter,
-                            TezCounter writesCounter,
-                            TezCounter bytesReadCounter,
-                            DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    return merge(conf, fs, serializationContext, null, segments, mergeFactor, tmpDir,
-        comparator, reporter, sortSegments, readsCounter, writesCounter,
-        bytesReadCounter, true, inputContext);
-  }
-
-  public static TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-      SerializationContext serializationContext,
-      CompressionCodec codec,
-      List<Segment> segments,
-      int mergeFactor, Path tmpDir,
-      RawComparator comparator, Progressable reporter,
-      TezCounter readsCounter,
-      TezCounter writesCounter,
-      TezCounter bytesReadCounter,
-      DecompressorPool inputContext) throws IOException, InterruptedException {
-    return merge(conf, fs, serializationContext, codec, segments, mergeFactor, tmpDir,
-        comparator, reporter, false, readsCounter, writesCounter,
-        bytesReadCounter, false, inputContext);
-  }
-
-  public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-      SerializationContext serializationContext,
-      CompressionCodec codec,
-      List<Segment> segments,
-      int mergeFactor, Path tmpDir,
-      RawComparator comparator, Progressable reporter,
-      boolean sortSegments,
-      TezCounter readsCounter,
-      TezCounter writesCounter,
-      TezCounter bytesReadCounter,
-      boolean checkForSameKeys, DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    return merge(conf, fs, serializationContext, codec, segments, mergeFactor, 0,
-        tmpDir, comparator, reporter, sortSegments,
-        readsCounter, writesCounter, bytesReadCounter, checkForSameKeys, inputContext);
-  }
-
-  public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-                            SerializationContext serializationContext,
-                            CompressionCodec codec,
-                            List<Segment> segments,
-                            int mergeFactor, Path tmpDir,
-                            RawComparator comparator, Progressable reporter,
-                            boolean sortSegments,
-                            TezCounter readsCounter,
-                            TezCounter writesCounter,
-                            TezCounter bytesReadCounter,
-                            DecompressorPool inputContext)
-      throws IOException, InterruptedException {
-    return merge(conf, fs, serializationContext, codec, segments, mergeFactor, tmpDir,
-        comparator, reporter, sortSegments, readsCounter, writesCounter, bytesReadCounter, true,
-        inputContext);
-  }
-
-  public static <K extends Object, V extends Object>
-  TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
-                          SerializationContext serializationContext,
-                          CompressionCodec codec,
-                          List<Segment> segments,
-                          int mergeFactor, int inMemSegments, Path tmpDir,
-                          RawComparator comparator, Progressable reporter,
-                          boolean sortSegments,
-                          TezCounter readsCounter,
-                          TezCounter writesCounter,
-                          TezCounter bytesReadCounter,
-                          InputContext inputContext)
-      throws IOException, InterruptedException {
-    return merge(conf, fs, serializationContext, codec, segments, mergeFactor,
-        inMemSegments, tmpDir, comparator, reporter, sortSegments,
-        readsCounter, writesCounter, bytesReadCounter, true,
-        inputContext);
-  }
-
-  private static <K extends Object, V extends Object>
   TezRawKeyValueIterator merge(Configuration conf, FileSystem fs,
       SerializationContext serializationContext,
       CompressionCodec codec,
@@ -180,9 +74,9 @@ public class TezMerger {
       DecompressorPool inputContext)
       throws IOException, InterruptedException {
     return new MergeQueue(conf, fs, segments, comparator, reporter,
-        sortSegments, codec, checkForSameKeys)
-        .merge(serializationContext, mergeFactor, inMemSegments, tmpDir,
-            readsCounter, writesCounter, bytesReadCounter, inputContext);
+        sortSegments, codec, checkForSameKeys).merge(serializationContext,
+        mergeFactor, inMemSegments, tmpDir, readsCounter, writesCounter,
+        bytesReadCounter, inputContext);
   }
 
   public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppend writer,
@@ -616,17 +510,6 @@ public class TezMerger {
       return comparator.compare(key1.getData(), s1, l1, key2.getData(), s2, l2) < 0;
     }
     
-    public TezRawKeyValueIterator merge(SerializationContext serializationContext,
-                                        int factor, Path tmpDir,
-                                        TezCounter readsCounter,
-                                        TezCounter writesCounter,
-                                        TezCounter bytesReadCounter,
-                                        DecompressorPool inputContext)
-        throws IOException, InterruptedException {
-      return merge(serializationContext, factor, 0, tmpDir,
-                   readsCounter, writesCounter, bytesReadCounter, inputContext);
-    }
-
     TezRawKeyValueIterator merge(SerializationContext serializationContext,
                                      int factor, int inMem, Path tmpDir,
                                      TezCounter readsCounter,


### PR DESCRIPTION
### Motivation
- Reduce API surface and maintenance by keeping a single, most-general `merge(...)` entry point instead of many narrow overloads.
- Make all merge call sites explicit so behavior and defaults are visible at the call site and to simplify future refactors.

### Description
- Removed the redundant `TezMerger.merge(...)` overloads and kept a single general signature `merge(Configuration, FileSystem, SerializationContext, CompressionCodec, List<Segment>, int mergeFactor, int inMemSegments, Path tmpDir, RawComparator, Progressable, boolean sortSegments, TezCounter readsCounter, TezCounter writesCounter, TezCounter bytesReadCounter, boolean checkForSameKeys, DecompressorPool)` which delegates to `MergeQueue`.
- Deleted the convenience `MergeQueue.merge(...)` overload so the queue only exposes the full-argument merge implementation used by the top-level method.
- Updated all call sites to use the new full-argument `TezMerger.merge(...)` signature, including invocations in `MergeManager` (in-memory, mem-to-disk, on-disk, intermediate and final merge paths) and `PipelinedSorter`, passing explicit default values where appropriate.
- Removed an now-unused `InputContext` import from `TezMerger` as part of cleanup.

### Testing
- Ran `git diff --check` to validate whitespace / diff issues and it passed.
- Ran a repository sanity check script (Python) confirming there's a single top-level `TezMerger.merge` and a single `MergeQueue.merge` remaining and it passed.
- Attempted a lightweight module compile with `mvn -pl tez-runtime-library -am -DskipTests compile` which failed in this environment due to external Maven plugin resolution (`com.github.os72:protoc-jar-maven-plugin:3.8.0` returned HTTP 403 from an external repository), not due to the refactor itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69beb3ee7e6883289b3d1de1f0bc56b9)