### PR TITLE
Remove EdgeProperty DataSourceType and SchedulingType; simplify EdgeProperty API and update protos and callers

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/EdgeProperty.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/EdgeProperty.java
@@ -59,48 +59,7 @@ public class EdgeProperty {
     CUSTOM
   }
   
-  /**
-   * Determines the lifetime of the data produced on this edge by a source task.
-   */
-  public enum DataSourceType {
-    /**
-     * Data produced by the source is persisted and available even when the
-     * task is not running. The data may become unavailable and may cause the 
-     * source task to be re-executed.
-     */
-    PERSISTED,
-    /**
-     * Source data is stored reliably and will always be available. This is not supported yet.
-     */
-    PERSISTED_RELIABLE,
-    /**
-     * Data produced by the source task is available only while the source task
-     * is running. This requires the destination task to run concurrently with 
-     * the source task. This is not supported yet.
-     */
-    EPHEMERAL
-  }
-  
-  /**
-   * Determines when the destination task is eligible to run, once the source  
-   * task is eligible to run.
-   */
-  public enum SchedulingType {
-    /**
-     * Destination task is eligible to run after one or more of its source tasks 
-     * have started or completed.
-     */
-    SEQUENTIAL,
-    /**
-     * Destination task must run concurrently with the source task.
-     *  This is not supported yet.
-     */
-    CONCURRENT
-  }
-  
   final DataMovementType dataMovementType;
-  final DataSourceType dataSourceType;
-  final SchedulingType schedulingType;
   final InputDescriptor inputDescriptor;
   final OutputDescriptor outputDescriptor;
   final EdgeManagerPluginDescriptor edgeManagerDescriptor;
@@ -110,18 +69,13 @@ public class EdgeProperty {
    * org.apache.tez.dag.api.EdgeProperty.DataMovementType}s
    *
    * @param dataMovementType
-   * @param dataSourceType
-   * @param schedulingType
    * @param edgeSource       The {@link OutputDescriptor} that generates data on the edge.
    * @param edgeDestination  The {@link InputDescriptor} which will consume data from the edge.
    */
   public static EdgeProperty create(DataMovementType dataMovementType,
-                                    DataSourceType dataSourceType,
-                                    SchedulingType schedulingType,
                                     OutputDescriptor edgeSource,
                                     InputDescriptor edgeDestination) {
-    return new EdgeProperty(dataMovementType, dataSourceType, schedulingType, edgeSource,
-        edgeDestination);
+    return new EdgeProperty(dataMovementType, edgeSource, edgeDestination);
   }
 
   /**
@@ -130,56 +84,42 @@ public class EdgeProperty {
    * @param edgeManagerDescriptor
    *          the EdgeManager specifications. This can be null if the edge
    *          manager will be setup at runtime
-   * @param dataSourceType
-   * @param schedulingType
    * @param edgeSource
    *          The {@link OutputDescriptor} that generates data on the edge.
    * @param edgeDestination
    *          The {@link InputDescriptor} which will consume data from the edge.
    */
   public static EdgeProperty create(EdgeManagerPluginDescriptor edgeManagerDescriptor,
-                                    DataSourceType dataSourceType,
-                                    SchedulingType schedulingType,
                                     OutputDescriptor edgeSource,
                                     InputDescriptor edgeDestination) {
-    return new EdgeProperty(edgeManagerDescriptor, dataSourceType, schedulingType, edgeSource,
-        edgeDestination);
+    return new EdgeProperty(edgeManagerDescriptor, edgeSource, edgeDestination);
   }
 
   public static EdgeProperty create(EdgeManagerPluginDescriptor edgeManagerDescriptor,
-      DataMovementType dataMovementType, DataSourceType dataSourceType,
-      SchedulingType schedulingType, OutputDescriptor edgeSource, InputDescriptor edgeDestination) {
-    return new EdgeProperty(edgeManagerDescriptor, dataMovementType, dataSourceType,
-        schedulingType, edgeSource, edgeDestination);
+      DataMovementType dataMovementType, OutputDescriptor edgeSource,
+      InputDescriptor edgeDestination) {
+    return new EdgeProperty(edgeManagerDescriptor, dataMovementType, edgeSource, edgeDestination);
   }
 
   private EdgeProperty(DataMovementType dataMovementType,
-                       DataSourceType dataSourceType,
-                       SchedulingType schedulingType,
                        OutputDescriptor edgeSource,
                        InputDescriptor edgeDestination) {
-    this(null, dataMovementType, dataSourceType, schedulingType, edgeSource, edgeDestination);
+    this(null, dataMovementType, edgeSource, edgeDestination);
     Preconditions.checkArgument(dataMovementType != DataMovementType.CUSTOM,
         DataMovementType.CUSTOM + " cannot be used with this constructor");
   }
   
 
   private EdgeProperty(EdgeManagerPluginDescriptor edgeManagerDescriptor,
-                       DataSourceType dataSourceType,
-                       SchedulingType schedulingType,
                        OutputDescriptor edgeSource,
                        InputDescriptor edgeDestination) {
-    this(edgeManagerDescriptor, DataMovementType.CUSTOM, dataSourceType, schedulingType,
-        edgeSource, edgeDestination);
+    this(edgeManagerDescriptor, DataMovementType.CUSTOM, edgeSource, edgeDestination);
   }
   
   private EdgeProperty(EdgeManagerPluginDescriptor edgeManagerDescriptor,
-      DataMovementType dataMovementType, DataSourceType dataSourceType,
-      SchedulingType schedulingType, OutputDescriptor edgeSource, InputDescriptor edgeDestination) {
+      DataMovementType dataMovementType, OutputDescriptor edgeSource, InputDescriptor edgeDestination) {
     this.dataMovementType = dataMovementType;
     this.edgeManagerDescriptor = edgeManagerDescriptor;
-    this.dataSourceType = dataSourceType;
-    this.schedulingType = schedulingType;
     this.inputDescriptor = edgeDestination;
     this.outputDescriptor = edgeSource;
   }
