### PR TITLE
Expose writer RLE flag and honor it when writing merged records

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -61,6 +61,11 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       }
   }
 
+  @Override
+  public boolean isRleEnabled() {
+      return isRleEnabled;
+  }
+
   private void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -101,6 +101,7 @@ public class IFile {
 
   public interface WriterAppendDataInputBuffer {
     void append(DataInputBuffer key, DataInputBuffer value) throws IOException;
+    boolean isRleEnabled();
     void close() throws IOException;
   }
 
@@ -589,6 +590,11 @@ public class IFile {
       } else {
         appendNoRle(key, value);
       }
+    }
+
+    @Override
+    public boolean isRleEnabled() {
+      return isRleEnabled;
     }
 
     private void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -82,9 +82,10 @@ public class TezMerger {
       Progressable progressable, long recordsBeforeProgress)
       throws IOException, InterruptedException {
     long recordCtr = 0;
+    boolean isRleEnabled = writer.isRleEnabled();
     // long count = 0;
     while (records.next()) {
-      if (records.isSameKey()) {
+      if (isRleEnabled && records.isSameKey()) {
         writer.append(IFile.REPEAT_KEY, records.getValue());
         // count++;
       } else {


### PR DESCRIPTION
### Motivation
- Ensure writers that do not support run-length encoding (RLE) do not receive or emit RLE repeat-key markers during merge output by making the writer capability explicit and conditioning merge logic on it.

### Description
- Add `isRleEnabled()` to the `IFile.WriterAppendDataInputBuffer` interface and implement it in the in-memory/file writer implementations (`IFile` writer and `InMemoryWriter`).
- Modify `TezMerger.writeFile` to call `writer.isRleEnabled()` and only emit `IFile.REPEAT_KEY` when RLE is enabled and `records.isSameKey()` is true.
- Preserve existing append logic by delegating to `appendRle` or `appendNoRle` based on the writer capability.

### Testing
- Ran the Maven unit test suite with `mvn -DskipTests=false test`, and the tests completed successfully.
- Performed a full build with `mvn -DskipTests=false package`, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9f1ea719483288749cd6365a0d305)