### PR TITLE
Return decompressed IFile SectionLayout from readToMemory and propagate to callers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -117,13 +117,13 @@ public class ShuffleUtils {
     return false;
   }
 
-  public static void shuffleToMemory(byte[] shuffleData,
+  public static IFile.SectionLayout shuffleToMemory(byte[] shuffleData,
       InputStream input, IFile.SectionLayout layout, int decompressedLength, int compressedLength,
       CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLength,
       Logger LOG, InputAttemptIdentifier identifier,
       TaskContext taskContext, boolean useThreadLocalDecompressor) throws IOException {
     try {
-      IFile.Reader.readToMemory(shuffleData, input, layout, codec,
+      return IFile.Reader.readToMemory(shuffleData, input, layout, codec,
           ifileReadAhead, ifileReadAheadLength, taskContext, useThreadLocalDecompressor);
       // metrics.inputBytes(shuffleData.length);
       // finished reading shuffleData.length bytes from identifier

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -719,10 +719,13 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         }
 
         if (fetchedInput.getType() == Type.MEMORY) {
-          ShuffleUtils.shuffleToMemory(((MemoryFetchedInput) fetchedInput).getBytes(),
+          IFile.SectionLayout updatedLayout = ShuffleUtils.shuffleToMemory(((MemoryFetchedInput) fetchedInput).getBytes(),
               input, mapOutputStat.layout, (int) decompressedLength, (int) compressedLength, codec,
               fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength, LOG,
               fetchedInput.getInputAttemptIdentifier(), taskContext, true);
+          if (updatedLayout != null) {
+            fetchedInput.setSectionLayout(updatedLayout);
+          }
         } else if (fetchedInput.getType() == Type.DISK) {
           ShuffleUtils.shuffleToDisk(((DiskFetchedInput) fetchedInput).getOutputStream(),
               (host + ":" + port), input, mapOutputStat.layout, compressedLength, decompressedLength, LOG,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleInputEventHandlerImpl.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleInputEventHandlerImpl.java
@@ -215,11 +215,14 @@ public class ShuffleInputEventHandlerImpl implements ShuffleEventHandler {
       break;
     case MEMORY:
       // set useThreadLocalDecompressor = false because we are inside an EventHandler thread, not a Fetcher thread
-      ShuffleUtils.shuffleToMemory(((MemoryFetchedInput) fetchedInput).getBytes(),
+      IFile.SectionLayout updatedLayout = ShuffleUtils.shuffleToMemory(((MemoryFetchedInput) fetchedInput).getBytes(),
           dataProto.getData().newInput(), layout, dataProto.getRawLength(),
           dataProto.getCompressedLength(),
           codec, ifileReadAhead, ifileReadAheadLength, LOG,
           fetchedInput.getInputAttemptIdentifier(), inputContext, false);
+      if (updatedLayout != null) {
+        fetchedInput.setSectionLayout(updatedLayout);
+      }
       break;
     case WAIT:
     default:

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -594,10 +594,13 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         }
 
         if (mapOutput.getType() == Type.MEMORY) {
-          ShuffleUtils.shuffleToMemory(mapOutput.getMemory(), input, mapOutputStat.layout, (int) decompressedLength,
+          IFile.SectionLayout updatedLayout = ShuffleUtils.shuffleToMemory(mapOutput.getMemory(), input, mapOutputStat.layout, (int) decompressedLength,
               (int) compressedLength, codec, fetcherConfig.ifileReadAhead,
               fetcherConfig.ifileReadAheadLength, LOG,
               mapOutput.getAttemptIdentifier(), taskContext, true);
+          if (updatedLayout != null) {
+            mapOutput.setSectionLayout(updatedLayout);
+          }
         } else if (mapOutput.getType() == Type.DISK) {
           ShuffleUtils.shuffleToDisk(mapOutput.getDisk(), host,
               input, mapOutputStat.layout, compressedLength, decompressedLength, LOG,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -153,7 +153,7 @@ public abstract class MapOutput implements ShuffleInput {
   }
 
   public void setSectionLayout(IFile.SectionLayout sectionLayout) {
-    assert this.sectionLayout == null && sectionLayout != null;
+    assert sectionLayout != null;
     this.sectionLayout = sectionLayout;
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -812,7 +812,7 @@ public class IFile {
      * Read the entire IFile contents to memory (byte[] array).
      * If the IFile header indicates compression, decompress all the three sections.
      */
-    public static void readToMemory(byte[] buffer, InputStream in, SectionLayout layout,
+    public static SectionLayout readToMemory(byte[] buffer, InputStream in, SectionLayout layout,
         CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLength,
         TaskContext taskContext, boolean useThreadLocalDecompressor)
         throws IOException {
@@ -841,7 +841,7 @@ public class IFile {
             ifileReadAhead, ifileReadAheadLength);
         readStoredSectionToBuffer(buffer, offset, in, lengthsLength + checksumSize,
             ifileReadAhead, ifileReadAheadLength);
-        return;
+        return null;
       }
 
       if (codec == null) {
@@ -884,6 +884,15 @@ public class IFile {
       } finally {
         returnDecompressor(codec, taskContext, useThreadLocalDecompressor, decompressor);
       }
+
+      SectionLayout decompressedLayout = new SectionLayout(
+          HEADER.length,
+          HEADER.length + valuesRawLength + checksumSize,
+          HEADER.length + valuesRawLength + checksumSize + keysRawLength + checksumSize,
+          layout.totalRawLength,
+          layout.totalNumRecordsWritten,
+          valuesRawLength, keysRawLength, lengthsRawLength);
+      return decompressedLayout;
     }
 
     private static void readSectionToMemory(byte[] buffer, int offset,


### PR DESCRIPTION
### Motivation
- Ensure callers know the actual section offsets when an IFile is decompressed into memory so callers can update their `IFile.SectionLayout` accordingly.
- Allow replacing an existing layout after memory-read so in-memory consumers have correct metadata for downstream processing.

### Description
- Changed `ShuffleUtils.shuffleToMemory` to return an `IFile.SectionLayout` instead of `void` and to propagate the value returned from `IFile.Reader.readToMemory`.
- Updated `IFile.readToMemory` signature to return a `SectionLayout`, return `null` for the uncompressed fast-path, and construct/return a decompressed `SectionLayout` for compressed IFiles.
- Updated call sites in `FetcherUnordered`, `ShuffleInputEventHandlerImpl`, and `FetcherOrderedGrouped` to capture the returned `SectionLayout` and call `setSectionLayout` when a non-null layout is returned.
- Relaxed the assertion in `MapOutput.setSectionLayout` to allow updating an existing layout by changing `assert this.sectionLayout == null && sectionLayout != null;` to `assert sectionLayout != null;`.

### Testing
- Ran the `tez-runtime-library` module unit tests via `mvn -pl tez-runtime-library test`; the test suite completed successfully.
- Executed shuffle-related integration/unit tests that exercise in-memory and compressed IFile paths; they passed and verified that decompressed layouts are propagated without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa3fe84b88328a8b5fe363dbba619)