### PR TITLE
Refactor IFile.Writer into WriterInputBuffer and WriterBytesWritable subclasses

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -42,6 +42,7 @@ import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.Segment;
@@ -845,7 +846,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       Writer writer = null;
       long outFileLen = 0;
       try {
-        writer = new Writer(rfs, outputPath, codec,
+        writer = new WriterInputBuffer(rfs, outputPath, codec,
             null, null, writeBuffer);
 
         TezRawKeyValueIterator rIter = null;
@@ -972,7 +973,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       outputPath = localDirAllocator.getLocalPathForWrite(outputPathString, approxOutputSize, conf);
       outputPath = outputPath.suffix(Constants.MERGED_OUTPUT_PREFIX + mergeFileSequenceId.getAndIncrement());
 
-      Writer writer = new Writer(rfs, outputPath, codec, null,
+      Writer writer = new WriterInputBuffer(rfs, outputPath, codec, null,
           null, writeBuffer);
       tmpDir = new Path(inputContext.getUniqueIdentifier());
       try {
@@ -1123,7 +1124,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             comparator, progressable, false, spilledRecordsCounter, null,
             additionalSpillBytesRead, true, inputContext);
         final byte[] writeBuffer = IFile.allocateWriteBuffer();
-        final Writer writer = new Writer(fs, outputPath, codec, null, null, writeBuffer);
+        final Writer writer = new WriterInputBuffer(fs, outputPath, codec, null, null, writeBuffer);
         try {
           TezMerger.writeFile(rIter, writer, progressable, TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);
         } catch (IOException e) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -121,7 +121,7 @@ public class IFile {
    * done intentionally, as it is not possible to know compressed data length
    * upfront.
    */
-  public static class FileBackedInMemIFileWriter extends Writer {
+  public static class FileBackedInMemIFileWriter extends WriterBytesWritable {
 
     private final FileSystem fs;
     private boolean bufferFull;
@@ -150,7 +150,7 @@ public class IFile {
         CompressionCodec codec, TezCounter writesCounter,
         TezCounter serializedBytesCounter, int cacheSize, byte[] writeBuffer) throws IOException {
       super(new FSDataOutputStream(createBoundedBuffer(cacheSize), null), null,
-          writesCounter, serializedBytesCounter, false, writeBuffer, null);
+          writesCounter, serializedBytesCounter, writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
       this.taskOutput = taskOutput;
@@ -277,8 +277,7 @@ public class IFile {
   /**
    * <code>IFile.Writer</code> to write out intermediate map-outputs.
    */
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  public static class Writer implements WriterAppend {
+  public abstract static class Writer {
     // DataOutput: rawOut <-- checksumOut <-- compressedOut <-- out <-- [writeBuffer]
 
     protected DataOutputStream out;
@@ -307,19 +306,11 @@ public class IFile {
     private final TezCounter writtenRecordsCounter;
     private final TezCounter serializedUncompressedBytes;
 
-    private final Serializer keySerializer;
-    private final Serializer valueSerializer;
-
-    private final DataOutputBuffer buffer = new DataOutputBuffer();
-    private final DataOutputBuffer previous = new DataOutputBuffer();
     protected DataInputBuffer prevKey = null;
     protected boolean headerWritten = false;
 
     final int RLE_MARKER_SIZE = INT_SIZE;
     final int V_END_MARKER_SIZE = INT_SIZE;
-
-    // de-dup keys or not
-    protected final boolean rle;
 
     // We use writeBuffer[] to reduce the number of writes to 'out' and thus
     // to reduce the number of writes to 'compressedOut'.
@@ -330,26 +321,25 @@ public class IFile {
 
     private final Compressor compressorExternal;  // not to be shared with concurrent threads
 
-    public Writer(FileSystem fs, Path file,
-                  CompressionCodec codec,
-                  TezCounter writesCounter,
-                  TezCounter serializedBytesCounter,
-                  byte[] writeBuffer) throws IOException {
+    protected Writer(FileSystem fs, Path file,
+                     CompressionCodec codec,
+                     TezCounter writesCounter,
+                     TezCounter serializedBytesCounter,
+                     byte[] writeBuffer) throws IOException {
       this(fs.create(file), codec,
-           writesCounter, serializedBytesCounter, false, writeBuffer, null);
+          writesCounter, serializedBytesCounter, writeBuffer, null);
       ownOutputStream = true;   // because of fs.create(file)
     }
 
-    public Writer(FSDataOutputStream outputStream,
-                  CompressionCodec codec, TezCounter writesCounter, TezCounter serializedBytesCounter,
-                  boolean rle,
-                  byte[] writeBuffer,
-                  @Nullable Compressor compressorExternal) throws IOException {
+    protected Writer(FSDataOutputStream outputStream,
+                     CompressionCodec codec, TezCounter writesCounter,
+                     TezCounter serializedBytesCounter,
+                     byte[] writeBuffer,
+                     @Nullable Compressor compressorExternal) throws IOException {
       this.rawOut = outputStream;
       this.writtenRecordsCounter = writesCounter;
       this.serializedUncompressedBytes = serializedBytesCounter;
       this.start = this.rawOut.getPos();
-      this.rle = rle;
 
       this.writeBuffer = writeBuffer;
       this.writeBufferLength = writeBuffer.length;
@@ -360,11 +350,6 @@ public class IFile {
 
       setupOutputStream(codec);
       writeHeader(outputStream);
-
-      this.keySerializer = SerializationContext.getKeySerializer();
-      this.keySerializer.open(buffer);
-      this.valueSerializer = SerializationContext.getValueSerializer();
-      this.valueSerializer.open(buffer);
     }
 
     void setupOutputStream(CompressionCodec codec) throws IOException {
@@ -402,15 +387,9 @@ public class IFile {
         throw new IOException("Writer was already closed earlier");
       }
 
-      keySerializer.close();
-      valueSerializer.close();
-
-      // write V_END_MARKER as needed
-      writeValueMarker();
+      onClose();
 
       // Write EOF_MARKER for key/value length
-      // bufferWriteInt(EOF_MARKER);
-      // bufferWriteInt(EOF_MARKER);
       long combined = ((long) EOF_MARKER << 32) | (EOF_MARKER & 0xFFFFFFFFL);
       bufferWriteLong(combined);
 
@@ -450,69 +429,14 @@ public class IFile {
         writtenRecordsCounter.increment(numRecordsWritten);
       }
       if (isDebugEnabled) {
-        LOG.debug("Total keys written=" + numRecordsWritten + "; rleEnabled=" + rle + "; Savings" +
+        LOG.debug("Total keys written=" + numRecordsWritten + "; rleEnabled=" + hasRle() + "; Savings" +
             "(due to multi-kv/rle)=" + totalKeySaving + "; number of RLEs written=" +
             rleWritten + "; compressedLen=" + compressedBytesWritten + "; rawLen="
             + decompressedBytesWritten);
       }
     }
 
-    // Called only from sites that pass BytesWritable and construct writer with rle=false
-    // (unordered writer paths, plus ordered single-record spill path).
-    public void append(BytesWritable key, BytesWritable value) throws IOException {
-      assert !this.rle;
-      int keyLength = 0;
-
-      keySerializer.serialize(key);
-      keyLength = buffer.getLength();
-      assert (keyLength >= 0);
-
-      // Append the 'value'
-      valueSerializer.serialize(value);
-      int valueLength = buffer.getLength() - keyLength;
-      assert (valueLength >= 0);
-      // dump entire key value pair
-      writeKVPair(buffer.getData(), 0, keyLength, buffer.getData(),
-          keyLength, buffer.getLength() - keyLength);
-
-      // Reset
-      buffer.reset();
-      ++numRecordsWritten;
-    }
-
-    /**
-     * Send key/value to be appended to IFile. To represent same key as previous
-     * one, send IFile.REPEAT_KEY as key parameter.  Should not call this method with
-     * IFile.REPEAT_KEY as the first key. It is caller's responsibility to pass non-negative
-     * key/value lengths. Otherwise,IndexOutOfBoundsException could be thrown at runtime.
-     *
-     *
-     * @param key
-     * @param value
-     * @throws IOException
-     */
-    public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
-      int keyLength = key.getLength() - key.getPosition();
-      assert (key == REPEAT_KEY || keyLength >=0);
-
-      int valueLength = value.getLength() - value.getPosition();
-      assert (valueLength >= 0);
-
-      boolean sameKey = (key == REPEAT_KEY);
-      if (!sameKey && rle) {
-        sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
-      }
-
-      if (!sameKey) {
-        writeKVPair(key.getData(), key.getPosition(), keyLength,
-            value.getData(), value.getPosition(), valueLength);
-        if (rle) {
-          BufferUtils.copy(key, previous);
-        }
-      } else {
-        writeValue(value.getData(), value.getPosition(), valueLength);
-      }
-      prevKey = sameKey ? REPEAT_KEY : key;
+    protected void incrementRecordsWritten() {
       ++numRecordsWritten;
     }
 
@@ -532,8 +456,6 @@ public class IFile {
         byte[] valueData, int valPos, int valueLength) throws IOException {
       writeValueMarker();
 
-      // bufferWriteInt(keyLength);
-      // bufferWriteLong(valueLength);
       long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
       bufferWriteLong(combined);
 
@@ -547,31 +469,25 @@ public class IFile {
       }
     }
 
-    private void writeRLE() throws IOException {
-      /**
-       * To strike a balance between 2 use cases (lots of unique KV in stream
-       * vs lots of identical KV in stream), we start off by writing KV pair.
-       * If subsequent KV is identical, we write RLE marker along with V_END_MARKER
-       * {KL1, VL1, K1, V1}
-       * {RLE, VL2, V2, VL3, V3, ...V_END_MARKER}
-       */
-      if (prevKey != REPEAT_KEY) {
-        bufferWriteInt(RLE_MARKER);
-        decompressedBytesWritten += RLE_MARKER_SIZE;
-        rleWritten++;
-      }
+    protected void writeRLE() throws IOException {
     }
 
     protected void writeValueMarker() throws IOException {
-      /**
-       * Write V_END_MARKER only in RLE scenario. This will
-       * save space in conditions where lots of unique KV pairs are found in the
-       * stream.
-       */
-      if (prevKey == REPEAT_KEY) {
-        bufferWriteInt(V_END_MARKER);
-        decompressedBytesWritten += V_END_MARKER_SIZE;
-      }
+    }
+
+    protected void onClose() throws IOException {
+    }
+
+    protected boolean hasRle() {
+      return false;
+    }
+
+    protected void incrementRleWritten() {
+      rleWritten++;
+    }
+
+    protected void incrementDecompressedBytesWritten(long length) {
+      decompressedBytesWritten += length;
     }
 
     protected void bufferWriteInt(int val) throws IOException {
@@ -620,6 +536,135 @@ public class IFile {
 
     public long getCompressedLength() {
       return compressedBytesWritten;
+    }
+  }
+
+  public static class WriterInputBuffer extends Writer implements WriterAppend {
+
+    private final DataOutputBuffer previous = new DataOutputBuffer();
+    // de-dup keys or not
+    protected final boolean rle;
+
+    public WriterInputBuffer(FileSystem fs, Path file,
+        CompressionCodec codec,
+        TezCounter writesCounter,
+        TezCounter serializedBytesCounter,
+        byte[] writeBuffer) throws IOException {
+      this(fs.create(file), codec, writesCounter, serializedBytesCounter, false, writeBuffer, null);
+      ownOutputStream = true;
+    }
+
+    public WriterInputBuffer(FSDataOutputStream outputStream,
+        CompressionCodec codec, TezCounter writesCounter, TezCounter serializedBytesCounter,
+        boolean rle, byte[] writeBuffer, @Nullable Compressor compressorExternal) throws IOException {
+      super(outputStream, codec, writesCounter, serializedBytesCounter, writeBuffer, compressorExternal);
+      this.rle = rle;
+    }
+
+    @Override
+    protected boolean hasRle() {
+      return rle;
+    }
+
+    /**
+     * Send key/value to be appended to IFile. To represent same key as previous
+     * one, send IFile.REPEAT_KEY as key parameter.  Should not call this method with
+     * IFile.REPEAT_KEY as the first key. It is caller's responsibility to pass non-negative
+     * key/value lengths. Otherwise,IndexOutOfBoundsException could be thrown at runtime.
+     */
+    @Override
+    public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      int keyLength = key.getLength() - key.getPosition();
+      assert (key == REPEAT_KEY || keyLength >=0);
+
+      int valueLength = value.getLength() - value.getPosition();
+      assert (valueLength >= 0);
+
+      boolean sameKey = (key == REPEAT_KEY);
+      if (!sameKey && rle) {
+        sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
+      }
+
+      if (!sameKey) {
+        writeKVPair(key.getData(), key.getPosition(), keyLength,
+            value.getData(), value.getPosition(), valueLength);
+        if (rle) {
+          BufferUtils.copy(key, previous);
+        }
+      } else {
+        writeValue(value.getData(), value.getPosition(), valueLength);
+      }
+      prevKey = sameKey ? REPEAT_KEY : key;
+      incrementRecordsWritten();
+    }
+
+    @Override
+    protected void writeRLE() throws IOException {
+      if (prevKey != REPEAT_KEY) {
+        bufferWriteInt(RLE_MARKER);
+        incrementDecompressedBytesWritten(RLE_MARKER_SIZE);
+        incrementRleWritten();
+      }
+    }
+
+    @Override
+    protected void writeValueMarker() throws IOException {
+      if (prevKey == REPEAT_KEY) {
+        bufferWriteInt(V_END_MARKER);
+        incrementDecompressedBytesWritten(V_END_MARKER_SIZE);
+      }
+    }
+
+    @Override
+    protected void onClose() throws IOException {
+      writeValueMarker();
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static class WriterBytesWritable extends Writer {
+
+    private final Serializer keySerializer;
+    private final Serializer valueSerializer;
+    private final DataOutputBuffer buffer = new DataOutputBuffer();
+
+    public WriterBytesWritable(FileSystem fs, Path file,
+        CompressionCodec codec,
+        TezCounter writesCounter,
+        TezCounter serializedBytesCounter,
+        byte[] writeBuffer) throws IOException {
+      this(fs.create(file), codec, writesCounter, serializedBytesCounter, writeBuffer, null);
+      ownOutputStream = true;
+    }
+
+    public WriterBytesWritable(FSDataOutputStream outputStream,
+        CompressionCodec codec, TezCounter writesCounter, TezCounter serializedBytesCounter,
+        byte[] writeBuffer, @Nullable Compressor compressorExternal) throws IOException {
+      super(outputStream, codec, writesCounter, serializedBytesCounter, writeBuffer, compressorExternal);
+      this.keySerializer = SerializationContext.getKeySerializer();
+      this.keySerializer.open(buffer);
+      this.valueSerializer = SerializationContext.getValueSerializer();
+      this.valueSerializer.open(buffer);
+    }
+
+    public void append(BytesWritable key, BytesWritable value) throws IOException {
+      keySerializer.serialize(key);
+      int keyLength = buffer.getLength();
+      assert (keyLength >= 0);
+
+      valueSerializer.serialize(value);
+      int valueLength = buffer.getLength() - keyLength;
+      assert (valueLength >= 0);
+      writeKVPair(buffer.getData(), 0, keyLength, buffer.getData(), keyLength, valueLength);
+
+      buffer.reset();
+      incrementRecordsWritten();
+    }
+
+    @Override
+    protected void onClose() throws IOException {
+      keySerializer.close();
+      valueSerializer.close();
     }
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -56,6 +56,8 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterBytesWritable;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.Segment;
 
@@ -496,12 +498,12 @@ public class PipelinedSorter extends ExternalSorter {
         if (isThreadInterrupted()) {
           return;
         }
-        Writer writer = null;
+        WriterBytesWritable writer = null;
         try {
           long segmentStart = out.getPos();
           if (!sendEmptyPartitionDetails || (i == partition)) {
-            writer = new Writer(out,
-                codec, spilledRecordsCounter, null, false,
+            writer = new WriterBytesWritable(out,
+                codec, spilledRecordsCounter, null,
                 writeBuffer, null);
           }
           // we need not check for combiner since its a single record
@@ -608,13 +610,13 @@ public class PipelinedSorter extends ExternalSorter {
         TezRawKeyValueIterator kvIter = merger.filter(i);
         // write merged output to disk
         long segmentStart = fsOutput.getPos();
-        Writer writer = null;
+        WriterInputBuffer writer = null;
         boolean hasNext = kvIter.hasNext();
         if (hasNext || !sendEmptyPartitionDetails) {
           if (codec != null && compressorExternal == null) {
             compressorExternal = CodecUtils.getCompressor(codec);
           }
-          writer = new Writer(
+          writer = new WriterInputBuffer(
               fsOutput,
               codec, spilledRecordsCounter, null, merger.needsRLE(),
               writeBuffer, compressorExternal);
@@ -866,7 +868,7 @@ public class PipelinedSorter extends ExternalSorter {
         long rawLength = 0;
         long partLength = 0;
         if (shouldWrite) {
-          Writer writer = new Writer(
+          Writer writer = new WriterInputBuffer(
               finalOut,
               codec, spilledRecordsCounter, null, merger.needsRLE(),
               writeBuffer, null);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -44,6 +44,7 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterInputBuffer;
 import org.apache.tez.runtime.library.utils.BufferUtils;
 
 /**
@@ -620,7 +621,7 @@ public class TezMerger {
 
           // TODO Would it ever make sense to make this an in-memory writer ?
           // Merging because of too many disk segments - might fit in memory.
-          Writer writer = new Writer(fs, outputFile, codec,
+          Writer writer = new WriterInputBuffer(fs, outputFile, codec,
               writesCounter, null, writeBuffer);
 
           writeFile(this, writer, reporter, recordsBeforeProgress);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -73,7 +73,8 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.Constants;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterBytesWritable;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
@@ -134,7 +135,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
   private final boolean rfsSpillFilePerms;
 
   // for single partition cases
-  private final IFile.Writer writer;
+  private final IFile.WriterBytesWritable writer;
   private final boolean skipBuffers;
 
   private int numBuffers;
@@ -255,7 +256,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
             writeBuffer);
       } else {
         finalOutPath = outputFileHandler.getOutputFileForWrite();
-        writer = new IFile.Writer(rfs, finalOutPath,
+        writer = new IFile.WriterBytesWritable(rfs, finalOutPath,
             codec, outputRecordsCounter, outputRecordBytesCounter,
             writeBuffer);
         ensureSpillFilePermissions(finalOutPath, rfs, rfsSpillFilePerms);
@@ -653,7 +654,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
         for (int i = 0; i < numPartitions; i++) {
-          IFile.Writer writer = null;
+          WriterInputBuffer writer = null;
           try {
             long segmentStart = fsOutput.getPos();
             long numRecords = 0;
@@ -667,7 +668,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
                   compressorExternal = CodecUtils.getCompressor(codec);
                 }
                 // all Writer instances share the same FSDataOutputStream out
-                writer = new Writer(
+                writer = new WriterInputBuffer(
                     fsOutput, codec, null, null, false,
                     writeBuffer, compressorExternal);
               }
@@ -717,7 +718,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     }
   }
 
-  private long writePartition(int pos, WrappedBuffer wrappedBuffer, Writer writer,
+  private long writePartition(int pos, WrappedBuffer wrappedBuffer, WriterInputBuffer writer,
       DataInputBuffer keyBuffer, DataInputBuffer valBuffer) throws IOException {
     long numRecords = 0;
     while (pos != WrappedBuffer.PARTITION_ABSENT_POSITION) {
@@ -1154,7 +1155,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     try {
       out = rfs.create(finalOutPath);
       ensureSpillFilePermissions(finalOutPath, rfs, rfsSpillFilePerms);
-      Writer writer = null;
+      WriterInputBuffer writer = null;
 
       byte[] writeBuffer = IFile.allocateWriteBuffer();
       for (int i = 0; i < numPartitions; i++) {
@@ -1166,7 +1167,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
           continue;
         }
         // inside close()
-        writer = new Writer(
+        writer = new WriterInputBuffer(
             out, codec, null, null, false,
             writeBuffer, null);
         try {
@@ -1291,9 +1292,9 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         final long recordStart = out.getPos();
         if (i == partition) {
           spilledRecordsCounter.increment(1);
-          Writer writer = null;
+          WriterBytesWritable writer = null;
           try {
-            writer = new IFile.Writer(out, codec, null, null, false,
+            writer = new IFile.WriterBytesWritable(out, codec, null, null,
                 IFile.allocateWriteBufferSingle(), null);
             writer.append(key, value);
             outputLargeRecordsCounter.increment(1);


### PR DESCRIPTION
### Motivation
- Separate append APIs by input type so writers expose only the relevant `append` signature and to centralize RLE logic to only the readers that require it.
- Reduce mixing of `BytesWritable` serialization and `DataInputBuffer` RLE logic in a single monolithic `Writer` implementation.

### Description
- Made `IFile.Writer` an abstract base class that holds shared stream, buffering and lifecycle logic but no concrete `append` methods.
- Added `IFile.WriterInputBuffer` which implements `IFile.WriterAppend`, keeps the `rle` boolean, and provides `public void append(DataInputBuffer key, DataInputBuffer value)` plus RLE handling and value-marker behavior.
- Added `IFile.WriterBytesWritable` which exposes only `public void append(BytesWritable key, BytesWritable value)` and contains the `BytesWritable` serialization path; it does not carry an `rle` field.
- Updated `FileBackedInMemIFileWriter` to extend `WriterBytesWritable` and switched existing writer construction sites to create either `WriterInputBuffer` (ordered/merge/`DataInputBuffer` paths) or `WriterBytesWritable` (unordered / `BytesWritable` paths) in `TezMerger`, `PipelinedSorter`, `MergeManager`, `UnorderedPartitionedKVWriter`, and related call sites.

### Testing
- Ran a module compile attempt with `mvn -pl tez-runtime-library -DskipTests compile`, which did not complete due to an external plugin resolution failure for `com.github.os72:protoc-jar-maven-plugin:3.8.0` (HTTP 403 from remote repository), so Java compilation results could not be validated in this environment.
- Performed repository-wide text/code updates verification via searches and local edits (no automated unit tests executed in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50b797b2083289a93407c4bd70e40)