### PR TITLE
Optimize IFile serialized-bytes counter updates

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -331,6 +331,8 @@ public class IFile {
     private long compressedBytesWritten = 0;
     // Count records written to disk
     private long numRecordsWritten = 0;
+    // Count serialized key/value bytes for counter updates.
+    private long numSerializedBytesWritten = 0;
 
     private final AtomicBoolean closed = new AtomicBoolean(false);
 
@@ -441,6 +443,9 @@ public class IFile {
       if (writtenRecordsCounter != null) {
         writtenRecordsCounter.increment(numRecordsWritten);
       }
+      if (serializedUncompressedBytes != null) {
+        serializedUncompressedBytes.increment(numSerializedBytesWritten);
+      }
       if (isDebugEnabled) {
         LOG.debug("Total keys written=" + numRecordsWritten + "; compressedLen="
             + compressedBytesWritten + "; rawLen=" + decompressedBytesWritten);
@@ -456,9 +461,7 @@ public class IFile {
       bufferWriteBytes(data, offset, length);
       // Update bytes written
       decompressedBytesWritten += length + INT_SIZE;
-      if (serializedUncompressedBytes != null) {
-        serializedUncompressedBytes.increment(length);
-      }
+      numSerializedBytesWritten += length;
     }
 
     protected void writeKVPair(byte[] keyData, int keyPos, int keyLength,
@@ -471,9 +474,7 @@ public class IFile {
 
       // Update bytes written
       decompressedBytesWritten += keyLength + valueLength + INT_SIZE + INT_SIZE;
-      if (serializedUncompressedBytes != null) {
-        serializedUncompressedBytes.increment(keyLength + valueLength);
-      }
+      numSerializedBytesWritten += keyLength + valueLength;
     }
 
     protected void onClose() throws IOException {


### PR DESCRIPTION
### Motivation
- `IFile.Writer` was incrementing the `serializedUncompressedBytes` `TezCounter` on each write path (`writeValue` / `writeKVPair`) which is a hot path and can cause synchronization/contention overhead. 
- Batch-updating the counter once per `Writer` lifecycle reduces frequent synchronized updates while preserving the same counted metric (serialized key/value payload bytes).

### Description
- Added a local accumulator field `numSerializedBytesWritten` to `IFile.Writer` to aggregate serialized key/value byte counts. 
- Changed `writeValue` and `writeKVPair` to increment the local accumulator instead of calling `serializedUncompressedBytes.increment(...)` on each call. 
- Moved the `serializedUncompressedBytes` `TezCounter` update to `Writer.close()` so the counter is incremented once per writer instead of per append operation.

### Testing
- Attempted to compile the `tez-runtime-library` module with `mvn -pl tez-runtime-library -DskipTests compile`, which failed due to external plugin resolution (`com.github.os72:protoc-jar-maven-plugin:3.11.4` returned HTTP 403) and not due to the code changes. 
- No automated unit tests were run in this environment because the Maven build could not complete due to the external dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db674e23c8832893061df562a04c6e)