### PR TITLE
Disassociate in-memory merge readers from IFile.Reader inheritance

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -21,6 +21,7 @@ package org.apache.tez.runtime.library.common.readers;
 import java.io.IOException;
 
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.slf4j.Logger;
@@ -51,9 +52,11 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   
   private final BytesWritable key;
   private final BytesWritable value;
+  private final DataInputBuffer keyIn;
+  private final DataInputBuffer valueIn;
   
   private FetchedInput currentFetchedInput;
-  private IFile.Reader currentReader;
+  private IFile.KeyValueInputReader currentReader;
   
   // TODO Remove this once per I/O counters are separated properly. Relying on
   // the counter at the moment will generate aggregate numbers. 
@@ -71,6 +74,8 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
 
     this.key = new BytesWritable();
     this.value = new BytesWritable();
+    this.keyIn = new DataInputBuffer();
+    this.valueIn = new DataInputBuffer();
   }
 
   /**
@@ -124,13 +129,20 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     if (this.currentReader == null) {
       return false;
     } else {
-      boolean hasMore = this.currentReader.nextRawKey(key);
+      boolean hasMore = this.currentReader.readRawKey(keyIn) != IFile.Reader.KeyState.NO_KEY;
       if (hasMore) {
-        this.currentReader.nextRawValue(value);
+        setBytesWritableFromDataInputBuffer(keyIn, key);
+        this.currentReader.nextRawValue(valueIn);
+        setBytesWritableFromDataInputBuffer(valueIn, value);
         return true;
       }
       return false;
     }
+  }
+
+  private static void setBytesWritableFromDataInputBuffer(DataInputBuffer in, BytesWritable out) {
+    final int position = in.getPosition();
+    out.set(in.getData(), position, in.getLength() - position);
   }
   
   /**
@@ -166,7 +178,7 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     }
   }
 
-  private IFile.Reader openIFileReader(FetchedInput fetchedInput)
+  private IFile.KeyValueInputReader openIFileReader(FetchedInput fetchedInput)
       throws IOException {
     if (fetchedInput.getType() == Type.MEMORY) {
       MemoryFetchedInput mfi = (MemoryFetchedInput) fetchedInput;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -21,7 +21,6 @@ package org.apache.tez.runtime.library.common.readers;
 import java.io.IOException;
 
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.slf4j.Logger;
@@ -52,8 +51,6 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   
   private final BytesWritable key;
   private final BytesWritable value;
-  private final DataInputBuffer keyIn;
-  private final DataInputBuffer valueIn;
   
   private FetchedInput currentFetchedInput;
   private IFile.KeyValueInputReader currentReader;
@@ -74,8 +71,6 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
 
     this.key = new BytesWritable();
     this.value = new BytesWritable();
-    this.keyIn = new DataInputBuffer();
-    this.valueIn = new DataInputBuffer();
   }
 
   /**
@@ -129,20 +124,13 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     if (this.currentReader == null) {
       return false;
     } else {
-      boolean hasMore = this.currentReader.readRawKey(keyIn) != IFile.Reader.KeyState.NO_KEY;
+      boolean hasMore = this.currentReader.readRawKey(key) != IFile.Reader.KeyState.NO_KEY;
       if (hasMore) {
-        setBytesWritableFromDataInputBuffer(keyIn, key);
-        this.currentReader.nextRawValue(valueIn);
-        setBytesWritableFromDataInputBuffer(valueIn, value);
+        this.currentReader.nextRawValue(value);
         return true;
       }
       return false;
     }
-  }
-
-  private static void setBytesWritableFromDataInputBuffer(DataInputBuffer in, BytesWritable out) {
-    final int position = in.getPosition();
-    out.set(in.getData(), position, in.getLength() - position);
   }
   
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -269,6 +269,7 @@ public class InMemoryReader implements KeyValueInputReader {
     return true;
   }
 
+  @Override
   public KeyState readRawKey(DataInputBuffer key) throws IOException {
     try {
       if (!positionToNextRecord(memDataIn)) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -305,6 +305,8 @@ public class InMemoryReader implements KeyValueInputReader {
         return KeyState.NO_KEY;
       }
       if (currentKeyLength == IFile.RLE_MARKER) {
+        byte[] data = memDataIn.getData();
+        key.set(data, originalKeyPos, originalKeyLength);
         return KeyState.SAME_KEY;
       }
       int pos = memDataIn.getPosition();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -269,7 +269,6 @@ public class InMemoryReader implements KeyValueInputReader {
     return true;
   }
 
-  @Override
   public KeyState readRawKey(DataInputBuffer key) throws IOException {
     try {
       if (!positionToNextRecord(memDataIn)) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -28,12 +28,13 @@ import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.KeyValueInputReader;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
 
 /**
  * <code>IFile.InMemoryReader</code> to read map-outputs present in-memory.
  */
