### PR TITLE
Release committed memory when closing LOCAL_BYTE_CACHE IFile.Reader in MergeManager

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1049,7 +1049,22 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       java.io.InputStream inputStream = mapOutput.getInputStream();
       return new IFile.Reader(
           inputStream, mapOutput.getSize(), codec,
-          null, null, ifileReadAhead, ifileReadAheadLength, inputContext);
+          null, null, ifileReadAhead, ifileReadAheadLength, inputContext) {
+        private boolean releasedCommittedMemory;
+
+        @Override
+        public void close() throws IOException {
+          if (releasedCommittedMemory) {
+            return;
+          }
+          try {
+            super.close();
+          } finally {
+            releasedCommittedMemory = true;
+            releaseCommittedMemory(mapOutput.getSize(), 0L);
+          }
+        }
+      };
     }
     byte[] data = mapOutput.getMemory();
     return new InMemoryReader(


### PR DESCRIPTION
### Motivation
- Ensure committed memory held by `LOCAL_BYTE_CACHE` map-output readers is released when the reader is closed to avoid memory retention and leaks.

### Description
- For `MapOutput.Type.LOCAL_BYTE_CACHE` return an anonymous `IFile.Reader` subclass that overrides `close()` to call `releaseCommittedMemory(mapOutput.getSize(), 0L)` exactly once, guarded by a `releasedCommittedMemory` flag.

### Testing
- Ran unit tests with `mvn -DskipTests=false test` and relevant shuffle/integration tests exercising `MergeManager`; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc59fc73c48328b254f62bff2879ad)