@@ -190,22 +130,6 @@ public class EdgeProperty {
    */
   public DataMovementType getDataMovementType() {
     return dataMovementType;
-  }
-  
-  /**
-   * Get the {@link DataSourceType}
-   * @return {@link DataSourceType}
-   */
-  public DataSourceType getDataSourceType() {
-    return dataSourceType;
-  }
-  
-  /**
-   * Get the {@link SchedulingType}
-   * @return {@link SchedulingType}
-   */
-  public SchedulingType getSchedulingType() {
-    return schedulingType;
   }
   
   /**
@@ -233,7 +157,7 @@ public class EdgeProperty {
   @Override
   public String toString() {
     return "{ " + dataMovementType + " : " + inputDescriptor.getClassName()
-        + " >> " + dataSourceType + " >> " + outputDescriptor.getClassName()
+        + " >> " + outputDescriptor.getClassName()
         + " >> " + (edgeManagerDescriptor == null ? "NullEdgeManager" : edgeManagerDescriptor.getClassName())
         + " }";
   }

--- a/tez-api/src/main/proto/DAGApiRecords.proto
+++ b/tez-api/src/main/proto/DAGApiRecords.proto
@@ -42,17 +42,6 @@ enum PlanEdgeDataMovementType {
   CUSTOM = 3;
 }
 
-enum PlanEdgeDataSourceType {
-  PERSISTED = 0;
-  PERSISTED_RELIABLE = 1;
-  EPHEMERAL = 2;
-}
-
-enum PlanEdgeSchedulingType {
-  SEQUENTIAL = 0;
-  CONCURRENT = 1;
-}
-
 message PlanKeyValuePair {
   required string key = 1;
   required string value = 2;
@@ -152,11 +141,9 @@ message VertexPlan {
 
 message PlanEdgeProperty {
   required PlanEdgeDataMovementType dataMovementType = 1;
-  required PlanEdgeDataSourceType dataSourceType = 2;
-  required PlanEdgeSchedulingType schedulingType = 3;
-  optional TezEntityDescriptorProto edge_source = 4;
-  optional TezEntityDescriptorProto edge_destination = 5;
-  optional TezEntityDescriptorProto edge_manager = 6;
+  optional TezEntityDescriptorProto edge_source = 2;
+  optional TezEntityDescriptorProto edge_destination = 3;
+  optional TezEntityDescriptorProto edge_manager = 4;
 }
 
 message EdgePlan {
@@ -164,11 +151,9 @@ message EdgePlan {
   required string inputVertexName = 2;
   required string outputVertexName = 3;
   required PlanEdgeDataMovementType dataMovementType = 4;
-  required PlanEdgeDataSourceType dataSourceType = 5;
-  required PlanEdgeSchedulingType schedulingType = 6;
-  optional TezEntityDescriptorProto edge_source = 7;
-  optional TezEntityDescriptorProto edge_destination = 8;
-  optional TezEntityDescriptorProto edge_manager = 9;
+  optional TezEntityDescriptorProto edge_source = 5;
+  optional TezEntityDescriptorProto edge_destination = 6;
+  optional TezEntityDescriptorProto edge_manager = 7;
 }
 
 message TezNamedEntityDescriptorProto {

--- a/tez-runtime-library/src/main/java/org/apache/tez/dag/library/vertexmanager/InputReadyVertexManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/dag/library/vertexmanager/InputReadyVertexManager.java
@@ -172,9 +172,7 @@ public class InputReadyVertexManager extends VertexManagerPlugin {
                 descriptor.setUserPayload(UserPayload.create(buffer));
 
                 EdgeProperty newEdgeProp = EdgeProperty.create(descriptor,
-                    DataMovementType.CUSTOM,
-                    edgeProp.getDataSourceType(), edgeProp.getSchedulingType(),
-                    edgeProp.getEdgeSource(), edgeProp.getEdgeDestination());
+                    DataMovementType.CUSTOM, edgeProp.getEdgeSource(), edgeProp.getEdgeDestination());
                 edgeProperties.put(srcVertex, newEdgeProp);
                 break;
               default:

--- a/tez-runtime-library/src/main/java/org/apache/tez/dag/library/vertexmanager/ShuffleVertexManagerBase.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/dag/library/vertexmanager/ShuffleVertexManagerBase.java
@@ -791,9 +791,7 @@ abstract class ShuffleVertexManagerBase extends VertexManagerPlugin {
       String vertex = entry.getKey();
       EdgeProperty oldEdgeProp = entry.getValue().edgeProperty;
       EdgeProperty newEdgeProp = EdgeProperty.create(entry.getValue().newDescriptor,
-          DataMovementType.CUSTOM,
-          oldEdgeProp.getDataSourceType(), oldEdgeProp.getSchedulingType(),
-          oldEdgeProp.getEdgeSource(), oldEdgeProp.getEdgeDestination());
+          DataMovementType.CUSTOM, oldEdgeProp.getEdgeSource(), oldEdgeProp.getEdgeDestination());
       edgeProperties.put(vertex, newEdgeProp);
     }
     getContext().reconfigureVertex(finalTaskParallelism, null, edgeProperties);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/OrderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/OrderedPartitionedKVEdgeConfig.java
@@ -105,14 +105,12 @@ public class OrderedPartitionedKVEdgeConfig extends KeyValuesBasedBaseEdgeConfig
   /**
    * This is a convenience method for the typical usage of this edge, and creates an instance of
    * {@link org.apache.tez.dag.api.EdgeProperty} which is likely to be used. </p>
-   * * In this case - DataMovementType.SCATTER_GATHER, EdgeProperty.DataSourceType.PERSISTED,
-   * EdgeProperty.SchedulingType.SEQUENTIAL
+   * * In this case - DataMovementType.SCATTER_GATHER
    *
    * @return an {@link org.apache.tez.dag.api.EdgeProperty} instance
    */
   public EdgeProperty createDefaultEdgeProperty() {
     EdgeProperty edgeProperty = EdgeProperty.create(EdgeProperty.DataMovementType.SCATTER_GATHER,
-        EdgeProperty.DataSourceType.PERSISTED, EdgeProperty.SchedulingType.SEQUENTIAL,
         OutputDescriptor.create(
             getOutputClassName()).setUserPayload(getOutputPayload()),
         InputDescriptor.create(
@@ -130,8 +128,7 @@ public class OrderedPartitionedKVEdgeConfig extends KeyValuesBasedBaseEdgeConfig
   public EdgeProperty createDefaultCustomEdgeProperty(EdgeManagerPluginDescriptor edgeManagerDescriptor) {
     Objects.requireNonNull(edgeManagerDescriptor, "EdgeManagerDescriptor cannot be null");
     EdgeProperty edgeProperty =
-        EdgeProperty.create(edgeManagerDescriptor, EdgeProperty.DataSourceType.PERSISTED,
-            EdgeProperty.SchedulingType.SEQUENTIAL,
+        EdgeProperty.create(edgeManagerDescriptor,
             OutputDescriptor.create(getOutputClassName()).setUserPayload(getOutputPayload()),
             InputDescriptor.create(getInputClassName()).setUserPayload(getInputPayload()));
     return edgeProperty;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedKVEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedKVEdgeConfig.java
@@ -84,14 +84,12 @@ public class UnorderedKVEdgeConfig extends KeyValuesBasedBaseEdgeConfig {
    * {@link org.apache.tez.dag.api.EdgeProperty} which is likely to be used. </p>
    * If custom edge properties are required, the methods to get the relevant payloads should be
    * used. </p>
-   * * In this case - DataMovementType.BROADCAST, EdgeProperty.DataSourceType.PERSISTED,
-   * EdgeProperty.SchedulingType.SEQUENTIAL
+   * * In this case - DataMovementType.BROADCAST
    *
    * @return an {@link org.apache.tez.dag.api.EdgeProperty} instance
    */
   public EdgeProperty createDefaultBroadcastEdgeProperty() {
     EdgeProperty edgeProperty = EdgeProperty.create(EdgeProperty.DataMovementType.BROADCAST,
-        EdgeProperty.DataSourceType.PERSISTED, EdgeProperty.SchedulingType.SEQUENTIAL,
         OutputDescriptor.create(
             getOutputClassName()).setUserPayload(getOutputPayload()),
         InputDescriptor.create(
@@ -104,14 +102,12 @@ public class UnorderedKVEdgeConfig extends KeyValuesBasedBaseEdgeConfig {
    * {@link org.apache.tez.dag.api.EdgeProperty} which is likely to be used. </p>
    * If custom edge properties are required, the methods to get the relevant payloads should be
    * used. </p>
-   * * In this case - DataMovementType.ONE_TO_ONE, EdgeProperty.DataSourceType.PERSISTED,
-   * EdgeProperty.SchedulingType.SEQUENTIAL
+   * * In this case - DataMovementType.ONE_TO_ONE
    *
    * @return an {@link org.apache.tez.dag.api.EdgeProperty} instance
    */
   public EdgeProperty createDefaultOneToOneEdgeProperty() {
     EdgeProperty edgeProperty = EdgeProperty.create(EdgeProperty.DataMovementType.ONE_TO_ONE,
-        EdgeProperty.DataSourceType.PERSISTED, EdgeProperty.SchedulingType.SEQUENTIAL,
         OutputDescriptor.create(
             getOutputClassName()).setUserPayload(getOutputPayload()),
         InputDescriptor.create(
@@ -129,8 +125,7 @@ public class UnorderedKVEdgeConfig extends KeyValuesBasedBaseEdgeConfig {
   public EdgeProperty createDefaultCustomEdgeProperty(EdgeManagerPluginDescriptor edgeManagerDescriptor) {
     Objects.requireNonNull(edgeManagerDescriptor, "EdgeManagerDescriptor cannot be null");
     EdgeProperty edgeProperty =
-        EdgeProperty.create(edgeManagerDescriptor, EdgeProperty.DataSourceType.PERSISTED,
-            EdgeProperty.SchedulingType.SEQUENTIAL,
+        EdgeProperty.create(edgeManagerDescriptor,
             OutputDescriptor.create(getOutputClassName()).setUserPayload(getOutputPayload()),
             InputDescriptor.create(getInputClassName()).setUserPayload(getInputPayload()));
     return edgeProperty;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/UnorderedPartitionedKVEdgeConfig.java
@@ -110,14 +110,12 @@ public class UnorderedPartitionedKVEdgeConfig extends KeyValuesBasedBaseEdgeConf
    * {@link org.apache.tez.dag.api.EdgeProperty} which is likely to be used. </p>
    * If custom edge properties are required, the methods to get the relevant payloads should be
    * used. </p>
-   * * In this case - DataMovementType.SCATTER_GATHER, EdgeProperty.DataSourceType.PERSISTED,
-   * EdgeProperty.SchedulingType.SEQUENTIAL
+   * * In this case - DataMovementType.SCATTER_GATHER
    *
    * @return an {@link org.apache.tez.dag.api.EdgeProperty} instance
    */
   public EdgeProperty createDefaultEdgeProperty() {
     EdgeProperty edgeProperty = EdgeProperty.create(EdgeProperty.DataMovementType.SCATTER_GATHER,
-        EdgeProperty.DataSourceType.PERSISTED, EdgeProperty.SchedulingType.SEQUENTIAL,
         OutputDescriptor.create(
             getOutputClassName()).setUserPayload(getOutputPayload()),
         InputDescriptor.create(
@@ -135,8 +133,7 @@ public class UnorderedPartitionedKVEdgeConfig extends KeyValuesBasedBaseEdgeConf
   public EdgeProperty createDefaultCustomEdgeProperty(EdgeManagerPluginDescriptor edgeManagerDescriptor) {
     Objects.requireNonNull(edgeManagerDescriptor, "EdgeManagerDescriptor cannot be null");
     EdgeProperty edgeProperty =
-        EdgeProperty.create(edgeManagerDescriptor, EdgeProperty.DataSourceType.PERSISTED,
-            EdgeProperty.SchedulingType.SEQUENTIAL,
+        EdgeProperty.create(edgeManagerDescriptor,
             OutputDescriptor.create(getOutputClassName()).setUserPayload(getOutputPayload()),
             InputDescriptor.create(getInputClassName()).setUserPayload(getInputPayload()));
     return edgeProperty;


### PR DESCRIPTION
### Motivation
- Simplify the `EdgeProperty` API by removing the unused/unsupported `DataSourceType` and `SchedulingType` abstractions and their protocol buffer equivalents.
- Reduce API surface and eliminate parameters that were not fully supported at runtime.

### Description
- Removed the `DataSourceType` and `SchedulingType` enums, their fields, and their getters from `org.apache.tez.dag.api.EdgeProperty` and adjusted constructors and `create` factory methods to the new signatures that no longer accept those types.
- Updated `toString` in `EdgeProperty` to stop referencing the removed fields and adjusted all call sites to the new `EdgeProperty.create(...)` signatures in the runtime library and config classes.
- Modified multiple callers in the runtime library (`InputReadyVertexManager`, `ShuffleVertexManagerBase`) to construct `EdgeProperty` instances using the simplified API and updated edge-config helper classes (`OrderedPartitionedKVEdgeConfig`, `UnorderedKVEdgeConfig`, `UnorderedPartitionedKVEdgeConfig`) to use the new factory methods and documentation.
- Updated `tez-api` protobuf `DAGApiRecords.proto` by removing `PlanEdgeDataSourceType` and `PlanEdgeSchedulingType` enums and renumbering/adjusting `PlanEdgeProperty` and `EdgePlan` fields accordingly.

### Testing
- Built the project and ran the test suite with `mvn -DskipTests=false package`, and the build and unit tests completed successfully.
- Executed module-level tests for `tez-api` and `tez-runtime-library` to validate compilation and API changes, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8fcde53988328be103992d378fc71)