### PR TITLE
Use LongBuffer for SortSpan metadata in PipelinedSorter

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -23,6 +23,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -974,12 +975,10 @@ public class PipelinedSorter extends ExternalSorter {
 
   private final class SortSpan implements IndexedSortable {
     final IntBuffer kvmeta;
-    final byte[] rawkvmeta;
-    final int kvmetabase;
+    final LongBuffer kvmetalong;
     final ByteBuffer kvbuffer;
     final NonSyncDataOutputStream out;
     final RawComparator comparator;
-    final byte[] imeta = new byte[METASIZE];
 
     private int index = 0;
     private long eq = 0;
@@ -1005,11 +1004,9 @@ public class PipelinedSorter extends ExternalSorter {
       reserved.flip();
       reserved.limit(metasize);
       ByteBuffer kvmetabuffer = reserved.slice();
-      rawkvmeta = kvmetabuffer.array();
-      kvmetabase = kvmetabuffer.arrayOffset();
-      kvmeta = kvmetabuffer
-                .order(ByteOrder.nativeOrder())
-               .asIntBuffer();
+      ByteBuffer orderedMetaBuffer = kvmetabuffer.order(ByteOrder.nativeOrder());
+      kvmeta = orderedMetaBuffer.asIntBuffer();
+      kvmetalong = orderedMetaBuffer.asLongBuffer();
       out = new NonSyncDataOutputStream(
               new BufferStreamWrapper(kvbuffer));
       this.comparator = comparator;
@@ -1028,15 +1025,21 @@ public class PipelinedSorter extends ExternalSorter {
       return (i * NMETA);
     }
 
-    public void swap(final int mi, final int mj) {
-      final int kvi = offsetFor(mi);
-      final int kvj = offsetFor(mj);
+    int longOffsetFor(int i) {
+      return i * (NMETA / 2);
+    }
 
-      final int kvioff = kvmetabase + (kvi << 2);
-      final int kvjoff = kvmetabase + (kvj << 2);
-      System.arraycopy(rawkvmeta, kvioff, imeta, 0, METASIZE);
-      System.arraycopy(rawkvmeta, kvjoff, rawkvmeta, kvioff, METASIZE);
-      System.arraycopy(imeta, 0, rawkvmeta, kvjoff, METASIZE);
+    public void swap(final int mi, final int mj) {
+      final int kvi = longOffsetFor(mi);
+      final int kvj = longOffsetFor(mj);
+      final long l1 = kvmetalong.get(kvi);
+      final long l2 = kvmetalong.get(kvi + 1);
+
+      kvmetalong.put(kvi, kvmetalong.get(kvj));
+      kvmetalong.put(kvi + 1, kvmetalong.get(kvj + 1));
+
+      kvmetalong.put(kvj, l1);
+      kvmetalong.put(kvj + 1, l2);
     }
 
     protected int compareKeys(final int kvi, final int kvj) {


### PR DESCRIPTION
### Motivation
- Replace raw byte-array metadata manipulation with typed buffers to simplify swaps, avoid manual array copies, and improve correctness and performance when handling metadata.

### Description
- Add `LongBuffer` support and a new `kvmetalong` field to `SortSpan` and import `java.nio.LongBuffer`.
- Create an ordered meta `ByteBuffer` (`orderedMetaBuffer`) and derive both `kvmeta = orderedMetaBuffer.asIntBuffer()` and `kvmetalong = orderedMetaBuffer.asLongBuffer()` from it.
- Remove `rawkvmeta`, `kvmetabase`, and the temporary `imeta` byte array, and replace `System.arraycopy` based metadata swaps with `LongBuffer` `get`/`put` operations.
- Introduce `longOffsetFor(int)` and update `swap` to use long-indexed offsets to swap metadata pairs via `kvmetalong`.

### Testing
- Ran the project's unit test suite using `mvn test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d23d8f47e883288e26823347e9c620)