### PR TITLE
Add LOCAL_BYTE_CACHE InputStream MapOutput and fix local fetch abort scope

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -674,12 +674,12 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
       TezSpillRecord spillRecord = null;  // specific to each inputAttemptIdentifier/pathComponent
       Path inputFilePath = null;
 
-      MapOutput mapOutput = null;
       boolean hasFailures = false;
       // Fetch partition count number of map outputs (handles auto-reduce case)
       for (int k = 0; k < partitionCount; k++) {
         int reduceId = partitionId + k;
         InputAttemptIdentifier srcAttemptId = pathToAttemptMap.get(new PathPartition(pathComponent, reduceId));
+        MapOutput mapOutput = null;
 
         try {
           long startTime = System.currentTimeMillis();
@@ -702,6 +702,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
           long endTime = System.currentTimeMillis();
           fetcherCallback.fetchSucceeded(shuffleClientId, host, srcAttemptId, mapOutput,
               indexRecord.getPartLength(), indexRecord.getRawLength(), (endTime - startTime));
+          mapOutput = null;
         } catch (IOException | InternalError e) {
           if (mapOutput != null) {
             mapOutput.abort();


### PR DESCRIPTION
### Motivation
- Enable fetching map outputs from a local byte-cache (`ConcurrentByteCache`) without copying into memory by introducing an InputStream-backed map output type. 
- Ensure merges can consume input streams directly while preserving the MergeManager memory accounting semantics. 
- Fix a correctness issue where an outer-scoped `mapOutput` reference could be aborted by a later partition failure, which is unsafe for `LOCAL_BYTE_CACHE` because `abort()` closes the underlying stream.

### Description
- Added a new `MapOutput.Type.LOCAL_BYTE_CACHE` and an `InputStreamMapOutput` implementation with `getInputStream()`, sized `getSize()`, `commit()` and `abort()` behaviors that do not allocate merge-manager memory. 
- Added `MapOutput.createInputStreamMapOutput(...)` to construct `InputStreamMapOutput` instances. 
- Updated `FetcherOrderedGrouped` to support local byte-cache fetches via `getMapOutputForDirectFetch(...)`, which creates an `InputStreamMapOutput` from a `MultiByteArrayOutputStream` and wraps it with `BoundedInputStream` limited to the index-part length. 
- Updated `MergeManager` to treat `LOCAL_BYTE_CACHE` map outputs like memory-backed ones by adding `createMapOutputReader(...)` that creates an `IFile.Reader` over the input stream and overrides `close()` to call `releaseCommittedMemory(...)`, and refactored merge call sites to use this helper. 
- Fixed the local fetch loop in `FetcherOrderedGrouped` by scoping `mapOutput` inside the partition loop and clearing it after `fetcherCallback.fetchSucceeded(...)` to avoid aborting previously-committed map outputs.

### Testing
- Attempted a module compile with `mvn -pl tez-runtime-library -DskipTests test-compile`, which failed due to external Maven plugin resolution returning HTTP 403 for `protoc-jar-maven-plugin`, so no build artifacts or automated tests were produced in this environment. 
- Performed code inspection and local static verification of the changed call sites and added reader/close semantics; no automated unit/integration tests ran successfully due to the environment dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc660da3b08328b033954e473e51ee)