### PR TITLE
Optimize IFile.WriterBytesWritable to write BytesWritable directly

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -47,8 +47,6 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
-import org.apache.hadoop.io.serializer.Serializer;
-import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.common.counters.TezCounter;
 
 import javax.annotation.Nullable;
@@ -602,10 +600,6 @@ public class IFile {
 
   public static class WriterBytesWritable extends Writer {
 
-    private final Serializer<BytesWritable> keySerializer;
-    private final Serializer<BytesWritable> valueSerializer;
-    private final DataOutputBuffer buffer = new DataOutputBuffer();
-
     public WriterBytesWritable(FileSystem fs, Path file,
         CompressionCodec codec,
         TezCounter writesCounter,
@@ -619,30 +613,16 @@ public class IFile {
         CompressionCodec codec, TezCounter writesCounter, TezCounter serializedBytesCounter,
         byte[] writeBuffer, @Nullable Compressor compressorExternal) throws IOException {
       super(outputStream, codec, writesCounter, serializedBytesCounter, writeBuffer, compressorExternal);
-      this.keySerializer = SerializationContext.getKeySerializer();
-      this.keySerializer.open(buffer);
-      this.valueSerializer = SerializationContext.getValueSerializer();
-      this.valueSerializer.open(buffer);
     }
 
     public void append(BytesWritable key, BytesWritable value) throws IOException {
-      keySerializer.serialize(key);
-      int keyLength = buffer.getLength();
+      int keyLength = key.getLength();
       assert (keyLength >= 0);
 
-      valueSerializer.serialize(value);
-      int valueLength = buffer.getLength() - keyLength;
+      int valueLength = value.getLength();
       assert (valueLength >= 0);
-      writeKVPair(buffer.getData(), 0, keyLength, buffer.getData(), keyLength, valueLength);
-
-      buffer.reset();
+      writeKVPair(key.getBytes(), 0, keyLength, value.getBytes(), 0, valueLength);
       incrementRecordsWritten();
-    }
-
-    @Override
-    protected void onClose() throws IOException {
-      keySerializer.close();
-      valueSerializer.close();
     }
   }
 


### PR DESCRIPTION
### Motivation

- Remove an unnecessary serialization staging step and extra copy since `TezBytesWritableSerializer.serialize()` writes raw backing bytes without framing. 
- Reduce allocations and buffer management in the hot path of IFile writes by writing `BytesWritable` backing arrays directly.

### Description

- Removed `keySerializer`, `valueSerializer`, and the intermediate `DataOutputBuffer` from `IFile.WriterBytesWritable`.
- Updated `append(BytesWritable key, BytesWritable value)` to use `key.getLength()` / `value.getLength()` and call `writeKVPair(key.getBytes(), 0, keyLength, value.getBytes(), 0, valueLength)` directly.
- Dropped the serializer lifecycle calls (constructor `open()` / `onClose()` `close()` handling) and cleaned up now-unused serializer imports.

### Testing

- Ran a module compile with `mvn -pl tez-runtime-library -DskipTests compile` as an automated sanity check, but the build could not proceed in this environment due to external plugin resolution failure (`com.github.os72:protoc-jar-maven-plugin:3.8.0` returned HTTP 403 from `maven.atlassian.com`).
- No unit/integration tests were executed in this environment due to the build plugin resolution issue, so behavior should be validated in a CI environment where Maven can resolve all plugins.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd1c02d78832898dc8471302131d1)