### PR TITLE
Remove redundant BytesWritable serializers in ExternalSorter/PipelinedSorter

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/ExternalSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/ExternalSorter.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.RawComparator;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.serializer.Serializer;
 import org.apache.hadoop.util.IndexedSorter;
 import org.apache.hadoop.util.Progressable;
 import org.apache.hadoop.util.QuickSort;
@@ -92,9 +91,6 @@ public abstract class ExternalSorter {
   protected final RawComparator comparator;
 
   protected final Partitioner partitioner;
-
-  protected final Serializer<BytesWritable> keySerializer;
-  protected final Serializer<BytesWritable> valSerializer;
 
   // Compression for map-outputs
   protected final CompressionCodec codec;
@@ -182,13 +178,10 @@ public abstract class ExternalSorter {
     this.conf.setInt(TezRuntimeFrameworkConfigs.TEZ_RUNTIME_NUM_EXPECTED_PARTITIONS, this.partitions);
     this.partitioner = TezRuntimeUtils.instantiatePartitioner(this.conf);
 
-    // k/v serialization
-    this.keySerializer = SerializationContext.getKeySerializer();
-    this.valSerializer = SerializationContext.getValueSerializer();
     LOG.info("{}, memoryMb={}", outputContext.getDestinationVertexName(), assignedMb);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("keySerializerClass=" + SerializationContext.getKeyClass()
-          + ", valueSerializerClass=" + SerializationContext.getValueClass()
+      LOG.debug("keyClass=" + SerializationContext.getKeyClass()
+          + ", valueClass=" + SerializationContext.getValueClass()
           + ", comparator=" + SerializationContext.getKeyComparator()
           + ", partitioner=" + conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS)
           + ", reportPartitionStats=" + reportPartitionStats);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -227,9 +227,6 @@ public class PipelinedSorter extends ExternalSorter {
         .setNameFormat("Sorter {" + outputContext.getDestinationVertexName() + "} #%d")
         .build());
 
-    valSerializer.open(this.span.out);
-    keySerializer.open(this.span.out);
-
     this.deflater = TezCommonUtils.newBestCompressionDeflater();
 
     this.finalEvents = Lists.newLinkedList();
@@ -375,8 +372,6 @@ public class PipelinedSorter extends ExternalSorter {
       merger.add(future);
       span = newSpan;
     }
-    valSerializer.open(span.out);
-    keySerializer.open(span.out);
   }
 
   // if pipelined shuffle is enabled, this method is called to send events for every spill
@@ -423,9 +418,9 @@ public class PipelinedSorter extends ExternalSorter {
     int valstart = -1;
     int valend = -1;
     try {
-      keySerializer.serialize(key);
+      span.out.write(key.getBytes(), 0, key.getLength());
       valstart = span.kvbuffer.position();      
-      valSerializer.serialize(value);
+      span.out.write(value.getBytes(), 0, value.getLength());
       valend = span.kvbuffer.position();
     } catch (BufferOverflowException overflow) {
       // restore limit


### PR DESCRIPTION
### Motivation
- `SerializationContext.TezBytesWritableSerializer.serialize()` simply writes the raw bytes from `BytesWritable`, so maintaining `keySerializer` and `valSerializer` fields and calling `serialize()` is redundant for this code path.
- Removing the serializers simplifies the sorter code and avoids unnecessary indirection when writing key/value bytes into the in-memory span output.

### Description
- Removed `keySerializer` and `valSerializer` fields and their import from `ExternalSorter` and eliminated their initialization in the constructor.
- Replaced calls to `keySerializer.serialize(key)` and `valSerializer.serialize(value)` in `PipelinedSorter.collect()` with direct writes to the span output via `span.out.write(key.getBytes(), 0, key.getLength())` and `span.out.write(value.getBytes(), 0, value.getLength())`.
- Removed the `open()` calls for the serializers in `PipelinedSorter` initialization and span switching logic.
- Clarified the debug log labels in `ExternalSorter` from `keySerializerClass/valueSerializerClass` to `keyClass/valueClass` to reflect the actual information being logged.

### Testing
- Attempted to compile the module with `mvn -pl tez-runtime-library -DskipTests compile`, but the build failed due to external plugin resolution (`com.github.os72:protoc-jar-maven-plugin:3.8.0` fetch from an external repository returned HTTP 403), which is unrelated to the code changes and prevented a successful compile verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfd48f3b9c83289d2d386b2fef1898)