### PR TITLE
Lazy-create sorter and KV writers only when data is written

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/OrderedPartitionedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/OrderedPartitionedKVOutput.java
@@ -60,6 +60,7 @@ public class OrderedPartitionedKVOutput extends AbstractLogicalOutput implements
   private static final Logger LOG = LoggerFactory.getLogger(OrderedPartitionedKVOutput.class);
 
   protected PipelinedSorter sorter;
+  private KeyValuesWriterEdge writer;
   protected Configuration conf;
   private RawLocalFileSystem localFs;
   protected MemoryUpdateCallbackHandler memoryUpdateCallbackHandler;
@@ -112,9 +113,6 @@ public class OrderedPartitionedKVOutput extends AbstractLogicalOutput implements
       // We do not use TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT.
       isFinalMergeEnabled = !this.isPipelinedShuffle;
 
-      sorter = new PipelinedSorter(getContext(), conf, getNumPhysicalOutputs(),
-          memoryUpdateCallbackHandler.getMemoryAssigned());
-
       isStarted.set(true);
     }
   }
@@ -122,27 +120,55 @@ public class OrderedPartitionedKVOutput extends AbstractLogicalOutput implements
   @Override
   public synchronized KeyValuesWriterEdge getWriter() throws IOException {
     Preconditions.checkState(isStarted.get(), "Cannot get writer before starting the Output");
-    return new KeyValuesWriterEdge() {
-      @Override
-      public void setDefaultLengths(int defaultKeyLen, int defaultValLen) {
-        sorter.setDefaultLengths(defaultKeyLen, defaultValLen);
-      }
+    if (writer == null) {
+      writer = new KeyValuesWriterEdge() {
+        private int defaultKeyLen = -1;
+        private int defaultValLen = -1;
+        private boolean closeWriterCalled = false;
 
-      @Override
-      public void closeWriter() {
-        sorter.closeWriter();
-      }
+        private PipelinedSorter getOrCreateSorter() throws IOException {
+          if (sorter == null) {
+            sorter = new PipelinedSorter(getContext(), conf, getNumPhysicalOutputs(),
+                memoryUpdateCallbackHandler.getMemoryAssigned());
+            if (defaultKeyLen >= 0 && defaultValLen >= 0) {
+              sorter.setDefaultLengths(defaultKeyLen, defaultValLen);
+            }
+            if (closeWriterCalled) {
+              sorter.closeWriter();
+            }
+          }
+          return sorter;
+        }
 
-      @Override
-      public void write(BytesWritable key, BytesWritable value) throws IOException {
-        sorter.write(key, value);
-      }
+        @Override
+        public void setDefaultLengths(int defaultKeyLen, int defaultValLen) {
+          this.defaultKeyLen = defaultKeyLen;
+          this.defaultValLen = defaultValLen;
+          if (sorter != null) {
+            sorter.setDefaultLengths(defaultKeyLen, defaultValLen);
+          }
+        }
 
-      @Override
-      public void write(BytesWritable key, Iterable<BytesWritable> values) throws IOException {
-        sorter.write(key, values);
-      }
-    };
+        @Override
+        public void closeWriter() {
+          closeWriterCalled = true;
+          if (sorter != null) {
+            sorter.closeWriter();
+          }
+        }
+
+        @Override
+        public void write(BytesWritable key, BytesWritable value) throws IOException {
+          getOrCreateSorter().write(key, value);
+        }
+
+        @Override
+        public void write(BytesWritable key, Iterable<BytesWritable> values) throws IOException {
+          getOrCreateSorter().write(key, values);
+        }
+      };
+    }
+    return writer;
   }
 
   @Override
@@ -158,6 +184,11 @@ public class OrderedPartitionedKVOutput extends AbstractLogicalOutput implements
       returnEvents.addAll(sorter.close());
       returnEvents.addAll(generateEvents());
       sorter = null;