-public class InMemoryReader extends Reader {
+public class InMemoryReader implements KeyValueInputReader {
 
   private static class ByteArrayDataInput extends NonSyncByteArrayInputStream implements DataInput {
 
@@ -151,6 +152,13 @@ public class InMemoryReader extends Reader {
 
   private final MergeManager merger;
   private final InputAttemptIdentifier taskAttemptId;
+  private boolean eof = false;
+  private int recNo = 1;
+  private int originalKeyLength;
+  private int prevKeyLength;
+  private int currentKeyLength;
+  private int currentValueLength;
+  private long bytesRead;
   private int originalKeyPos;
 
   private byte[] buffer = null;
@@ -163,7 +171,6 @@ public class InMemoryReader extends Reader {
   public InMemoryReader(MergeManager merger, InputAttemptIdentifier taskAttemptId,
                         byte[] data, int start, int length, int usedMemoryForMergeManager)
       throws IOException {
-    super(null, length - start, null, null, null, false, 0, null);
     this.merger = merger;
     this.taskAttemptId = taskAttemptId;
 
@@ -218,12 +225,52 @@ public class InMemoryReader extends Reader {
   }
 
   protected void readKeyValueLength(DataInput dIn) throws IOException {
-    super.readKeyValueLength(dIn);
+    currentKeyLength = dIn.readInt();
+    currentValueLength = dIn.readInt();
     if (currentKeyLength != IFile.RLE_MARKER) {
+      originalKeyLength = currentKeyLength;
       originalKeyPos = memDataIn.getPosition();
+    }
+    bytesRead += Integer.BYTES + Integer.BYTES;
+  }
+
+  protected void readValueLength(DataInput dIn) throws IOException {
+    currentValueLength = dIn.readInt();
+    bytesRead += Integer.BYTES;
+    if (currentValueLength == IFile.V_END_MARKER) {
+      readKeyValueLength(dIn);
     }
   }
 
+  protected boolean positionToNextRecord(DataInput dIn) throws IOException {
+    if (eof) {
+      throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
+    }
+    prevKeyLength = currentKeyLength;
+
+    if (prevKeyLength == IFile.RLE_MARKER) {
+      readValueLength(dIn);
+    } else {
+      readKeyValueLength(dIn);
+    }
+
+    if (currentKeyLength == IFile.EOF_MARKER && currentValueLength == IFile.EOF_MARKER) {
+      eof = true;
+      return false;
+    }
+
+    if (currentKeyLength != IFile.RLE_MARKER && currentKeyLength < 0) {
+      throw new IOException("Rec# " + recNo + ": Negative key-length: " +
+          currentKeyLength + " PreviousKeyLen: " + prevKeyLength);
+    }
+    if (currentValueLength < 0) {
+      throw new IOException("Rec# " + recNo + ": Negative value-length: " +
+          currentValueLength);
+    }
+    return true;
+  }
+
+  @Override
   public KeyState readRawKey(DataInputBuffer key) throws IOException {
     try {
       if (!positionToNextRecord(memDataIn)) {
@@ -253,7 +300,6 @@ public class InMemoryReader extends Reader {
     }
   }
 
-  @Override
   public KeyState readRawKey(BytesWritable key) throws IOException {
     try {
       if (!positionToNextRecord(memDataIn)) {
@@ -280,6 +326,7 @@ public class InMemoryReader extends Reader {
     }
   }
 
+  @Override
   public void nextRawValue(DataInputBuffer value) throws IOException {
     try {
       int pos = memDataIn.getPosition();
@@ -302,7 +349,6 @@ public class InMemoryReader extends Reader {
     }
   }
 
-  @Override
   public void nextRawValue(BytesWritable value) throws IOException {
     try {
       int pos = memDataIn.getPosition();
@@ -325,6 +371,7 @@ public class InMemoryReader extends Reader {
     }
   }
 
+  @Override
   public void close() {
     // Release
     buffer = null;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -305,8 +305,6 @@ public class InMemoryReader implements KeyValueInputReader {
         return KeyState.NO_KEY;
       }
       if (currentKeyLength == IFile.RLE_MARKER) {
-        byte[] data = memDataIn.getData();
-        key.set(data, originalKeyPos, originalKeyLength);
         return KeyState.SAME_KEY;
       }
       int pos = memDataIn.getPosition();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -183,7 +183,6 @@ public class InMemoryReader implements KeyValueInputReader {
     this.usedMemoryForMergeManager = usedMemoryForMergeManager;
   }
 
-  @Override
   public void reset(int offset) {
     memDataIn.reset(buffer, start + offset, length);
     bytesRead = offset;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1050,7 +1050,6 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       this.size = size;
     }
 
-    @Override
     public IFile.Reader.KeyState readRawKey(DataInputBuffer key) throws IOException {
       if (kvIter.next()) {
         final DataInputBuffer kb = kvIter.getKey();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1050,6 +1050,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       this.size = size;
     }
 
+    @Override
     public IFile.Reader.KeyState readRawKey(DataInputBuffer key) throws IOException {
       if (kvIter.next()) {
         final DataInputBuffer kb = kvIter.getKey();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -720,7 +720,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             }
           } else {
             mergeOutputSize += mo.getSize();
-            IFile.Reader reader = new InMemoryReader(MergeManager.this,
+            IFile.KeyValueInputReader reader = new InMemoryReader(MergeManager.this,
                 mo.getAttemptIdentifier(), mo.getMemory(), 0, mo.getMemory().length,
                 (int)mo.getUsedMemoryForMergeManager());
             inMemorySegments.add(new Segment(reader,
@@ -1026,7 +1026,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       long size = data.length;
       totalSize += size;
       fullSize -= size;
-      IFile.Reader reader = new InMemoryReader(MergeManager.this, 
+      IFile.KeyValueInputReader reader = new InMemoryReader(MergeManager.this,
           mo.getAttemptIdentifier(), data, 0, (int)size,
           (int)mo.getUsedMemoryForMergeManager());
       inMemorySegments.add(new Segment(reader,
@@ -1037,32 +1037,32 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     return totalSize;
   }
 
-  class RawKVIteratorReader extends IFile.Reader {
+  class RawKVIteratorReader implements IFile.KeyValueInputReader {
 
     private final TezRawKeyValueIterator kvIter;
     private final long size;
+    private long bytesRead;
 
     public RawKVIteratorReader(TezRawKeyValueIterator kvIter, long size)
         throws IOException {
-      super(null, size, null, spilledRecordsCounter, null, ifileReadAhead,
-          ifileReadAheadLength, inputContext);
       this.kvIter = kvIter;
       this.size = size;
     }
 
     @Override
-    public KeyState readRawKey(DataInputBuffer key) throws IOException {
+    public IFile.Reader.KeyState readRawKey(DataInputBuffer key) throws IOException {
       if (kvIter.next()) {
         final DataInputBuffer kb = kvIter.getKey();
         final int kp = kb.getPosition();
         final int klen = kb.getLength() - kp;
         key.reset(kb.getData(), kp, klen);
         bytesRead += klen;
-        return kvIter.isSameKey() ? KeyState.SAME_KEY : KeyState.NEW_KEY;
+        return kvIter.isSameKey() ? IFile.Reader.KeyState.SAME_KEY : IFile.Reader.KeyState.NEW_KEY;
       }
-      return KeyState.NO_KEY;
+      return IFile.Reader.KeyState.NO_KEY;
     }
 
+    @Override
     public void nextRawValue(DataInputBuffer value) throws IOException {
       final DataInputBuffer vb = kvIter.getValue();
       final int vp = vb.getPosition();
@@ -1071,10 +1071,12 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       bytesRead += vlen;
     }
 
+    @Override
     public long getPosition() throws IOException {
       return bytesRead;
     }
 
+    @Override
     public void close() throws IOException {
       kvIter.close();
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1066,13 +1066,16 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     @Override
     public IFile.Reader.KeyState readRawKey(BytesWritable key) throws IOException {
       if (kvIter.next()) {
+        if (kvIter.isSameKey()) {
+          return IFile.Reader.KeyState.SAME_KEY;
+        }
         final DataInputBuffer kb = kvIter.getKey();
         final int kp = kb.getPosition();
         final int klen = kb.getLength() - kp;
         key.setSize(klen);
         System.arraycopy(kb.getData(), kp, key.getBytes(), 0, klen);
         bytesRead += klen;
-        return kvIter.isSameKey() ? IFile.Reader.KeyState.SAME_KEY : IFile.Reader.KeyState.NEW_KEY;
+        return IFile.Reader.KeyState.NEW_KEY;
       }
       return IFile.Reader.KeyState.NO_KEY;
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.FileChunk;
 import org.apache.hadoop.io.RawComparator;
@@ -1063,11 +1064,35 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     }
 
     @Override
+    public IFile.Reader.KeyState readRawKey(BytesWritable key) throws IOException {
+      if (kvIter.next()) {
+        final DataInputBuffer kb = kvIter.getKey();
+        final int kp = kb.getPosition();
+        final int klen = kb.getLength() - kp;
+        key.setSize(klen);
+        System.arraycopy(kb.getData(), kp, key.getBytes(), 0, klen);
+        bytesRead += klen;
+        return kvIter.isSameKey() ? IFile.Reader.KeyState.SAME_KEY : IFile.Reader.KeyState.NEW_KEY;
+      }
+      return IFile.Reader.KeyState.NO_KEY;
+    }
+
+    @Override
     public void nextRawValue(DataInputBuffer value) throws IOException {
       final DataInputBuffer vb = kvIter.getValue();
       final int vp = vb.getPosition();
       final int vlen = vb.getLength() - vp;
       value.reset(vb.getData(), vp, vlen);
+      bytesRead += vlen;
+    }
+
+    @Override
+    public void nextRawValue(BytesWritable value) throws IOException {
+      final DataInputBuffer vb = kvIter.getValue();
+      final int vp = vb.getPosition();
+      final int vlen = vb.getLength() - vp;
+      value.setSize(vlen);
+      System.arraycopy(vb.getData(), vp, value.getBytes(), 0, vlen);
       bytesRead += vlen;
     }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -1042,8 +1042,8 @@ public class IFile {
         return KeyState.NO_KEY;
       }
       if(currentKeyLength == RLE_MARKER) {
-        // BytesWritable readers reuse the same key object across records, so on RLE paths
-        // the previous key is already present in "key".
+        // Keep BytesWritable path robust even if callers do not reuse the same key object.
+        key.set(keyBytes, 0, originalKeyLength);
         return KeyState.SAME_KEY;
       }
       key.setSize(currentKeyLength);
@@ -1052,6 +1052,7 @@ public class IFile {
       if (i != currentKeyLength) {
         throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
       }
+      keyBytes = keyData;
       bytesRead += currentKeyLength;
       return KeyState.NEW_KEY;
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -663,7 +663,9 @@ public class IFile {
    */
   public interface KeyValueInputReader {
     Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
+    Reader.KeyState readRawKey(BytesWritable key) throws IOException;
     void nextRawValue(DataInputBuffer value) throws IOException;
+    void nextRawValue(BytesWritable value) throws IOException;
     long getPosition() throws IOException;
     long getLength();
     void close() throws IOException;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -667,8 +667,6 @@ public class IFile {
     long getPosition() throws IOException;
     long getLength();
     void close() throws IOException;
-    default void reset(int offset) {
-    }
   }
 
   public static class Reader implements KeyValueInputReader {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -663,6 +663,13 @@ public class IFile {
    */
   public interface KeyValueInputReader {
     Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
+    /**
+     * Read the next key into {@code key}.
+     * <p>
+     * On {@link Reader.KeyState#SAME_KEY}, implementations may assume {@code key} already
+     * contains the previous key read from this stream and may avoid rewriting it.
+     * On the first call, {@code key} can be any {@link BytesWritable} instance.
+     */
     Reader.KeyState readRawKey(BytesWritable key) throws IOException;
     void nextRawValue(DataInputBuffer value) throws IOException;
     void nextRawValue(BytesWritable value) throws IOException;
@@ -1042,8 +1049,8 @@ public class IFile {
         return KeyState.NO_KEY;
       }
       if(currentKeyLength == RLE_MARKER) {
-        // Keep BytesWritable path robust even if callers do not reuse the same key object.
-        key.set(keyBytes, 0, originalKeyLength);
+        // BytesWritable readers reuse the same key object across records, so on RLE paths
+        // the previous key is already present in "key".
         return KeyState.SAME_KEY;
       }
       key.setSize(currentKeyLength);
@@ -1052,7 +1059,6 @@ public class IFile {
       if (i != currentKeyLength) {
         throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
       }
-      keyBytes = keyData;
       bytesRead += currentKeyLength;
       return KeyState.NEW_KEY;
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -662,6 +662,7 @@ public class IFile {
    * <code>IFile.Reader</code> to read intermediate map-outputs.
    */
   public interface KeyValueInputReader {
+    Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
     /**
      * Read the next key into {@code key}.
      * <p>

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -661,7 +661,17 @@ public class IFile {
   /**
    * <code>IFile.Reader</code> to read intermediate map-outputs.
    */
-  public static class Reader {
+  public interface KeyValueInputReader {
+    Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
+    void nextRawValue(DataInputBuffer value) throws IOException;
+    long getPosition() throws IOException;
+    long getLength();
+    void close() throws IOException;
+    default void reset(int offset) {
+    }
+  }
+
+  public static class Reader implements KeyValueInputReader {
 
     public enum KeyState {NO_KEY, NEW_KEY, SAME_KEY}
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -662,7 +662,6 @@ public class IFile {
    * <code>IFile.Reader</code> to read intermediate map-outputs.
    */
   public interface KeyValueInputReader {
-    Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
     /**
      * Read the next key into {@code key}.
      * <p>

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.RawComparator;
@@ -110,38 +111,11 @@ public class TezMerger {
     } */
   }
 
-  static class KeyValueBuffer {
-    private byte[] buf;
-    private int position;
-    private int length;
-
-    public KeyValueBuffer(byte buf[], int position, int length) {
-      reset(buf, position, length);
-    }
-
-    public void reset(byte[] input, int position, int length) {
-      this.buf = input;
-      this.position = position;
-      this.length = length;
-    }
-
-    public byte[] getData() {
-      return buf;
-    }
-
-    public int getPosition() {
-      return position;
-    }
-
-    public int getLength() {
-      return length;
-    }
-  }
-
   public static class Segment {
     static final byte[] EMPTY_BYTES = new byte[0];
     KeyValueInputReader reader = null;
-    final KeyValueBuffer key = new KeyValueBuffer(EMPTY_BYTES, 0, 0);
+    final BytesWritable key = new BytesWritable(EMPTY_BYTES);
+    final BytesWritable valueBytes = new BytesWritable(EMPTY_BYTES);
     TezCounter mapOutputsCounter = null;
 
     public Segment(KeyValueInputReader reader, TezCounter mapOutputsCounter) {
@@ -159,7 +133,7 @@ public class TezMerger {
       return true;
     }
 
-    KeyValueBuffer getKey() { return key; }
+    BytesWritable getKey() { return key; }
 
     DataInputBuffer getValue(DataInputBuffer value) throws IOException {
       nextRawValue(value);
@@ -170,20 +144,21 @@ public class TezMerger {
       return reader.getLength();
     }
 
-    KeyState readRawKey(DataInputBuffer nextKey) throws IOException {
+    KeyState readRawKey(BytesWritable nextKey) throws IOException {
       KeyState keyState = reader.readRawKey(nextKey);
-      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
+      key.set(nextKey);
       return keyState;
     }
 
-    boolean nextRawKey(DataInputBuffer nextKey) throws IOException {
+    boolean nextRawKey(BytesWritable nextKey) throws IOException {
       boolean hasNext = reader.readRawKey(nextKey) != KeyState.NO_KEY;
-      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
+      key.set(nextKey);
       return hasNext;
     }
 
     void nextRawValue(DataInputBuffer value) throws IOException {
-      reader.nextRawValue(value);
+      reader.nextRawValue(valueBytes);
+      value.reset(valueBytes.getBytes(), valueBytes.getLength());
     }
 
     void closeReader() throws IOException {
@@ -335,7 +310,7 @@ public class TezMerger {
     
     final DataInputBuffer key = new DataInputBuffer();
     final DataInputBuffer value = new DataInputBuffer();
-    final DataInputBuffer nextKey = new DataInputBuffer();
+    final BytesWritable nextKey = new BytesWritable();
     final DataInputBuffer diskIFileValue = new DataInputBuffer();
     
     Segment minSegment;
@@ -436,7 +411,7 @@ public class TezMerger {
       Segment nextTop = top();
       if (checkForSameKeys && nextTop != current) {
         // we have a different file. Compare it with previous key
-        KeyValueBuffer nextKey = nextTop.getKey();
+        BytesWritable nextKey = nextTop.getKey();
         int compare = compare(nextKey, prevKey);
         if (compare == 0) {
           // Same key is available in the next segment.
@@ -451,8 +426,8 @@ public class TezMerger {
       }
 
       minSegment = top();
-      KeyValueBuffer nextKey = minSegment.getKey();
-      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength());
+      BytesWritable nextKey = minSegment.getKey();
+      key.reset(nextKey.getBytes(), nextKey.getLength());
       if (!minSegment.inMemory()) {
         // When we load the value from an inmemory segment, we reset
         // the "value" DIB in this class to the inmem segment's byte[].
@@ -471,10 +446,10 @@ public class TezMerger {
       return true;
     }
 
-    int compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
-      byte[] b1 = nextKey.getData();
+    int compare(BytesWritable nextKey, DataOutputBuffer buf2) {
+      byte[] b1 = nextKey.getBytes();
       byte[] b2 = buf2.getData();
-      int s1 = nextKey.getPosition();
+      int s1 = 0;
       int s2 = 0;
       int l1 = nextKey.getLength();
       int l2 = buf2.getLength();
@@ -482,14 +457,14 @@ public class TezMerger {
     }
 
     protected boolean lessThan(Object a, Object b) {
-      KeyValueBuffer key1 = ((Segment)a).getKey();
-      KeyValueBuffer key2 = ((Segment)b).getKey();
-      int s1 = key1.getPosition();
+      BytesWritable key1 = ((Segment)a).getKey();
+      BytesWritable key2 = ((Segment)b).getKey();
+      int s1 = 0;
       int l1 = key1.getLength();
-      int s2 = key2.getPosition();
+      int s2 = 0;
       int l2 = key2.getLength();;
 
-      return comparator.compare(key1.getData(), s1, l1, key2.getData(), s2, l2) < 0;
+      return comparator.compare(key1.getBytes(), s1, l1, key2.getBytes(), s2, l2) < 0;
     }
     
     TezRawKeyValueIterator merge(int factor, int inMem, Path tmpDir,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.RawComparator;
@@ -111,11 +110,38 @@ public class TezMerger {
     } */
   }
 
+  static class KeyValueBuffer {
+    private byte[] buf;
+    private int position;
+    private int length;
+
+    public KeyValueBuffer(byte buf[], int position, int length) {
+      reset(buf, position, length);
+    }
+
+    public void reset(byte[] input, int position, int length) {
+      this.buf = input;
+      this.position = position;
+      this.length = length;
+    }
+
+    public byte[] getData() {
+      return buf;
+    }
+
+    public int getPosition() {
+      return position;
+    }
+
+    public int getLength() {
+      return length;
+    }
+  }
+
   public static class Segment {
     static final byte[] EMPTY_BYTES = new byte[0];
     KeyValueInputReader reader = null;
-    final BytesWritable key = new BytesWritable(EMPTY_BYTES);
-    final BytesWritable valueBytes = new BytesWritable(EMPTY_BYTES);
+    final KeyValueBuffer key = new KeyValueBuffer(EMPTY_BYTES, 0, 0);
     TezCounter mapOutputsCounter = null;
 
     public Segment(KeyValueInputReader reader, TezCounter mapOutputsCounter) {
@@ -133,7 +159,7 @@ public class TezMerger {
       return true;
     }
 
-    BytesWritable getKey() { return key; }
+    KeyValueBuffer getKey() { return key; }
 
     DataInputBuffer getValue(DataInputBuffer value) throws IOException {
       nextRawValue(value);
@@ -144,21 +170,20 @@ public class TezMerger {
       return reader.getLength();
     }
 
-    KeyState readRawKey(BytesWritable nextKey) throws IOException {
+    KeyState readRawKey(DataInputBuffer nextKey) throws IOException {
       KeyState keyState = reader.readRawKey(nextKey);
-      key.set(nextKey);
+      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
       return keyState;
     }
 
-    boolean nextRawKey(BytesWritable nextKey) throws IOException {
+    boolean nextRawKey(DataInputBuffer nextKey) throws IOException {
       boolean hasNext = reader.readRawKey(nextKey) != KeyState.NO_KEY;
-      key.set(nextKey);
+      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
       return hasNext;
     }
 
     void nextRawValue(DataInputBuffer value) throws IOException {
-      reader.nextRawValue(valueBytes);
-      value.reset(valueBytes.getBytes(), valueBytes.getLength());
+      reader.nextRawValue(value);
     }
 
     void closeReader() throws IOException {
@@ -310,7 +335,7 @@ public class TezMerger {
     
     final DataInputBuffer key = new DataInputBuffer();
     final DataInputBuffer value = new DataInputBuffer();
-    final BytesWritable nextKey = new BytesWritable();
+    final DataInputBuffer nextKey = new DataInputBuffer();
     final DataInputBuffer diskIFileValue = new DataInputBuffer();
     
     Segment minSegment;
@@ -411,7 +436,7 @@ public class TezMerger {
       Segment nextTop = top();
       if (checkForSameKeys && nextTop != current) {
         // we have a different file. Compare it with previous key
-        BytesWritable nextKey = nextTop.getKey();
+        KeyValueBuffer nextKey = nextTop.getKey();
         int compare = compare(nextKey, prevKey);
         if (compare == 0) {
           // Same key is available in the next segment.
@@ -426,8 +451,8 @@ public class TezMerger {
       }
 
       minSegment = top();
-      BytesWritable nextKey = minSegment.getKey();
-      key.reset(nextKey.getBytes(), nextKey.getLength());
+      KeyValueBuffer nextKey = minSegment.getKey();
+      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength());
       if (!minSegment.inMemory()) {
         // When we load the value from an inmemory segment, we reset
         // the "value" DIB in this class to the inmem segment's byte[].
@@ -446,10 +471,10 @@ public class TezMerger {
       return true;
     }
 
-    int compare(BytesWritable nextKey, DataOutputBuffer buf2) {
-      byte[] b1 = nextKey.getBytes();
+    int compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
+      byte[] b1 = nextKey.getData();
       byte[] b2 = buf2.getData();
-      int s1 = 0;
+      int s1 = nextKey.getPosition();
       int s2 = 0;
       int l1 = nextKey.getLength();
       int l2 = buf2.getLength();
@@ -457,14 +482,14 @@ public class TezMerger {
     }
 
     protected boolean lessThan(Object a, Object b) {
-      BytesWritable key1 = ((Segment)a).getKey();
-      BytesWritable key2 = ((Segment)b).getKey();
-      int s1 = 0;
+      KeyValueBuffer key1 = ((Segment)a).getKey();
+      KeyValueBuffer key2 = ((Segment)b).getKey();
+      int s1 = key1.getPosition();
       int l1 = key1.getLength();
-      int s2 = 0;
+      int s2 = key2.getPosition();
       int l2 = key2.getLength();;
 
-      return comparator.compare(key1.getBytes(), s1, l1, key2.getBytes(), s2, l2) < 0;
+      return comparator.compare(key1.getData(), s1, l1, key2.getData(), s2, l2) < 0;
     }
     
     TezRawKeyValueIterator merge(int factor, int inMem, Path tmpDir,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -43,6 +43,7 @@ import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.KeyValueInputReader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterInputBuffer;
@@ -139,11 +140,11 @@ public class TezMerger {
 
   public static class Segment {
     static final byte[] EMPTY_BYTES = new byte[0];
-    Reader reader = null;
+    KeyValueInputReader reader = null;
     final KeyValueBuffer key = new KeyValueBuffer(EMPTY_BYTES, 0, 0);
     TezCounter mapOutputsCounter = null;
 
-    public Segment(Reader reader, TezCounter mapOutputsCounter) {
+    public Segment(KeyValueInputReader reader, TezCounter mapOutputsCounter) {
       this.reader = reader;
       this.mapOutputsCounter = mapOutputsCounter;
     }
@@ -176,7 +177,7 @@ public class TezMerger {
     }
 
     boolean nextRawKey(DataInputBuffer nextKey) throws IOException {
-      boolean hasNext = reader.nextRawKey(nextKey);
+      boolean hasNext = reader.readRawKey(nextKey) != KeyState.NO_KEY;
       key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
       return hasNext;
     }
@@ -205,7 +206,7 @@ public class TezMerger {
       return reader.getPosition();
     }
 
-    Reader getReader() {
+    KeyValueInputReader getReader() {
       return reader;
     }
 
@@ -296,7 +297,7 @@ public class TezMerger {
     private final MultiByteArrayOutputStream byteArrayOutput;
     private final boolean cleanupOnClose;
 
-    IntermediateMemorySegment(Reader reader,
+    IntermediateMemorySegment(KeyValueInputReader reader,
         MultiByteArrayOutputStream byteArrayOutput, boolean cleanupOnClose) {
       super(reader, null);
       this.byteArrayOutput = byteArrayOutput;


### PR DESCRIPTION
### Motivation
- `InMemoryReader` and `MergeManager.RawKVIteratorReader` previously extended `IFile.Reader` but invoked `super(null, ...)`, inheriting stream/checksum/compression state they do not use and creating accidental coupling with stream-backed reader internals.
- Introduce a minimal reader abstraction for merge code paths so merge implementations only depend on the methods they actually need and accidental coupling is reduced.

### Description
- Add a focused interface `IFile.KeyValueInputReader` exposing `readRawKey`, `nextRawValue`, `getPosition`, `getLength`, `close`, and a default `reset(int)`; make `IFile.Reader` implement this interface to preserve compatibility with stream-backed readers (file: `IFile.java`).
- Convert `InMemoryReader` from `extends IFile.Reader` to `implements IFile.KeyValueInputReader`, and move the in-memory parsing/position state into the class while preserving `reset(offset)`, `getPosition()`, and `dumpOnError()` behavior (file: `InMemoryReader.java`).
- Convert `MergeManager.RawKVIteratorReader` to implement `IFile.KeyValueInputReader` and track `bytesRead` locally instead of relying on `IFile.Reader` stream initialization (file: `MergeManager.java`).
- Update merge abstractions to depend on the interface by changing `TezMerger.Segment` and `IntermediateMemorySegment` to hold `KeyValueInputReader` instead of concrete `IFile.Reader`, and update call sites that construct/pass readers (file: `TezMerger.java` and call sites in `MergeManager.java`).
- Preserved existing external behavior: key/value parsing logic, `reset` semantics for in-memory readers, `dumpOnError` handling, and reader length/position reporting.

### Testing
- Attempted to compile the runtime module with `mvn -pl tez-runtime-library -DskipTests compile` to validate changes, but the build could not complete in this environment due to external Maven plugin resolution failing with HTTP 403 when fetching `com.github.os72:protoc-jar-maven-plugin:3.8.0` (failure unrelated to the code changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7c21c806c8328a0f937d4fa6ab92c)