### PR TITLE
Implement RLE append logic and previous-key tracking in IFile and InMemoryWriter

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -21,10 +21,12 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
+import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.io.NonSyncDataOutputStream;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
+import org.apache.tez.runtime.library.utils.BufferUtils;
 
 public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
@@ -39,6 +41,7 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   private final boolean isRleEnabled;
 
   private DataInputBuffer prevKey = null;
+  private final DataOutputBuffer previous = new DataOutputBuffer();
 
   // InMemoryWriter does not use another byte[] buffer, unlike IFile.Writer
   public InMemoryWriter(byte[] array, boolean isRleEnabled) throws IOException {
@@ -68,7 +71,15 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   }
 
   public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
-    assert false;
+    int keyLength = key.getLength() - key.getPosition();
+    assert (key == IFile.REPEAT_KEY || keyLength >= 0);
+
+    boolean sameKey = key == IFile.REPEAT_KEY;
+    if (!sameKey) {
+      sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
+    }
+
+    appendRleAccurate(sameKey ? IFile.REPEAT_KEY : key, value);
   }
 
   public void appendRleAccurate(DataInputBuffer key, DataInputBuffer value) throws IOException {
@@ -88,6 +99,7 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
       out.write(key.getData(), key.getPosition(), keyLength);
       out.write(value.getData(), value.getPosition(), valueLength);
+      BufferUtils.copy(key, previous);
     } else {
       // Repeated key
       if (prevKey != IFile.REPEAT_KEY) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -610,14 +610,22 @@ public class IFile {
       int keyLength = key.getLength() - key.getPosition();
       assert (key == REPEAT_KEY || keyLength >=0);
 
-      int valueLength = value.getLength() - value.getPosition();
-      assert (valueLength >= 0);
-
       boolean sameKey = key == REPEAT_KEY;
       if (!sameKey) {
         sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
       }
 
+      appendRleAccurate(sameKey ? REPEAT_KEY : key, value);
+    }
+
+    public void appendRleAccurate(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      int keyLength = key.getLength() - key.getPosition();
+      assert (key == REPEAT_KEY || keyLength >= 0);
+
+      int valueLength = value.getLength() - value.getPosition();
+      assert (valueLength >= 0);
+
+      boolean sameKey = key == REPEAT_KEY;
       if (!sameKey) {
         writeKVPairRle(key.getData(), key.getPosition(), keyLength,
           value.getData(), value.getPosition(), valueLength);
@@ -627,10 +635,6 @@ public class IFile {
       }
       prevKey = sameKey ? REPEAT_KEY : key;
       incrementRecordsWritten();
-    }
-
-    public void appendRleAccurate(DataInputBuffer key, DataInputBuffer value) throws IOException {
-      assert false;
     }
 
     private void writeRLE() throws IOException {


### PR DESCRIPTION
### Motivation
- Restore and implement run-length encoding (RLE) append behavior that was previously a placeholder assert, so repeated keys can be detected and encoded efficiently. 
- Ensure both in-memory and on-disk writers use the same logic to detect repeated keys by comparing against a stored previous key buffer. 

### Description
- Add a `previous` `DataOutputBuffer` and import `BufferUtils` to `InMemoryWriter`, and implement `appendRle` to detect same-key cases via `BufferUtils.compareEqual` and delegate to `appendRleAccurate`. 
- Implement `appendRleAccurate` in `InMemoryWriter` to write normal or RLE-encoded entries and copy the current key into `previous` using `BufferUtils.copy`. 
- Update `IFile` to implement `appendRle` detection and add `appendRleAccurate` that performs the accurate write paths (`writeKVPairRle` or `writeValueRle`) and updates `previous`/`prevKey`. 
- Remove the prior `assert false` placeholders and align both writers to increment record counters and write the appropriate RLE/V_END markers. 

### Testing
- Ran the module unit tests for `tez-runtime-library` including the IFile/shuffle related tests as part of the CI test suite. All executed automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da3937720c832893e2111694388e2f)