### PR TITLE
Distinguish MapOutput reader length from merge-accounting size for local byte-cache inputs

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -776,6 +776,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     return MapOutput.createInputStreamMapOutput(
         srcAttemptId, allocator,
         new BoundedInputStream(inputStream, indexRecord.getPartLength()),
+        indexRecord.getRawLength(),
         indexRecord.getPartLength(),
         true);
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -85,8 +85,10 @@ public abstract class MapOutput implements ShuffleInput {
       FetchedInputAllocatorOrderedGrouped callback,
       InputStream inputStream,
       long size,
+      long readerLength,
       boolean primaryMapOutput) {
-    return new InputStreamMapOutput(attemptIdentifier, callback, inputStream, size, primaryMapOutput);
+    return new InputStreamMapOutput(
+        attemptIdentifier, callback, inputStream, size, readerLength, primaryMapOutput);
   }
 
   // may throw OutOfMemoryError
@@ -141,7 +143,25 @@ public abstract class MapOutput implements ShuffleInput {
 
   public abstract ShuffleClient.Type getType();
 
-  public long getSize() {
+  /**
+   * Logical size of this map output as used by MergeManager for in-memory merge accounting,
+   * merge candidate ordering, and output buffer sizing decisions.
+   *
+   * For MEMORY/DISK map outputs this usually matches physical bytes.
+   * For LOCAL_BYTE_CACHE it represents the logical/raw footprint used by merge accounting.
+   */
+  public long getSizeForMergeAccounting() {
+    return -1;
+  }
+
+  /**
+   * Physical byte length presented to IFile.Reader.
+   *
+   * This can differ from getSizeForMergeAccounting() when the map output is streamed from local byte cache:
+   * getSizeForMergeAccounting() is the logical/raw accounting size, while getReaderLength() is the actual
+   * bounded stream length consumed by IFile.Reader.
+   */
+  public long getReaderLength() {
     return -1;
   }
 
@@ -165,10 +185,14 @@ public abstract class MapOutput implements ShuffleInput {
       if (o1.id == o2.id) { 
         return 0;
       }
-      
-      if (o1.getSize() < o2.getSize()) {
+
+      // Comparator is used for in-memory map-output collections that drive
+      // merge-triggering and merge candidate selection. It must therefore sort
+      // by the logical merge-accounting footprint, not by reader-length.
+      // (reader-length can diverge for LOCAL_BYTE_CACHE inputs).
+      if (o1.getSizeForMergeAccounting() < o2.getSizeForMergeAccounting()) {
         return -1;
-      } else if (o1.getSize() > o2.getSize()) {
+      } else if (o1.getSizeForMergeAccounting() > o2.getSizeForMergeAccounting()) {
         return 1;
       }
       
@@ -194,7 +218,13 @@ public abstract class MapOutput implements ShuffleInput {
     }
 
     @Override
-    public long getSize() {
+    public long getSizeForMergeAccounting() {
+      throw new UnsupportedOperationException(
+          "DiskDirectMapOutput does not support getSizeForMergeAccounting()");
+    }
+
+    @Override
+    public long getReaderLength() {
       return outputPath.getLength();
     }
 
@@ -238,7 +268,13 @@ public abstract class MapOutput implements ShuffleInput {
     }
 
     @Override
-    public long getSize() {
+    public long getSizeForMergeAccounting() {
+      throw new UnsupportedOperationException(
+          "DiskMapOutput does not support getSizeForMergeAccounting()");
+    }
+
+    @Override
+    public long getReaderLength() {
       return outputPath.getLength();
     }
 
@@ -284,7 +320,12 @@ public abstract class MapOutput implements ShuffleInput {
     }
 
     @Override
-    public long getSize() {
+    public long getSizeForMergeAccounting() {
+      return byteArray.length;
+    }
+
+    @Override
+    public long getReaderLength() {
       return byteArray.length;
     }
 
@@ -328,20 +369,28 @@ public abstract class MapOutput implements ShuffleInput {
     public ShuffleClient.Type getType() {
       return ShuffleClient.Type.WAIT;
     }
+
+    @Override
+    public long getReaderLength() {
+      return 0L;
+    }
   }
 
   private static class InputStreamMapOutput extends MapOutput {
     private InputStream inputStream;
     private final long size;
+    private final long readerLength;
 
     private InputStreamMapOutput(InputAttemptIdentifier attemptIdentifier,
                                  FetchedInputAllocatorOrderedGrouped callback,
                                  InputStream inputStream,
                                  long size,
+                                 long readerLength,
                                  boolean primaryMapOutput) {
       super(attemptIdentifier, callback, primaryMapOutput);
       this.inputStream = inputStream;
       this.size = size;
+      this.readerLength = readerLength;
     }
 
     @Override
@@ -350,8 +399,13 @@ public abstract class MapOutput implements ShuffleInput {
     }
 
     @Override
-    public long getSize() {
+    public long getSizeForMergeAccounting() {
       return size;
+    }
+
+    @Override
+    public long getReaderLength() {
+      return readerLength;
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -523,7 +523,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     inMemoryMapOutputs.add(mapOutput);
     trackAndLogCloseInMemoryFile(mapOutput);
 
-    this.commitMemory += mapOutput.getSize();
+    this.commitMemory += mapOutput.getSizeForMergeAccounting();
 
     if (this.commitMemory >= mergeThreshold) {
       startMemToDiskMerge();
@@ -540,10 +540,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   }
 
   private void trackAndLogCloseInMemoryFile(MapOutput mapOutput) {
-    statsInMemTotal.updateStats(mapOutput.getSize());
+    statsInMemTotal.updateStats(mapOutput.getSizeForMergeAccounting());
 
     if (isDebugEnabled) {
-      LOG.debug("closeInMemoryFile -> map-output of size: " + mapOutput.getSize()
+      LOG.debug("closeInMemoryFile -> map-output of size: " + mapOutput.getSizeForMergeAccounting()
           + ", inMemoryMapOutputs.size() -> " + inMemoryMapOutputs.size()
           + ", commitMemory -> " + this.commitMemory + ", usedMemory ->" +
           this.usedMemory + ", mapOutput=" + mapOutput);
@@ -567,12 +567,12 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     if (isDebugEnabled) {
       // This log could be moved to INFO level for a while, after mem-to-mem
       // merge is production ready.
-      LOG.debug("closeInMemoryMergedFile -> size: " + mapOutput.getSize() +
+      LOG.debug("closeInMemoryMergedFile -> size: " + mapOutput.getSizeForMergeAccounting() +
           ", inMemoryMergedMapOutputs.size() -> " +
           inMemoryMergedMapOutputs.size());
     }
 
-    this.commitMemory += mapOutput.getSize();
+    this.commitMemory += mapOutput.getSizeForMergeAccounting();
 
     if (this.commitMemory >= mergeThreshold) {
       startMemToDiskMerge();
@@ -717,21 +717,21 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         MapOutput lastAddedMapOutput = null;
         while (it.hasNext() && !Thread.currentThread().isInterrupted()) {
           MapOutput mo = it.next();
-          // We have to use mo.getSize(), not mo.getUsedMemoryForMergeManager(), because
+          // We have to use mo.getSizeForMergeAccounting(), not mo.getUsedMemoryForMergeManager(), because
           // we will create a buffer big enough to hold the sum of the actual sizes of all selected inputs.
           // Adding manager.getUsedMemory() is okay because
           // the guard is about whether we can safely charge the new merged buffer under the budget.
-          if ((mergeOutputSize + mo.getSize() + manager.getUsedMemory()) > memoryLimit) {
+          if ((mergeOutputSize + mo.getSizeForMergeAccounting() + manager.getUsedMemory()) > memoryLimit) {
             //Search for smaller segments that can fit into existing mem
             if (isDebugEnabled) {
               LOG.debug("Size is greater than usedMemory. "
                   + "mergeOutputSize=" + mergeOutputSize
-                  + ", moSize=" + mo.getSize()
+                  + ", moSize=" + mo.getSizeForMergeAccounting()
                   + ", usedMemory=" + manager.getUsedMemory()
                   + ", memoryLimit=" + memoryLimit);
             }
           } else {
-            mergeOutputSize += mo.getSize();
+            mergeOutputSize += mo.getSizeForMergeAccounting();
             IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mo);
             inMemorySegments.add(new Segment(reader,
                 (mo.isPrimaryMapOutput() ? mergedMapOutputsCounter : null)));
@@ -1027,12 +1027,12 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     // closed but not yet present in inMemoryMapOutputs
     long fullSize = 0L;
     for (MapOutput mo : inMemoryMapOutputs) {
-      fullSize += mo.getSize();
+      fullSize += mo.getSizeForMergeAccounting();
     }
     int inMemoryMapOutputsOffset = 0;
     while((fullSize > leaveBytes) && !Thread.currentThread().isInterrupted()) {
       MapOutput mo = inMemoryMapOutputs.get(inMemoryMapOutputsOffset++);
-      long size = mo.getSize();
+      long size = mo.getSizeForMergeAccounting();
       totalSize += size;
       fullSize -= size;
       IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mo);
@@ -1048,9 +1048,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     assert mapOutput.getType() == ShuffleClient.Type.MEMORY || mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE;
     if (mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE) {
       java.io.InputStream inputStream = mapOutput.getInputStream();
-      final long size = mapOutput.getSize();
+      final long size = mapOutput.getSizeForMergeAccounting();
+      final long readerLength = mapOutput.getReaderLength();
       return new IFile.Reader(
-          inputStream, size, codec,
+          inputStream, readerLength, codec,
           null, null, ifileReadAhead, ifileReadAheadLength, inputContext) {
         @Override
         public void close() throws IOException {
@@ -1252,11 +1253,11 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
                                   List<FileChunk> onDiskMapOutputs) {
     long inMemSegmentSize = 0;
     for (MapOutput inMemoryMapOutput : inMemoryMapOutputs) {
-      inMemSegmentSize += inMemoryMapOutput.getSize();
+      inMemSegmentSize += inMemoryMapOutput.getSizeForMergeAccounting();
 
       if (isDebugEnabled) {
         LOG.debug("finalMerge: inMemoryOutput=" + inMemoryMapOutput + ", size=" +
-            inMemoryMapOutput.getSize());
+            inMemoryMapOutput.getSizeForMergeAccounting());
       }
     }
     long onDiskSegmentSize = 0;


### PR DESCRIPTION
### Motivation
- Local byte-cache backed map outputs present a physical reader length that can differ from the logical size used for merge accounting, causing incorrect merge decisions and reader behavior.
- The change separates the semantics of the bytes presented to `IFile.Reader` from the logical footprint used by `MergeManager` and merge selection logic.

### Description
- Introduced two new `MapOutput` accessors: `getSizeForMergeAccounting()` for logical merge/accounting size and `getReaderLength()` for the physical length passed to `IFile.Reader`.
- Updated `InputStreamMapOutput` to accept a `readerLength` and changed `FetcherOrderedGrouped` to pass `indexRecord.getRawLength()` when creating input-stream-backed map outputs.
- Replaced usages of the old `getSize()` in merge accounting, stats, comparator ordering, and mem-to-mem merge selection with `getSizeForMergeAccounting()`, and updated the comparator to sort by merge-accounting size.
- Implemented `getReaderLength()` for relevant map-output types and adjusted `MergeManager#createMapOutputReader` to pass `readerLength` into `IFile.Reader`; disk-backed outputs now expose only reader length while throwing for merge-accounting size where inappropriate.

### Testing
- Ran the project unit test suite with `mvn test` (including shuffle/merge related tests) against the modified code.
- All automated unit tests and shuffle-related tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcab7b0c3083289f582be26968577c)