+      writer = null;
+    } else if (isStarted.get()) {
+      LOG.debug("{}: Output {} started but no records were written. Generating empty events",
+          getContext().getDestinationVertexName(), this.getClass().getSimpleName());
+      returnEvents = generateEmptyEvents();
     } else {
       LOG.warn(getContext().getDestinationVertexName() +
           ": Attempting to close output {} of type {} before it was started. Generating empty events",

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedKVOutput.java
@@ -18,6 +18,7 @@
 
 package org.apache.tez.runtime.library.output;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.tez.common.Preconditions;
 import org.apache.tez.runtime.library.api.LogicalOutputEdge;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.slf4j.Logger;
@@ -54,6 +56,7 @@ public class UnorderedKVOutput extends AbstractLogicalOutput implements LogicalO
   private static final Logger LOG = LoggerFactory.getLogger(UnorderedKVOutput.class);
 
   UnorderedPartitionedKVWriter kvWriter;
+  private KeyValuesWriterEdge writer;
   
   private Configuration conf;
   
@@ -91,9 +94,6 @@ public class UnorderedKVOutput extends AbstractLogicalOutput implements LogicalO
   public synchronized void start() throws Exception {
     if (!isStarted.get()) {
       memoryUpdateCallbackHandler.validateUpdateReceived();
-      //This would have just a single partition
-      this.kvWriter = new UnorderedPartitionedKVWriter(getContext(), conf, 1,
-          memoryUpdateCallbackHandler.getMemoryAssigned());
       isStarted.set(true);
       LOG.info(getContext().getDestinationVertexName() + " started. MemoryAssigned="
           + memoryUpdateCallbackHandler.getMemoryAssigned());
@@ -102,7 +102,57 @@ public class UnorderedKVOutput extends AbstractLogicalOutput implements LogicalO
 
   @Override
   public synchronized KeyValuesWriterEdge getWriter() throws Exception {
-    return kvWriter;
+    Preconditions.checkState(isStarted.get(), "Cannot get writer before starting the Output");
+    if (writer == null) {
+      writer = new KeyValuesWriterEdge() {
+        private int defaultKeyLen = -1;
+        private int defaultValLen = -1;
+        private boolean closeWriterCalled = false;
+
+        private UnorderedPartitionedKVWriter getOrCreateKVWriter() throws IOException {
+          if (kvWriter == null) {
+            // This output always has a single partition.
+            kvWriter = new UnorderedPartitionedKVWriter(getContext(), conf, 1,
+                memoryUpdateCallbackHandler.getMemoryAssigned());
+            if (defaultKeyLen >= 0 && defaultValLen >= 0) {
+              kvWriter.setDefaultLengths(defaultKeyLen, defaultValLen);
+            }
+            if (closeWriterCalled) {
+              kvWriter.closeWriter();
+            }
+          }
+          return kvWriter;
+        }
+
+        @Override
+        public void setDefaultLengths(int defaultKeyLen, int defaultValLen) {
+          this.defaultKeyLen = defaultKeyLen;
+          this.defaultValLen = defaultValLen;
+          if (kvWriter != null) {
+            kvWriter.setDefaultLengths(defaultKeyLen, defaultValLen);
+          }
+        }
+
+        @Override
+        public void closeWriter() {
+          closeWriterCalled = true;
+          if (kvWriter != null) {
+            kvWriter.closeWriter();
+          }
+        }
+
+        @Override
+        public void write(BytesWritable key, BytesWritable value) throws IOException {
+          getOrCreateKVWriter().write(key, value);
+        }
+
+        @Override
+        public void write(BytesWritable key, Iterable<BytesWritable> values) throws IOException {
+          getOrCreateKVWriter().write(key, values);
+        }
+      };
+    }
+    return writer;
   }
 
   @Override
@@ -113,9 +163,16 @@ public class UnorderedKVOutput extends AbstractLogicalOutput implements LogicalO
   @Override
   public synchronized List<Event> close() throws Exception {
     List<Event> returnEvents = null;
-    if (isStarted.get()) {
+    if (isStarted.get() && kvWriter != null) {
       returnEvents = kvWriter.close();
       kvWriter = null;
+      writer = null;
+    } else if (isStarted.get()) {
+      LOG.debug("{}: Output {} started but no records were written. Generating empty events",
+          getContext().getDestinationVertexName(), this.getClass().getSimpleName());
+      returnEvents = new LinkedList<Event>();
+      ShuffleUtils.generateEventsForNonStartedOutput(returnEvents, getNumPhysicalOutputs(), getContext(),
+          false, false, TezCommonUtils.newBestCompressionDeflater());
     } else {
       LOG.warn(getContext().getDestinationVertexName() +
           ": Attempting to close output {} of type {} before it was started. Generating empty events",

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedPartitionedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedPartitionedKVOutput.java
@@ -18,6 +18,7 @@
 
 package org.apache.tez.runtime.library.output;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -25,9 +26,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.common.Preconditions;
 
 import org.apache.tez.runtime.library.api.LogicalOutputEdge;
+import org.apache.tez.runtime.library.api.KeyValuesWriterEdge;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +57,7 @@ public class UnorderedPartitionedKVOutput extends AbstractLogicalOutput implemen
   private Configuration conf;
   private MemoryUpdateCallbackHandler memoryUpdateCallbackHandler;
   private UnorderedPartitionedKVWriter kvWriter;
+  private KeyValuesWriterEdge writer;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
 
   public UnorderedPartitionedKVOutput(OutputContext outputContext, int numPhysicalOutputs) {
@@ -77,16 +81,62 @@ public class UnorderedPartitionedKVOutput extends AbstractLogicalOutput implemen
   public synchronized void start() throws Exception {
     if (!isStarted.get()) {
       memoryUpdateCallbackHandler.validateUpdateReceived();
-      this.kvWriter = new UnorderedPartitionedKVWriter(getContext(), conf, getNumPhysicalOutputs(),
-          memoryUpdateCallbackHandler.getMemoryAssigned());
       isStarted.set(true);
     }
   }
 
   @Override
-  public synchronized UnorderedPartitionedKVWriter getWriter() throws Exception {
+  public synchronized KeyValuesWriterEdge getWriter() throws Exception {
     Preconditions.checkState(isStarted.get(), "Cannot get writer before starting the Output");
-    return kvWriter;
+    if (writer == null) {
+      writer = new KeyValuesWriterEdge() {
+        private int defaultKeyLen = -1;
+        private int defaultValLen = -1;
+        private boolean closeWriterCalled = false;
+
+        private UnorderedPartitionedKVWriter getOrCreateKVWriter() throws IOException {
+          if (kvWriter == null) {
+            kvWriter = new UnorderedPartitionedKVWriter(getContext(), conf, getNumPhysicalOutputs(),
+                memoryUpdateCallbackHandler.getMemoryAssigned());
+            if (defaultKeyLen >= 0 && defaultValLen >= 0) {
+              kvWriter.setDefaultLengths(defaultKeyLen, defaultValLen);
+            }
+            if (closeWriterCalled) {
+              kvWriter.closeWriter();
+            }
+          }
+          return kvWriter;
+        }
+
+        @Override
+        public void setDefaultLengths(int defaultKeyLen, int defaultValLen) {
+          this.defaultKeyLen = defaultKeyLen;
+          this.defaultValLen = defaultValLen;
+          if (kvWriter != null) {
+            kvWriter.setDefaultLengths(defaultKeyLen, defaultValLen);
+          }
+        }
+
+        @Override
+        public void closeWriter() {
+          closeWriterCalled = true;
+          if (kvWriter != null) {
+            kvWriter.closeWriter();
+          }
+        }
+
+        @Override
+        public void write(BytesWritable key, BytesWritable value) throws IOException {
+          getOrCreateKVWriter().write(key, value);
+        }
+
+        @Override
+        public void write(BytesWritable key, Iterable<BytesWritable> values) throws IOException {
+          getOrCreateKVWriter().write(key, values);
+        }
+      };
+    }
+    return writer;
   }
 
   @Override
@@ -96,9 +146,17 @@ public class UnorderedPartitionedKVOutput extends AbstractLogicalOutput implemen
   @Override
   public synchronized List<Event> close() throws Exception {
     List<Event> returnEvents = null;
-    if (isStarted.get()) {
+    if (isStarted.get() && kvWriter != null) {
       returnEvents = kvWriter.close();
       kvWriter = null;
+      writer = null;
+    } else if (isStarted.get()) {
+      LOG.debug("{}: Output {} started but no records were written. Generating empty events",
+          getContext().getDestinationVertexName(), this.getClass().getSimpleName());
+      returnEvents = new LinkedList<Event>();
+      ShuffleUtils
+          .generateEventsForNonStartedOutput(returnEvents, getNumPhysicalOutputs(), getContext(),
+              false, true, TezCommonUtils.newBestCompressionDeflater());
     } else {
       LOG.warn(getContext().getDestinationVertexName() +
           ": Attempting to close output {} of type {} before it was started. Generating empty events",


### PR DESCRIPTION
### Motivation

- Many `PipelinedSorter` and `UnorderedPartitionedKVWriter` instances are created but never receive records, causing unnecessary allocation and setup cost.  
- Defer heavy object construction until the first `write(...)` so empty outputs avoid creating sorters/writers.  

### Description

- Change `OrderedPartitionedKVOutput` to return a lazy `KeyValuesWriterEdge` wrapper that instantiates `PipelinedSorter` on the first `write(...)`, while caching and replaying `setDefaultLengths(...)` and `closeWriter()` calls.  
- Change `UnorderedKVOutput` to lazily create the single-partition `UnorderedPartitionedKVWriter` on first `write(...)` via a `KeyValuesWriterEdge` wrapper, preserving default-length and close semantics.  
- Change `UnorderedPartitionedKVOutput` to return a lazy `KeyValuesWriterEdge` wrapper that instantiates `UnorderedPartitionedKVWriter` on first `write(...)` and preserve previous behavior.  
- Update `close()` behavior to emit empty-output events for outputs that were `start()`ed but never written to, without allocating sorter/writer objects, and clear cached wrappers when the underlying object is closed.  

### Testing

- Ran `mvn -pl tez-runtime-library -DskipTests compile` to validate compilation in this environment, but the build failed due to an external Maven plugin resolution error (HTTP 403 on `protoc-jar-maven-plugin`), which is an environment/dependency issue and not a code error.  
- No automated unit tests were executed in this session due to the compilation environment failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddf91e76608328aa2be148e620b1c2)