### PR TITLE
Separate RLE and non-RLE codepaths for InMemory/IFile shuffle read/write

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -208,9 +208,23 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   private void readKeyValueLength(DataInput dIn) throws IOException {
+    if (isRleEnabled) {
+      readKeyValueLengthRle(dIn);
+    } else {
+      readKeyValueLengthNoRle(dIn);
+    }
+  }
+
+  private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
     currentKeyLength = dIn.readInt();
     currentValueLength = dIn.readInt();
-    if (isRleEnabled && currentKeyLength != IFile.RLE_MARKER) {
+    bytesRead += Integer.BYTES + Integer.BYTES;
+  }
+
+  private void readKeyValueLengthRle(DataInput dIn) throws IOException {
+    currentKeyLength = dIn.readInt();
+    currentValueLength = dIn.readInt();
+    if (currentKeyLength != IFile.RLE_MARKER) {
       originalKeyLength = currentKeyLength;
       originalKeyPos = memDataIn.getPosition();
     }
@@ -218,23 +232,67 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   private void readValueLength(DataInput dIn) throws IOException {
+    if (isRleEnabled) {
+      readValueLengthRle(dIn);
+    } else {
+      readValueLengthNoRle(dIn);
+    }
+  }
+
+  private void readValueLengthNoRle(DataInput dIn) throws IOException {
     currentValueLength = dIn.readInt();
     bytesRead += Integer.BYTES;
-    if (isRleEnabled && currentValueLength == IFile.V_END_MARKER) {
-      readKeyValueLength(dIn);
+  }
+
+  private void readValueLengthRle(DataInput dIn) throws IOException {
+    currentValueLength = dIn.readInt();
+    bytesRead += Integer.BYTES;
+    if (currentValueLength == IFile.V_END_MARKER) {
+      readKeyValueLengthRle(dIn);
     }
   }
 
   private boolean positionToNextRecord(DataInput dIn) throws IOException {
+    if (isRleEnabled) {
+      return positionToNextRecordRle(dIn);
+    } else {
+      return positionToNextRecordNoRle(dIn);
+    }
+  }
+
+  private boolean positionToNextRecordNoRle(DataInput dIn) throws IOException {
+    if (eof) {
+      throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
+    }
+    int prevKeyLength = currentKeyLength;
+    readKeyValueLengthNoRle(dIn);
+
+    if (currentKeyLength == IFile.EOF_MARKER && currentValueLength == IFile.EOF_MARKER) {
+      eof = true;
+      return false;
+    }
+
+    if (currentKeyLength < 0) {
+      throw new IOException("Rec# " + recNo + ": Negative key-length: " +
+          currentKeyLength + " PreviousKeyLen: " + prevKeyLength);
+    }
+    if (currentValueLength < 0) {
+      throw new IOException("Rec# " + recNo + ": Negative value-length: " +
+          currentValueLength);
+    }
+    return true;
+  }
+
+  private boolean positionToNextRecordRle(DataInput dIn) throws IOException {
     if (eof) {
       throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
     }
     int prevKeyLength = currentKeyLength;
 
-    if (isRleEnabled && prevKeyLength == IFile.RLE_MARKER) {
-      readValueLength(dIn);
+    if (prevKeyLength == IFile.RLE_MARKER) {
+      readValueLengthRle(dIn);
     } else {
-      readKeyValueLength(dIn);
+      readKeyValueLengthRle(dIn);
     }
 
     if (currentKeyLength == IFile.EOF_MARKER && currentValueLength == IFile.EOF_MARKER) {
@@ -242,8 +300,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
       return false;
     }
 
-    boolean isAllowedNegativeKeyLength =
-        isRleEnabled && currentKeyLength == IFile.RLE_MARKER;
+    boolean isAllowedNegativeKeyLength = currentKeyLength == IFile.RLE_MARKER;
     if (!isAllowedNegativeKeyLength && currentKeyLength < 0) {
       throw new IOException("Rec# " + recNo + ": Negative key-length: " +
           currentKeyLength + " PreviousKeyLen: " + prevKeyLength);
@@ -258,60 +315,114 @@ public class InMemoryReader implements IFile.KeyValueReader {
   @Override
   public KeyState readRawKey(DataInputBuffer key) throws IOException {
     try {
-      if (!positionToNextRecord(memDataIn)) {
-        return KeyState.NO_KEY;
+      if (isRleEnabled) {
+        return readRawKeyRle(key);
+      } else {
+        return readRawKeyNoRle(key);
       }
-      // Setup the key
-      int pos = memDataIn.getPosition();
-      byte[] data = memDataIn.getData();
-      if (isRleEnabled && currentKeyLength == IFile.RLE_MARKER) {
-        // get key length from original key
-        key.reset(data, originalKeyPos, originalKeyLength);
-        return KeyState.SAME_KEY;
-      }
-      key.reset(data, pos, currentKeyLength);
-      // Position for the next value
-      long skipped = memDataIn.skip(currentKeyLength);
-      if (skipped != currentKeyLength) {
-        throw new IOException("Rec# " + recNo +
-            ": Failed to skip past key of length: " +
-            currentKeyLength);
-      }
-      bytesRead += currentKeyLength;
-      return KeyState.NEW_KEY;
     } catch (IOException ioe) {
       dumpOnError();
       throw ioe;
     }
   }
 
+  private KeyState readRawKeyNoRle(DataInputBuffer key) throws IOException {
+    if (!positionToNextRecordNoRle(memDataIn)) {
+      return KeyState.NO_KEY;
+    }
+    int pos = memDataIn.getPosition();
+    byte[] data = memDataIn.getData();
+    key.reset(data, pos, currentKeyLength);
+    long skipped = memDataIn.skip(currentKeyLength);
+    if (skipped != currentKeyLength) {
+      throw new IOException("Rec# " + recNo +
+          ": Failed to skip past key of length: " +
+          currentKeyLength);
+    }
+    bytesRead += currentKeyLength;
+    return KeyState.NEW_KEY;
+  }
+
+  private KeyState readRawKeyRle(DataInputBuffer key) throws IOException {
+    if (!positionToNextRecordRle(memDataIn)) {
+      return KeyState.NO_KEY;
+    }
+    // Setup the key
+    int pos = memDataIn.getPosition();
+    byte[] data = memDataIn.getData();
+    if (currentKeyLength == IFile.RLE_MARKER) {
+      // get key length from original key
+      key.reset(data, originalKeyPos, originalKeyLength);
+      return KeyState.SAME_KEY;
+    }
+    key.reset(data, pos, currentKeyLength);
+    // Position for the next value
+    long skipped = memDataIn.skip(currentKeyLength);
+    if (skipped != currentKeyLength) {
+      throw new IOException("Rec# " + recNo +
+          ": Failed to skip past key of length: " +
+          currentKeyLength);
+    }
+    bytesRead += currentKeyLength;
+    return KeyState.NEW_KEY;
+  }
+
   public KeyState readRawKey(BytesWritable key) throws IOException {
     try {
-      if (!positionToNextRecord(memDataIn)) {
-        return KeyState.NO_KEY;
+      if (isRleEnabled) {
+        return readRawKeyRle(key);
+      } else {
+        return readRawKeyNoRle(key);
       }
-      if (isRleEnabled && currentKeyLength == IFile.RLE_MARKER) {
-        return KeyState.SAME_KEY;
-      }
-
-      int pos = memDataIn.getPosition();
-      byte[] data = memDataIn.getData();
-      // directly copy to the byte[] array of key after resizing if necessary
-      key.setSize(currentKeyLength);
-      System.arraycopy(data, pos, key.getBytes(), 0, currentKeyLength);
-
-      // Position for the next value
-      long skipped = memDataIn.skip(currentKeyLength);
-      if (skipped != currentKeyLength) {
-        throw new IOException("Rec# " + recNo + ": Failed to skip past key of length: " + currentKeyLength);
-      }
-
-      bytesRead += currentKeyLength;
-      return KeyState.NEW_KEY;
     } catch (IOException ioe) {
       dumpOnError();
       throw ioe;
     }
+  }
+
+  private KeyState readRawKeyNoRle(BytesWritable key) throws IOException {
+    if (!positionToNextRecordNoRle(memDataIn)) {
+      return KeyState.NO_KEY;
+    }
+
+    int pos = memDataIn.getPosition();
+    byte[] data = memDataIn.getData();
+    // directly copy to the byte[] array of key after resizing if necessary
+    key.setSize(currentKeyLength);
+    System.arraycopy(data, pos, key.getBytes(), 0, currentKeyLength);
+
+    // Position for the next value
+    long skipped = memDataIn.skip(currentKeyLength);
+    if (skipped != currentKeyLength) {
+      throw new IOException("Rec# " + recNo + ": Failed to skip past key of length: " + currentKeyLength);
+    }
+
+    bytesRead += currentKeyLength;
+    return KeyState.NEW_KEY;
+  }
+
+  private KeyState readRawKeyRle(BytesWritable key) throws IOException {
+    if (!positionToNextRecordRle(memDataIn)) {
+      return KeyState.NO_KEY;
+    }
+    if (currentKeyLength == IFile.RLE_MARKER) {
+      return KeyState.SAME_KEY;
+    }
+
+    int pos = memDataIn.getPosition();
+    byte[] data = memDataIn.getData();
+    // directly copy to the byte[] array of key after resizing if necessary
+    key.setSize(currentKeyLength);
+    System.arraycopy(data, pos, key.getBytes(), 0, currentKeyLength);
+
+    // Position for the next value
+    long skipped = memDataIn.skip(currentKeyLength);
+    if (skipped != currentKeyLength) {
+      throw new IOException("Rec# " + recNo + ": Failed to skip past key of length: " + currentKeyLength);
+    }
+
+    bytesRead += currentKeyLength;
+    return KeyState.NEW_KEY;
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -54,13 +54,36 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   }
 
   public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      if (isRleEnabled) {
+          appendRle(key, value);
+      } else {
+          appendNoRle(key, value);
+      }
+  }
+
+  private void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
-      if (!isRleEnabled && key == IFile.REPEAT_KEY) {
+      if (key == IFile.REPEAT_KEY) {
           throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
       }
-      boolean sameKey = (key == IFile.REPEAT_KEY) && isRleEnabled;
+
+      if (prevKey == IFile.REPEAT_KEY) {
+          out.writeInt(IFile.V_END_MARKER);
+      }
+
+      long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
+      out.writeLong(combined);
+      out.write(key.getData(), key.getPosition(), keyLength);
+      out.write(value.getData(), value.getPosition(), valueLength);
+      prevKey = key;
+  }
+
+  private void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      int keyLength = key.getLength() - key.getPosition();
+      int valueLength = value.getLength() - value.getPosition();
+      boolean sameKey = key == IFile.REPEAT_KEY;
 
       if (!sameKey) {
           // Normal key-value pair

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -54,9 +54,6 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   }
 
   public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
-      if (!isRleEnabled && key == IFile.REPEAT_KEY) {
-          throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
-      }
       if (isRleEnabled) {
           appendRle(key, value);
       } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -57,6 +57,9 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       if (isRleEnabled) {
           appendRle(key, value);
       } else {
+          if (key == IFile.REPEAT_KEY) {
+              throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
+          }
           appendNoRle(key, value);
       }
   }
@@ -64,14 +67,6 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   private void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
-
-      if (key == IFile.REPEAT_KEY) {
-          throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
-      }
-
-      if (prevKey == IFile.REPEAT_KEY) {
-          out.writeInt(IFile.V_END_MARKER);
-      }
 
       long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
       out.writeLong(combined);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -54,12 +54,12 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   }
 
   public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      if (!isRleEnabled && key == IFile.REPEAT_KEY) {
+          throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
+      }
       if (isRleEnabled) {
           appendRle(key, value);
       } else {
-          if (key == IFile.REPEAT_KEY) {
-              throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
-          }
           appendNoRle(key, value);
       }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -577,26 +577,45 @@ public class IFile {
      */
     @Override
     public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      if (isRleEnabled) {
+        appendRle(key, value);
+      } else {
+        appendNoRle(key, value);
+      }
+    }
+
+    private void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
       assert (key == REPEAT_KEY || keyLength >=0);
 
       int valueLength = value.getLength() - value.getPosition();
       assert (valueLength >= 0);
 
-      if (!isRleEnabled && key == REPEAT_KEY) {
+      if (key == REPEAT_KEY) {
         throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
       }
-      boolean sameKey = isRleEnabled && (key == REPEAT_KEY);
-      if (!sameKey && isRleEnabled) {
+      writeKVPair(key.getData(), key.getPosition(), keyLength,
+          value.getData(), value.getPosition(), valueLength);
+      prevKey = key;
+      incrementRecordsWritten();
+    }
+
+    private void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      int keyLength = key.getLength() - key.getPosition();
+      assert (key == REPEAT_KEY || keyLength >=0);
+
+      int valueLength = value.getLength() - value.getPosition();
+      assert (valueLength >= 0);
+
+      boolean sameKey = key == REPEAT_KEY;
+      if (!sameKey) {
         sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
       }
 
       if (!sameKey) {
         writeKVPair(key.getData(), key.getPosition(), keyLength,
             value.getData(), value.getPosition(), valueLength);
-        if (isRleEnabled) {
-          BufferUtils.copy(key, previous);
-        }
+        BufferUtils.copy(key, previous);
       } else {
         writeValue(value.getData(), value.getPosition(), valueLength);
       }
@@ -962,21 +981,49 @@ public class IFile {
     }
 
     protected void readValueLength(DataInput dIn) throws IOException {
+      if (isRleEnabled) {
+        readValueLengthRle(dIn);
+      } else {
+        readValueLengthNoRle(dIn);
+      }
+    }
+
+    private void readValueLengthNoRle(DataInput dIn) throws IOException {
       currentValueLength = dIn.readInt();
       bytesRead += INT_SIZE;
-      if (isRleEnabled && currentValueLength == V_END_MARKER) {
-        readKeyValueLength(dIn);
+    }
+
+    private void readValueLengthRle(DataInput dIn) throws IOException {
+      currentValueLength = dIn.readInt();
+      bytesRead += INT_SIZE;
+      if (currentValueLength == V_END_MARKER) {
+        readKeyValueLengthRle(dIn);
       }
     }
 
     protected void readKeyValueLength(DataInput dIn) throws IOException {
+      if (isRleEnabled) {
+        readKeyValueLengthRle(dIn);
+      } else {
+        readKeyValueLengthNoRle(dIn);
+      }
+    }
+
+    private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
+      currentKeyLength = dIn.readInt();
+      currentValueLength = dIn.readInt();
+      originalKeyLength = currentKeyLength;
+      bytesRead += INT_SIZE + INT_SIZE;
+    }
+
+    private void readKeyValueLengthRle(DataInput dIn) throws IOException {
       currentKeyLength = dIn.readInt();
       currentValueLength = dIn.readInt();
       // long combined = dIn.readLong();
       // currentKeyLength = (int) (combined >> 32);
       // currentValueLength = (int) combined;
 
-      if (!isRleEnabled || currentKeyLength != RLE_MARKER) {
+      if (currentKeyLength != RLE_MARKER) {
         // original key length
         originalKeyLength = currentKeyLength;
       }
@@ -992,17 +1039,52 @@ public class IFile {
      * @throws IOException
      */
     protected boolean positionToNextRecord(DataInput dIn) throws IOException {
+      if (isRleEnabled) {
+        return positionToNextRecordRle(dIn);
+      } else {
+        return positionToNextRecordNoRle(dIn);
+      }
+    }
+
+    private boolean positionToNextRecordNoRle(DataInput dIn) throws IOException {
       // Sanity check
       if (eof) {
         throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
       }
       int prevKeyLength = currentKeyLength;
 
-      if (isRleEnabled && prevKeyLength == RLE_MARKER) {
+      readKeyValueLengthNoRle(dIn);
+
+      // Check for EOF
+      if (currentKeyLength == EOF_MARKER && currentValueLength == EOF_MARKER) {
+        eof = true;
+        return false;
+      }
+
+      // Sanity check
+      if (currentKeyLength < 0) {
+        throw new IOException("Rec# " + recNo + ": Negative key-length: " +
+                              currentKeyLength + " PreviousKeyLen: " + prevKeyLength);
+      }
+      if (currentValueLength < 0) {
+        throw new IOException("Rec# " + recNo + ": Negative value-length: " +
+                              currentValueLength);
+      }
+      return true;
+    }
+
+    private boolean positionToNextRecordRle(DataInput dIn) throws IOException {
+      // Sanity check
+      if (eof) {
+        throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
+      }
+      int prevKeyLength = currentKeyLength;
+
+      if (prevKeyLength == RLE_MARKER) {
         // Same key as previous one. Just read value length alone
-        readValueLength(dIn);
+        readValueLengthRle(dIn);
       } else {
-        readKeyValueLength(dIn);
+        readKeyValueLengthRle(dIn);
       }
 
       // Check for EOF
@@ -1012,8 +1094,7 @@ public class IFile {
       }
 
       // Sanity check
-      boolean isAllowedNegativeKeyLength =
-          isRleEnabled && currentKeyLength == RLE_MARKER;
+      boolean isAllowedNegativeKeyLength = currentKeyLength == RLE_MARKER;
       if (!isAllowedNegativeKeyLength && currentKeyLength < 0) {
         throw new IOException("Rec# " + recNo + ": Negative key-length: " +
                               currentKeyLength + " PreviousKeyLen: " + prevKeyLength);
@@ -1041,10 +1122,34 @@ public class IFile {
     }
 
     public KeyState readRawKey(DataInputBuffer key) throws IOException {
-      if (!positionToNextRecord(dataIn)) {
+      if (isRleEnabled) {
+        return readRawKeyRle(key);
+      } else {
+        return readRawKeyNoRle(key);
+      }
+    }
+
+    private KeyState readRawKeyNoRle(DataInputBuffer key) throws IOException {
+      if (!positionToNextRecordNoRle(dataIn)) {
         return KeyState.NO_KEY;
       }
-      if (isRleEnabled && currentKeyLength == RLE_MARKER) {
+      if (keyBytes.length < currentKeyLength) {
+        keyBytes = createLargerArray(currentKeyLength);
+      }
+      int i = readData(keyBytes, currentKeyLength);
+      if (i != currentKeyLength) {
+        throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
+      }
+      key.reset(keyBytes, currentKeyLength);
+      bytesRead += currentKeyLength;
+      return KeyState.NEW_KEY;
+    }
+
+    private KeyState readRawKeyRle(DataInputBuffer key) throws IOException {
+      if (!positionToNextRecordRle(dataIn)) {
+        return KeyState.NO_KEY;
+      }
+      if (currentKeyLength == RLE_MARKER) {
         // get key length from original key
         key.reset(keyBytes, originalKeyLength);
         return KeyState.SAME_KEY;
@@ -1062,15 +1167,37 @@ public class IFile {
     }
 
     public KeyState readRawKey(BytesWritable key) throws IOException {
-      if (!positionToNextRecord(dataIn)) {
+      if (isRleEnabled) {
+        return readRawKeyRle(key);
+      } else {
+        return readRawKeyNoRle(key);
+      }
+    }
+
+    private KeyState readRawKeyNoRle(BytesWritable key) throws IOException {
+      if (!positionToNextRecordNoRle(dataIn)) {
         return KeyState.NO_KEY;
       }
-      if (isRleEnabled && currentKeyLength == RLE_MARKER) {
+      // directly copy to the byte[] array of key after resizing if necessary
+      key.setSize(currentKeyLength);
+      int i = readData(key.getBytes(), currentKeyLength);
+
+      if (i != currentKeyLength) {
+        throw new IOException(String.format(INCOMPLETE_READ, currentKeyLength, i));
+      }
+      bytesRead += currentKeyLength;
+      return KeyState.NEW_KEY;
+    }
+
+    private KeyState readRawKeyRle(BytesWritable key) throws IOException {
+      if (!positionToNextRecordRle(dataIn)) {
+        return KeyState.NO_KEY;
+      }
+      if (currentKeyLength == RLE_MARKER) {
         // BytesWritable readers reuse the same key object across records, so on RLE paths
         // the previous key is already present in "key".
         return KeyState.SAME_KEY;
       }
-
       // directly copy to the byte[] array of key after resizing if necessary
       key.setSize(currentKeyLength);
       int i = readData(key.getBytes(), currentKeyLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -580,20 +580,20 @@ public class IFile {
       if (isRleEnabled) {
         appendRle(key, value);
       } else {
+        if (key == REPEAT_KEY) {
+          throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
+        }
         appendNoRle(key, value);
       }
     }
 
     private void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
-      assert (key == REPEAT_KEY || keyLength >=0);
+      assert (keyLength >=0);
 
       int valueLength = value.getLength() - value.getPosition();
       assert (valueLength >= 0);
 
-      if (key == REPEAT_KEY) {
-        throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
-      }
       writeKVPair(key.getData(), key.getPosition(), keyLength,
           value.getData(), value.getPosition(), valueLength);
       prevKey = key;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -577,9 +577,6 @@ public class IFile {
      */
     @Override
     public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
-      if (!isRleEnabled && key == REPEAT_KEY) {
-        throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
-      }
       if (isRleEnabled) {
         appendRle(key, value);
       } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -577,12 +577,12 @@ public class IFile {
      */
     @Override
     public void append(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      if (!isRleEnabled && key == REPEAT_KEY) {
+        throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
+      }
       if (isRleEnabled) {
         appendRle(key, value);
       } else {
-        if (key == REPEAT_KEY) {
-          throw new IOException("REPEAT_KEY is not allowed when RLE is disabled");
-        }
         appendNoRle(key, value);
       }
     }


### PR DESCRIPTION
### Motivation
- Introduce explicit support for both RLE (run-length encoded repeated keys) and non-RLE modes in the in-memory shuffle reader/writer to avoid conditional checks scattered through hot paths and handle markers consistently.
- Ensure correct handling of RLE markers (`RLE_MARKER`, `V_END_MARKER`, `EOF_MARKER`) and prevent misuse of `REPEAT_KEY` when RLE is disabled.

### Description
- Refactored `InMemoryReader`, `InMemoryWriter`, and `IFile` to split logic into dedicated RLE and non-RLE methods (e.g. `readKeyValueLengthRle`/`readKeyValueLengthNoRle`, `positionToNextRecordRle`/`positionToNextRecordNoRle`, `readRawKeyRle`/`readRawKeyNoRle`, `appendRle`/`appendNoRle`).
- `InMemoryWriter.append` and `IFile.append` now dispatch based on the `isRleEnabled` flag and enforce that `REPEAT_KEY` is invalid when RLE is disabled, while the RLE path writes markers and compact repeated-key values.
- Reading paths are updated to advance and validate record boundaries correctly per-mode, including EOF detection and negative-length sanity checks, and to preserve original key length/position for RLE `SAME_KEY` cases.
- Minor I/O layout adjustments: no-RLE in-memory append writes a combined long for key/value lengths, while RLE append uses markers and separate value writes; `writeRLE`/`writeValueMarker` behavior remains and is used from the RLE-aware writers.

### Testing
- Executed the module unit test suite for `tez-runtime-library` (unit tests via Maven) against the modified reader/writer code; tests completed successfully.
- Ran shuffle/orderedgrouped-specific unit tests exercising RLE and non-RLE append/read paths; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9db50ff3c8328ab3b140d74605ce5)