### PR TITLE
Replace Serializer usage with direct BytesWritable writes in unordered KV writers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/BaseUnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/BaseUnorderedPartitionedKVWriter.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.serializer.Serializer;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.api.Event;
@@ -42,7 +41,6 @@ import org.apache.tez.runtime.library.api.KeyValuesWriterEdge;
 import org.apache.tez.runtime.library.api.Partitioner;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.TezRuntimeUtils;
-import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.api.TezTaskOutput;
 import org.apache.tez.runtime.library.utils.CodecUtils;
 
@@ -60,8 +58,6 @@ public abstract class BaseUnorderedPartitionedKVWriter extends KeyValuesWriterEd
   protected final int numPartitions;
 
   protected final Partitioner partitioner;
-  protected final Serializer<BytesWritable> keySerializer;
-  protected final Serializer<BytesWritable> valSerializer;
   protected final CompressionCodec codec;
 
   protected final String auxiliaryService;
@@ -132,10 +128,6 @@ public abstract class BaseUnorderedPartitionedKVWriter extends KeyValuesWriterEd
       throw new RuntimeException(e);
     }
     this.numPartitions = numOutputs;
-    
-    // k/v serialization
-    keySerializer = SerializationContext.getKeySerializer();
-    valSerializer = SerializationContext.getValueSerializer();
     
     outputRecordsCounter = outputContext.getCounters().findCounter(TaskCounter.OUTPUT_RECORDS);
     outputLargeRecordsCounter = outputContext.getCounters().findCounter(TaskCounter.OUTPUT_LARGE_RECORDS);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -60,7 +60,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezUtilsInternal;
 import org.apache.tez.common.counters.TezCounter;
-import org.apache.tez.common.io.NonSyncDataOutputStream;
 import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.ExecutorServiceUserGroupInformation;
 import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
@@ -144,7 +143,6 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
   private int spillLimit;
 
   private final ByteArrayOutputStream baos;
-  private final NonSyncDataOutputStream dos;
 
   private BlockingQueue<WrappedBuffer> availableBuffers;
   private WrappedBuffer[] buffers;
@@ -267,10 +265,6 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     }
 
     baos = new ByteArrayOutputStream();
-    dos = new NonSyncDataOutputStream(baos);
-    keySerializer.open(dos);
-    valSerializer.open(dos);
-
     if (!skipBuffers) {
       // originally the default value of TEZ_RUNTIME_UNORDERED_OUTPUT_MAX_PER_BUFFER_SIZE_BYTES
       int maxSingleBufferSizeBytes = Integer.MAX_VALUE;
@@ -410,7 +404,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     currentBuffer.availableSize -= (META_SIZE + metaSkip);
     currentBuffer.nextPosition += META_SIZE;
 
-    keySerializer.serialize(key);
+    baos.write(key.getBytes(), 0, key.getLength());
 
     if (currentBuffer.full) {
       if (metaStart == 0) { // Started writing at the start of the buffer. Write Key to disk.
@@ -428,7 +422,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     }
 
     int valStart = currentBuffer.nextPosition;
-    valSerializer.serialize(value);
+    baos.write(value.getBytes(), 0, value.getLength());
 
     if (currentBuffer.full) {
       // Value too large for current buffer, or K-V too large for entire buffer.


### PR DESCRIPTION
### Motivation
- Remove reliance on Hadoop `Serializer`/`SerializationContext` for key/value serialization and simplify the in-memory write path by writing `BytesWritable` contents directly to the buffer stream.

### Description
- Removed `Serializer<BytesWritable>` fields and `SerializationContext` usage from `BaseUnorderedPartitionedKVWriter` and related imports.
- Removed `NonSyncDataOutputStream` and serializer `open` calls in `UnorderedPartitionedKVWriter`, and replaced `keySerializer.serialize(...)` and `valSerializer.serialize(...)` with direct `baos.write(key.getBytes(), 0, key.getLength())` and `baos.write(value.getBytes(), 0, value.getLength())` respectively.
- Cleaned up unused imports and initialization code while preserving existing buffer/meta management and spill logic.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfbc2de0f08328a217bd6bf3e1c97a)