### PR TITLE
Consolidate DiskSegment constructors and update call sites

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -942,7 +942,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         final Path file = fileChunk.getPath();
         approxOutputSize += size;
         DiskSegment segment = new DiskSegment(rfs, file, offset, size, codec, ifileReadAhead,
-            ifileReadAheadLength, preserve, inputContext);
+            ifileReadAheadLength, preserve, null, inputContext);
         inputSegments.add(segment);
       }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -846,7 +846,7 @@ public class PipelinedSorter extends ExternalSorter {
             DiskSegment s =
                 new DiskSegment(localFs, spillFilename, indexRecord.getStartOffset(),
                     indexRecord.getPartLength(), codec, ifileReadAhead,
-                    ifileReadAheadLength, true, outputContext);
+                    ifileReadAheadLength, true, null, outputContext);
             segmentList.add(s);
           }
         }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -226,32 +226,6 @@ public class TezMerger {
     final DecompressorPool inputContext;
 
     public DiskSegment(FileSystem fs, Path file,
-        CompressionCodec codec, boolean ifileReadAhead,
-        int ifileReadAheadLength, boolean preserve, DecompressorPool inputContext)
-    throws IOException {
-      this(fs, file, codec, ifileReadAhead, ifileReadAheadLength,
-          preserve, null, inputContext);
-    }
-
-    public DiskSegment(FileSystem fs, Path file,
-                   CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLenth,
-                   boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)
-    throws IOException {
-      this(fs, file, 0, fs.getFileStatus(file).getLen(), codec,
-          ifileReadAhead, ifileReadAheadLenth, preserve,
-          mergedMapOutputsCounter, inputContext);
-    }
-
-    public DiskSegment(FileSystem fs, Path file,
-                   long segmentOffset, long segmentLength,
-                   CompressionCodec codec, boolean ifileReadAhead,
-                   int ifileReadAheadLength,
-                   boolean preserve, DecompressorPool inputContext) throws IOException {
-      this(fs, file, segmentOffset, segmentLength, codec, ifileReadAhead,
-          ifileReadAheadLength, preserve, null, inputContext);
-    }
-
-    public DiskSegment(FileSystem fs, Path file,
         long segmentOffset, long segmentLength, CompressionCodec codec,
         boolean ifileReadAhead, int ifileReadAheadLength,
         boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)
@@ -608,9 +582,9 @@ public class TezMerger {
           this.close();
 
           // Add the newly create segment to the list of segments to be merged
-          Segment tempSegment = 
-            new DiskSegment(fs, outputFile, codec, ifileReadAhead,
-                ifileReadAheadLength, false, inputContext);
+          Segment tempSegment =
+            new DiskSegment(fs, outputFile, 0, fs.getFileStatus(outputFile).getLen(), codec,
+                ifileReadAhead, ifileReadAheadLength, false, null, inputContext);
 
           // Insert new merged segment into the sorted list
           int pos = Collections.binarySearch(segments, tempSegment,


### PR DESCRIPTION
### Motivation
- Reduce API surface and eliminate duplicate convenience constructors for `DiskSegment` by keeping a single, most-general constructor that accepts `segmentOffset`, `segmentLength`, and an optional `TezCounter`.

### Description
- Removed three overloaded `DiskSegment` constructors from `TezMerger` and retained only the general constructor taking `(FileSystem, Path, long segmentOffset, long segmentLength, CompressionCodec, boolean ifileReadAhead, int ifileReadAheadLength, boolean preserve, TezCounter mergedMapOutputsCounter, DecompressorPool inputContext)`.
- Updated all call sites to invoke the general constructor explicitly, including `TezMerger` (create temp merged segment with `segmentOffset=0` and `segmentLength=fs.getFileStatus(outputFile).getLen()` and `mergedMapOutputsCounter=null`), `PipelinedSorter` (pass `mergedMapOutputsCounter=null`), and `MergeManager` (pass `mergedMapOutputsCounter=null`).
- Modified the following files: `tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java`, `tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java`, and `tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java`.

### Testing
- Ran a targeted Maven compile with `mvn -pl tez-runtime-library -DskipTests compile` which failed due to external plugin resolution (`com.github.os72:protoc-jar-maven-plugin:3.8.0` returned HTTP 403 from a remote repository) and not because of reported source-level compilation errors.
- Performed code search to find and update all `new DiskSegment(` call sites within the runtime library to ensure consistency, and no remaining usages of the removed overloads were left (search performed during the change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb9906c5c832896993f8b2e47bd33)