### PR TITLE
Read raw keys into BytesWritable and remove deserializers in UnorderedKVReader/IFile

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -25,9 +25,7 @@ import java.util.NoSuchElementException;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.RawComparator;
-import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.tez.common.counters.TezCounter;
-import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
 import org.apache.tez.common.Preconditions;
@@ -47,10 +45,6 @@ public class ValuesIterator {
   private BytesWritable value;          // current value
   private boolean more;                 // more in file
   private final RawComparator<BytesWritable> comparator;
-  private final Deserializer<BytesWritable> keyDeserializer;
-  private final Deserializer<BytesWritable> valDeserializer;
-  private final DataInputBuffer keyIn = new DataInputBuffer();
-  private final DataInputBuffer valueIn = new DataInputBuffer();
   private final TezCounter inputKeyCounter;
   private final TezCounter inputValueCounter;
   
@@ -69,10 +63,6 @@ public class ValuesIterator {
     this.comparator = comparator;
     this.inputKeyCounter = inputKeyCounter;
     this.inputValueCounter = inputValueCounter;
-    this.keyDeserializer = SerializationContext.getKeyDeserializer();
-    this.keyDeserializer.open(this.keyIn);
-    this.valDeserializer = SerializationContext.getValueDeserializer();
-    this.valDeserializer.open(this.valueIn);
   }
 
   TezRawKeyValueIterator getRawIterator() { return in; }
@@ -169,9 +159,7 @@ public class ValuesIterator {
     if (more) {      
       DataInputBuffer nextKeyBytes = in.getKey();
       if (!in.isSameKey()) {
-        keyIn.reset(nextKeyBytes.getData(), nextKeyBytes.getPosition(),
-            nextKeyBytes.getLength() - nextKeyBytes.getPosition());
-        nextKey = keyDeserializer.deserialize(nextKey);
+        nextKey = copyToWritable(nextKey, nextKeyBytes);
         // hasMoreValues = is it first key or is key the same?
         hasMoreValues = (key == null) || (comparator.compare(key, nextKey) == 0);
         if (key == null || false == hasMoreValues) {
@@ -196,9 +184,16 @@ public class ValuesIterator {
    */
   private void readNextValue() throws IOException {
     DataInputBuffer nextValueBytes = in.getValue();
-    valueIn.reset(nextValueBytes.getData(), nextValueBytes.getPosition(),
-        nextValueBytes.getLength() - nextValueBytes.getPosition());
-    value = valDeserializer.deserialize(value);
+    value = copyToWritable(value, nextValueBytes);
+  }
+
+  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source) {
+    BytesWritable target = writable;
+    if (target == null) {
+      target = new BytesWritable();
+    }
+    target.set(source.getData(), source.getPosition(), source.getLength() - source.getPosition());
+    return target;
   }
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -26,7 +26,6 @@ import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
@@ -44,8 +43,6 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   private final ShuffleManager shuffleManager;
   private final CompressionCodec codec;
   
-  private final DataInputBuffer valIn;
-
   private final boolean ifileReadAhead;
   private final int ifileReadAheadLength;
 
@@ -72,7 +69,6 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     this.ifileReadAheadLength = ifileReadAheadLength;
     this.inputRecordCounter = inputRecordCounter;
 
-    this.valIn = new DataInputBuffer();
     this.key = new BytesWritable();
     this.value = new BytesWritable();
   }
@@ -130,8 +126,7 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     } else {
       boolean hasMore = this.currentReader.nextRawKey(key);
       if (hasMore) {
-        this.currentReader.nextRawValue(valIn);
-        this.value.set(valIn.getData(), valIn.getPosition(), valIn.getLength() - valIn.getPosition());
+        this.currentReader.nextRawValue(value);
         return true;
       }
       return false;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -28,10 +28,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
-import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleManager;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.InMemoryReader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
@@ -46,9 +44,6 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   private final ShuffleManager shuffleManager;
   private final CompressionCodec codec;
   
-  private final Deserializer<BytesWritable> keyDeserializer;
-  private final Deserializer<BytesWritable> valDeserializer;
-  private final DataInputBuffer keyIn;
   private final DataInputBuffer valIn;
 
   private final boolean ifileReadAhead;
@@ -57,8 +52,8 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   private final TezCounter inputRecordCounter;
   private final InputContext context;
   
-  private BytesWritable key;
-  private BytesWritable value;
+  private final BytesWritable key;
+  private final BytesWritable value;
   
   private FetchedInput currentFetchedInput;
   private IFile.Reader currentReader;
@@ -77,13 +72,9 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     this.ifileReadAheadLength = ifileReadAheadLength;
     this.inputRecordCounter = inputRecordCounter;
 
-    this.keyIn = new DataInputBuffer();
     this.valIn = new DataInputBuffer();
-
-    this.keyDeserializer = SerializationContext.getKeyDeserializer();
-    this.keyDeserializer.open(keyIn);
-    this.valDeserializer = SerializationContext.getValueDeserializer();
-    this.valDeserializer.open(valIn);
+    this.key = new BytesWritable();
+    this.value = new BytesWritable();
   }
 
   /**
@@ -137,11 +128,10 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     if (this.currentReader == null) {
       return false;
     } else {
-      boolean hasMore = this.currentReader.nextRawKey(keyIn);
+      boolean hasMore = this.currentReader.nextRawKey(key);
       if (hasMore) {
         this.currentReader.nextRawValue(valIn);
-        this.key = keyDeserializer.deserialize(this.key);
-        this.value = valDeserializer.deserialize(this.value);
+        this.value.set(valIn.getData(), valIn.getPosition(), valIn.getLength() - valIn.getPosition());
         return true;
       }
       return false;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
@@ -252,11 +253,61 @@ public class InMemoryReader extends Reader {
     }
   }
 
+  @Override
+  public KeyState readRawKey(BytesWritable key) throws IOException {
+    try {
+      if (!positionToNextRecord(memDataIn)) {
+        return KeyState.NO_KEY;
+      }
+      int pos = memDataIn.getPosition();
+      byte[] data = memDataIn.getData();
+      if (currentKeyLength == IFile.RLE_MARKER) {
+        return KeyState.SAME_KEY;
+      }
+      key.set(data, pos, currentKeyLength);
+      // Position for the next value
+      long skipped = memDataIn.skip(currentKeyLength);
+      if (skipped != currentKeyLength) {
+        throw new IOException("Rec# " + recNo +
+            ": Failed to skip past key of length: " +
+            currentKeyLength);
+      }
+      bytesRead += currentKeyLength;
+      return KeyState.NEW_KEY;
+    } catch (IOException ioe) {
+      dumpOnError();
+      throw ioe;
+    }
+  }
+
   public void nextRawValue(DataInputBuffer value) throws IOException {
     try {
       int pos = memDataIn.getPosition();
       byte[] data = memDataIn.getData();
       value.reset(data, pos, currentValueLength);
+
+      // Position for the next record
+      long skipped = memDataIn.skip(currentValueLength);
+      if (skipped != currentValueLength) {
+        throw new IOException("Rec# " + recNo +
+            ": Failed to skip past value of length: " +
+            currentValueLength);
+      }
+      // Record the byte
+      bytesRead += currentValueLength;
+      ++recNo;
+    } catch (IOException ioe) {
+      dumpOnError();
+      throw ioe;
+    }
+  }
+
+  @Override
+  public void nextRawValue(BytesWritable value) throws IOException {
+    try {
+      int pos = memDataIn.getPosition();
+      byte[] data = memDataIn.getData();
+      value.set(data, pos, currentValueLength);
 
       // Position for the next record
       long skipped = memDataIn.skip(currentValueLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -1057,6 +1057,23 @@ public class IFile {
       ++numRecordsRead;
     }
 
+    public void nextRawValue(BytesWritable value) throws IOException {
+      if (keyBytes.length < currentValueLength) {
+        keyBytes = createLargerArray(currentValueLength);
+      }
+      int i = readData(keyBytes, currentValueLength);
+      if (i != currentValueLength) {
+        throw new IOException(String.format(INCOMPLETE_READ, currentValueLength, i));
+      }
+      value.set(keyBytes, 0, currentValueLength);
+
+      // Record the bytes read
+      bytesRead += currentValueLength;
+
+      ++recNo;
+      ++numRecordsRead;
+    }
+
     private static void verifyHeaderMagic(byte[] header) throws IOException {
       if (!(header[0] == 'T' && header[1] == 'I'
           && header[2] == 'F')) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -1020,18 +1020,20 @@ public class IFile {
         return KeyState.NO_KEY;
       }
       if(currentKeyLength == RLE_MARKER) {
-        // get key length from original key
-        key.set(keyBytes, 0, originalKeyLength);
+        // BytesWritable readers reuse the same key object across records, so on RLE paths
+        // the previous key is already present in "key". Fall back to keyBytes only if needed.
+        if (key.getLength() != originalKeyLength) {
+          key.set(keyBytes, 0, originalKeyLength);
+        }
         return KeyState.SAME_KEY;
       }
-      if (keyBytes.length < currentKeyLength) {
-        keyBytes = createLargerArray(currentKeyLength);
-      }
-      int i = readData(keyBytes, currentKeyLength);
+      key.setSize(currentKeyLength);
+      byte[] keyData = key.getBytes();
+      keyBytes = keyData;
+      int i = readData(keyData, currentKeyLength);
       if (i != currentKeyLength) {
         throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
       }
-      key.set(keyBytes, 0, currentKeyLength);
       bytesRead += currentKeyLength;
       return KeyState.NEW_KEY;
     }
@@ -1058,14 +1060,12 @@ public class IFile {
     }
 
     public void nextRawValue(BytesWritable value) throws IOException {
-      if (keyBytes.length < currentValueLength) {
-        keyBytes = createLargerArray(currentValueLength);
-      }
-      int i = readData(keyBytes, currentValueLength);
+      value.setSize(currentValueLength);
+      byte[] valueBytes = value.getBytes();
+      int i = readData(valueBytes, currentValueLength);
       if (i != currentValueLength) {
         throw new IOException(String.format(INCOMPLETE_READ, currentValueLength, i));
       }
-      value.set(keyBytes, 0, currentValueLength);
 
       // Record the bytes read
       bytesRead += currentValueLength;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -1021,10 +1021,7 @@ public class IFile {
       }
       if(currentKeyLength == RLE_MARKER) {
         // BytesWritable readers reuse the same key object across records, so on RLE paths
-        // the previous key is already present in "key". Fall back to keyBytes only if needed.
-        if (key.getLength() != originalKeyLength) {
-          key.set(keyBytes, 0, originalKeyLength);
-        }
+        // the previous key is already present in "key".
         return KeyState.SAME_KEY;
       }
       key.setSize(currentKeyLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -963,6 +963,10 @@ public class IFile {
       return readRawKey(key) != KeyState.NO_KEY;
     }
 
+    public final boolean nextRawKey(BytesWritable key) throws IOException {
+      return readRawKey(key) != KeyState.NO_KEY;
+    }
+
     private static byte[] createLargerArray(int currentLength) {
       if (currentLength > MAX_BUFFER_SIZE) {
         throw new IllegalArgumentException(
@@ -1001,6 +1005,33 @@ public class IFile {
         throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
       }
       key.reset(keyBytes, currentKeyLength);
+      bytesRead += currentKeyLength;
+      return KeyState.NEW_KEY;
+    }
+
+    public KeyState readRawKey(BytesWritable key) throws IOException {
+      if (!positionToNextRecord(dataIn)) {
+        if (isDebugEnabled) {
+          LOG.debug("currentKeyLength=" + currentKeyLength +
+              ", currentValueLength=" + currentValueLength +
+              ", bytesRead=" + bytesRead +
+              ", length=" + fileLength);
+        }
+        return KeyState.NO_KEY;
+      }
+      if(currentKeyLength == RLE_MARKER) {
+        // get key length from original key
+        key.set(keyBytes, 0, originalKeyLength);
+        return KeyState.SAME_KEY;
+      }
+      if (keyBytes.length < currentKeyLength) {
+        keyBytes = createLargerArray(currentKeyLength);
+      }
+      int i = readData(keyBytes, currentKeyLength);
+      if (i != currentKeyLength) {
+        throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
+      }
+      key.set(keyBytes, 0, currentKeyLength);
       bytesRead += currentKeyLength;
       return KeyState.NEW_KEY;
     }


### PR DESCRIPTION
### Motivation

- Reduce overhead and dependency on Hadoop serializers by reading keys/values directly into `BytesWritable` objects for unordered KV reading.

### Description

- Replace `DataInputBuffer` + Hadoop `Deserializer` usage in `UnorderedKVReader` with `BytesWritable` fields for both key and value and remove `SerializationContext` imports.
- Update `readNextFromCurrentReader` in `UnorderedKVReader` to call the new `IFile` API that reads raw keys into a `BytesWritable` and to populate the value `BytesWritable` directly from the value buffer.
- Add `nextRawKey(BytesWritable)` and `readRawKey(BytesWritable)` overloads in `IFile.Reader` to support writing key bytes directly into a `BytesWritable` without intermediate deserialization or buffer re-wrapping.
- Minor field cleanup to make `key`/`value` final and remove unused deserializer and `DataInputBuffer` for keys.

### Testing

- Ran the module unit tests for `tez-runtime-library` with `mvn test` and verified the tests completed successfully.
- Verified that existing reader code paths compile and that basic read loops (`next`, `getCurrentKey`, `getCurrentValue`) function without throwing IO errors during local integration runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf5768708883288054aeb98f0f4dab)