### PR TITLE
Optimize buffer allocation and spilling in UnorderedPartitionedKVWriter (final-merge path)

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -276,9 +276,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
 
     baos = new ByteArrayOutputStream();
     if (!skipBuffers) {
-      // originally the default value of TEZ_RUNTIME_UNORDERED_OUTPUT_MAX_PER_BUFFER_SIZE_BYTES
-      int maxSingleBufferSizeBytes = Integer.MAX_VALUE;
-      computeNumBuffersAndSize(maxSingleBufferSizeBytes);
+      computeNumBuffersAndSize();
 
       availableBuffers = new LinkedBlockingQueue<WrappedBuffer>();
       buffers = new WrappedBuffer[numBuffers];
@@ -330,47 +328,29 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     }
   }
 
-  private static final int ALLOC_OVERHEAD = 64;
-  private void computeNumBuffersAndSize(int bufferLimit) {
-    numBuffers = (int)(availableMemory / bufferLimit);
-
-    if (numBuffers >= 2) {
-      sizePerBuffer = bufferLimit - ALLOC_OVERHEAD;
-      lastBufferSize = (int)(availableMemory % bufferLimit);
-      // Use leftover memory last buffer only if the leftover memory > 50% of bufferLimit
-      if (lastBufferSize > bufferLimit / 2) {
-        numBuffers += 1;
-      } else {
-        if (lastBufferSize > 0) {
-          LOG.warn("Underallocating memory. Unused memory size: {}.",  lastBufferSize);
-        }
-        lastBufferSize = sizePerBuffer;
-      }
+  private void computeNumBuffersAndSize() {
+    // Non-pipelined + final merge path: keep more in-memory buffers to reduce spill frequency.
+    // Pipelined path: preserve existing behavior of eager spilling with 2 buffers.
+    if (!isPipelinedShuffle && isFinalMergeEnabled) {
+      numBuffers = 4;
     } else {
-      // We should have minimum of 2 buffers.
       numBuffers = 2;
-      if (availableMemory / numBuffers > Integer.MAX_VALUE) {
-        sizePerBuffer = Integer.MAX_VALUE;
-      } else {
-        sizePerBuffer = (int)(availableMemory / numBuffers);
-      }
-      // 2 equal sized buffers.
-      lastBufferSize = sizePerBuffer;
     }
+    if (availableMemory / numBuffers > Integer.MAX_VALUE) {
+      sizePerBuffer = Integer.MAX_VALUE;
+    } else {
+      sizePerBuffer = (int)(availableMemory / numBuffers);
+    }
+    // equal sized buffers
+    lastBufferSize = sizePerBuffer;
     // Ensure allocation size is multiple of INT_SIZE, truncate down.
     sizePerBuffer = sizePerBuffer - (sizePerBuffer % INT_SIZE);
     lastBufferSize = lastBufferSize - (lastBufferSize % INT_SIZE);
 
-    int mergePercent = conf.getInt(
-        TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_PARTITIONED_KVWRITER_BUFFER_MERGE_PERCENT,
-        TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_PARTITIONED_KVWRITER_BUFFER_MERGE_PERCENT_DEFAULT);
-    spillLimit = numBuffers * mergePercent / 100;
-    // Keep within limits.
-    if (spillLimit < 1) {
+    if (!isPipelinedShuffle && isFinalMergeEnabled) {
+      spillLimit = 3;
+    } else {
       spillLimit = 1;
-    }
-    if (spillLimit > numBuffers) {
-      spillLimit = numBuffers;
     }
   }
 
@@ -549,10 +529,10 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       boolean spillToFreeMemory = isPipelinedShuffle && useFreeMemoryWriterOutput;
 
       CompressionCodec spillCodec = spillCompressed ? codec : null;
+      WrappedBuffer oldestBuffer = filledBuffers.remove(0);
       ListenableFuture<SpillResult> future = spillExecutor.submit(new SpillCallable(
-          new ArrayList<WrappedBuffer>(filledBuffers), spillCodec, spilledRecordsCounter,
+          Collections.singletonList(oldestBuffer), spillCodec, spilledRecordsCounter,
           spillNumber, spillToFreeMemory));
-      filledBuffers.clear();
       Futures.addCallback(future, new SpillCallback(spillNumber));
       // Update once per buffer (instead of every record)
       updateTezCountersAndNotify();
@@ -799,8 +779,11 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
 
   @Override
   public List<Event> close() throws IOException, InterruptedException {
-    // In case there are buffers to be spilled, schedule spilling
-    scheduleSpill(true);
+    // In case there are buffers to be spilled, schedule spilling.
+    // For final-merge mode, filledBuffers are merged directly in mergeAll().
+    if (!isFinalMergeEnabled) {
+      scheduleSpill(true);
+    }
     List<Event> eventList = Lists.newLinkedList();
     isShutdown.set(true);
     spillLock.lock();
@@ -883,10 +866,12 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
              - If finalSpill did not generate data, it would automatically populate events
          */
         if (isFinalMergeEnabled) {
-          if (numSpills.get() > 0) {
+          // Keep the no-data fast path that existed in finalSpill() when there were no prior spills.
+          // In this case, final output generation should be skipped.
+          boolean noDataWithNoSpills =
+              (numSpills.get() == 0) && filledBuffers.isEmpty() && (currentBuffer.nextPosition == 0);
+          if (!noDataWithNoSpills) {
             mergeAll();
-          } else {
-            finalSpill();
           }
           updateTezCountersAndNotify();
           eventList.add(generateVMEvent());
@@ -912,6 +897,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
           //all events to be sent out are in finalEvents.
           eventList.addAll(finalEvents);
         }
+        filledBuffers.clear();
         cleanupCurrentBuffer();   // skipBuffers == false
         return eventList;
       }
@@ -1153,6 +1139,10 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
 
   private void mergeAll() throws IOException {
     long expectedSize = spilledSize;
+    for (WrappedBuffer buffer : filledBuffers) {
+      expectedSize += buffer.nextPosition - (buffer.numRecords * META_SIZE)
+          - buffer.skipSize + numPartitions * APPROX_HEADER_LENGTH;
+    }
     if (currentBuffer.nextPosition != 0) {
       expectedSize += currentBuffer.nextPosition - (currentBuffer.numRecords * META_SIZE)
           - currentBuffer.skipSize + numPartitions * APPROX_HEADER_LENGTH;
@@ -1212,6 +1202,11 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
             // Write current buffer.
             writePartition(currentBuffer.partitionHeads[i], currentBuffer, writer, keyBuffer,
                 valBuffer);
+          }
+          for (WrappedBuffer buffer : filledBuffers) {
+            if (buffer.partitionHeads[i] != WrappedBuffer.PARTITION_ABSENT_POSITION) {
+              writePartition(buffer.partitionHeads[i], buffer, writer, keyBuffer, valBuffer);
+            }
           }
           synchronized (spillInfoList) {
             for (SpillInfo spillInfo : spillInfoList) {


### PR DESCRIPTION
### Motivation
- Reduce unnecessary spilling and memory pressure by keeping more in-memory buffers for non-pipelined final-merge flows and avoid eager multi-buffer spills.
- Ensure filled but unspilled buffers are included in the final merge so data isn't lost or prematurely written out.
- Skip unnecessary spill scheduling and final output generation in no-data scenarios to avoid producing empty spill artifacts.

### Description
- Replaced the previous `computeNumBuffersAndSize(int)` logic with `computeNumBuffersAndSize()` that selects `numBuffers=4` for non-pipelined + final-merge and `numBuffers=2` otherwise, removed ALLOC_OVERHEAD and leftover-buffer heuristics, and aligned buffer sizes to `INT_SIZE`.
- Set `spillLimit` to `3` for the non-pipelined final-merge case and `1` otherwise, simplifying previous percent-based logic.
- Changed spill submission to only remove and submit the oldest filled buffer (`filledBuffers.remove(0)`) instead of submitting all `filledBuffers` at once, and moved clearing of `filledBuffers` to the finalization path.
- In `close()`, skip scheduling an intermediate spill when final-merge is enabled because `mergeAll()` will process filled buffers directly.
- Enhanced `mergeAll()` to account for `filledBuffers` in the expected size calculation and to write partitions from `filledBuffers` into the final merged output.
- Added a fast-path check to skip final-merge output generation when there are no prior spills, no filled buffers, and the current buffer is empty, and clear `filledBuffers` after final event generation.

### Testing
- Ran the module unit test suite for the runtime library and existing shuffle integration tests against these changes, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d60f5f8af48328b79a05cd8ce18761)