### PR TITLE
Add Tez offset metadata plumbing for non-RLE IFile writers/cache

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
@@ -1,6 +1,8 @@
 package org.apache.tez.runtime.api;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -23,12 +25,28 @@ public class IndexPathCache {
     private final ByteBuffer spillRecord;
     @Nullable
     private final TezOffsetRecord offsetRecord;
+    @Nullable
+    private final Map<Integer, TezOffsetRecord> offsetRecordMap;
 
     public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
                          @Nullable TezOffsetRecord offsetRecord) {
+      this(mapOutputFilePath, spillRecord, offsetRecord, null);
+    }
+
+    public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
+                         @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
+      this(mapOutputFilePath, spillRecord, null, offsetRecordMap);
+    }
+
+    private MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
+                         @Nullable TezOffsetRecord offsetRecord,
+                         @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
       this.mapOutputFilePath = mapOutputFilePath;
       this.spillRecord = spillRecord;
       this.offsetRecord = offsetRecord;
+      this.offsetRecordMap = offsetRecordMap == null
+          ? null
+          : Collections.unmodifiableMap(new HashMap<>(offsetRecordMap));
     }
 
     public Path getMapOutputFilePath() {
@@ -43,6 +61,11 @@ public class IndexPathCache {
     public TezOffsetRecord getOffsetRecord() {
       return offsetRecord;
     }
+
+    @Nullable
+    public Map<Integer, TezOffsetRecord> getOffsetRecordMap() {
+      return offsetRecordMap;
+    }
   }
 
   private final ConcurrentHashMap<String, MapOutputInfo> cache;
@@ -54,6 +77,11 @@ public class IndexPathCache {
   public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
                   @Nullable TezOffsetRecord offsetRecord) {
     cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecord));
+  }
+
+  public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
+                  @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
+    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecordMap));
   }
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
@@ -1,8 +1,6 @@
 package org.apache.tez.runtime.api;
 
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -24,19 +22,13 @@ public class IndexPathCache {
     private final Path mapOutputFilePath;   // null if data is not written directly to local disk
     private final ByteBuffer spillRecord;
     @Nullable
-    private final TezOffsetRecord offsetRecord;
-    @Nullable
     private final Map<Integer, TezOffsetRecord> offsetRecordMap;
 
     public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
-                         @Nullable TezOffsetRecord offsetRecord,
                          @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
       this.mapOutputFilePath = mapOutputFilePath;
       this.spillRecord = spillRecord;
-      this.offsetRecord = offsetRecord;
-      this.offsetRecordMap = offsetRecordMap == null
-          ? null
-          : Collections.unmodifiableMap(new HashMap<>(offsetRecordMap));
+      this.offsetRecordMap = offsetRecordMap;
     }
 
     public Path getMapOutputFilePath() {
@@ -45,11 +37,6 @@ public class IndexPathCache {
 
     public ByteBuffer getSpillRecord() {
       return spillRecord;
-    }
-
-    @Nullable
-    public TezOffsetRecord getOffsetRecord() {
-      return offsetRecord;
     }
 
     @Nullable
@@ -65,13 +52,8 @@ public class IndexPathCache {
   }
 
   public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
-                  @Nullable TezOffsetRecord offsetRecord) {
-    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecord, null));
-  }
-
-  public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
                   @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
-    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, null, offsetRecordMap));
+    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecordMap));
   }
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
@@ -21,10 +21,14 @@ public class IndexPathCache {
   public static class MapOutputInfo {
     private final Path mapOutputFilePath;   // null if data is not written directly to local disk
     private final ByteBuffer spillRecord;
+    @Nullable
+    private final TezOffsetRecord offsetRecord;
 
-    public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord) {
+    public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
+                         @Nullable TezOffsetRecord offsetRecord) {
       this.mapOutputFilePath = mapOutputFilePath;
       this.spillRecord = spillRecord;
+      this.offsetRecord = offsetRecord;
     }
 
     public Path getMapOutputFilePath() {
@@ -34,6 +38,11 @@ public class IndexPathCache {
     public ByteBuffer getSpillRecord() {
       return spillRecord;
     }
+
+    @Nullable
+    public TezOffsetRecord getOffsetRecord() {
+      return offsetRecord;
+    }
   }
 
   private final ConcurrentHashMap<String, MapOutputInfo> cache;
@@ -42,8 +51,9 @@ public class IndexPathCache {
     this.cache = new ConcurrentHashMap<>();
   }
 
-  public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord) {
-    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord));
+  public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
+                  @Nullable TezOffsetRecord offsetRecord) {
+    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecord));
   }
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java
@@ -29,16 +29,6 @@ public class IndexPathCache {
     private final Map<Integer, TezOffsetRecord> offsetRecordMap;
 
     public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
-                         @Nullable TezOffsetRecord offsetRecord) {
-      this(mapOutputFilePath, spillRecord, offsetRecord, null);
-    }
-
-    public MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
-                         @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
-      this(mapOutputFilePath, spillRecord, null, offsetRecordMap);
-    }
-
-    private MapOutputInfo(@Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
                          @Nullable TezOffsetRecord offsetRecord,
                          @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
       this.mapOutputFilePath = mapOutputFilePath;
@@ -76,12 +66,12 @@ public class IndexPathCache {
 
   public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
                   @Nullable TezOffsetRecord offsetRecord) {
-    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecord));
+    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecord, null));
   }
 
   public void add(String mapId, @Nullable Path mapOutputFilePath, ByteBuffer spillRecord,
                   @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
-    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, offsetRecordMap));
+    cache.put(mapId, new MapOutputInfo(mapOutputFilePath, spillRecord, null, offsetRecordMap));
   }
 
   /**

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/TezOffsetRecord.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/TezOffsetRecord.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.api;
+
+/**
+ * Metadata needed to decode non-RLE Tez IFile records with variable
+ * length-prefix transitions.
+ */
+public class TezOffsetRecord {
+  private final int maxKeyLen;
+  private final int maxValLen;
+  private final int firstKeyOffset;
+  private final int firstValOffset;
+  private final int eofPos;
+
+  public TezOffsetRecord(
+      int maxKeyLen,
+      int maxValLen,
+      int firstKeyOffset,
+      int firstValOffset,
+      int eofPos) {
+    this.maxKeyLen = maxKeyLen;
+    this.maxValLen = maxValLen;
+    this.firstKeyOffset = firstKeyOffset;
+    this.firstValOffset = firstValOffset;
+    this.eofPos = eofPos;
+  }
+
+  public int getMaxKeyLen() {
+    return maxKeyLen;
+  }
+
+  public int getMaxValLen() {
+    return maxValLen;
+  }
+
+  public int getFirstKeyOffset() {
+    return firstKeyOffset;
+  }
+
+  public int getFirstValOffset() {
+    return firstValOffset;
+  }
+
+  public int getEofPos() {
+    return eofPos;
+  }
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -673,13 +673,13 @@ public class ShuffleUtils {
       @Nullable Path outputFilePath,
       TezSpillRecord spillRecord,
       @Nullable MultiByteArrayOutputStream byteArrayOutput,
-      @Nullable TezOffsetRecord offsetRecord) {
+      @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
     assert !(outputFilePath != null && byteArrayOutput != null);
     String pathComponent = outputContext.getUniqueIdentifier();
     String mapId = ShuffleUtils.expandPathComponent(outputContext, true, pathComponent);
 
     IndexPathCache indexPathCache = outputContext.getIndexPathCache();
-    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer(), offsetRecord);
+    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer(), offsetRecordMap);
 
     if (byteArrayOutput != null) {
       ConcurrentByteCache concurrentByteCache = outputContext.getConcurrentByteCache();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -48,6 +48,7 @@ import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.ConcurrentByteCache;
 import org.apache.tez.runtime.api.IndexPathCache;
 import org.apache.tez.runtime.api.TaskContext;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.api.events.DataMovementEvent;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
@@ -670,13 +671,14 @@ public class ShuffleUtils {
       OutputContext outputContext,
       @Nullable Path outputFilePath,
       TezSpillRecord spillRecord,
-      @Nullable MultiByteArrayOutputStream byteArrayOutput) {
+      @Nullable MultiByteArrayOutputStream byteArrayOutput,
+      @Nullable TezOffsetRecord offsetRecord) {
     assert !(outputFilePath != null && byteArrayOutput != null);
     String pathComponent = outputContext.getUniqueIdentifier();
     String mapId = ShuffleUtils.expandPathComponent(outputContext, true, pathComponent);
 
     IndexPathCache indexPathCache = outputContext.getIndexPathCache();
-    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer());
+    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer(), offsetRecord);
 
     if (byteArrayOutput != null) {
       ConcurrentByteCache concurrentByteCache = outputContext.getConcurrentByteCache();
@@ -693,13 +695,14 @@ public class ShuffleUtils {
       int spillId,
       @Nullable Path outputFilePath,
       TezSpillRecord spillRecord,
-      @Nullable MultiByteArrayOutputStream byteArrayOutput) {
+      @Nullable MultiByteArrayOutputStream byteArrayOutput,
+      @Nullable TezOffsetRecord offsetRecord) {
     assert !(outputFilePath != null && byteArrayOutput != null);
     String pathComponent = ShuffleUtils.getUniqueIdentifierSpillId(outputContext, spillId);
     String mapId = ShuffleUtils.expandPathComponent(outputContext, true, pathComponent);
 
     IndexPathCache indexPathCache = outputContext.getIndexPathCache();
-    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer());
+    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer(), offsetRecord);
 
     if (byteArrayOutput != null) {
       ConcurrentByteCache concurrentByteCache = outputContext.getConcurrentByteCache();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -29,6 +29,7 @@ import java.util.AbstractMap;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.Deflater;
 
@@ -696,13 +697,13 @@ public class ShuffleUtils {
       @Nullable Path outputFilePath,
       TezSpillRecord spillRecord,
       @Nullable MultiByteArrayOutputStream byteArrayOutput,
-      @Nullable TezOffsetRecord offsetRecord) {
+      @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
     assert !(outputFilePath != null && byteArrayOutput != null);
     String pathComponent = ShuffleUtils.getUniqueIdentifierSpillId(outputContext, spillId);
     String mapId = ShuffleUtils.expandPathComponent(outputContext, true, pathComponent);
 
     IndexPathCache indexPathCache = outputContext.getIndexPathCache();
-    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer(), offsetRecord);
+    indexPathCache.add(mapId, outputFilePath, spillRecord.getByteBuffer(), offsetRecordMap);
 
     if (byteArrayOutput != null) {
       ConcurrentByteCache concurrentByteCache = outputContext.getConcurrentByteCache();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -508,6 +508,10 @@ public class IFile {
       decompressedBytesWritten += length;
     }
 
+    protected long getDecompressedBytesWritten() {
+      return decompressedBytesWritten;
+    }
+
     protected void bufferWriteInt(int val) throws IOException {
       final int len = 4;
       final int remaining = writeBufferLength - writeOffset;
@@ -616,7 +620,7 @@ public class IFile {
     }
 
     public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
-      int recordStartOffset = (int) decompressedBytesWritten;
+      int recordStartOffset = (int) getDecompressedBytesWritten();
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
@@ -756,7 +760,7 @@ public class IFile {
     }
 
     public void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException {
-      int recordStartOffset = (int) decompressedBytesWritten;
+      int recordStartOffset = (int) getDecompressedBytesWritten();
       int keyLength = key.getLength();
       int valueLength = value.getLength();
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.DecompressorPool;
 import org.apache.tez.runtime.api.TaskContext;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.api.TezTaskOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -344,6 +345,9 @@ public class IFile {
     protected int maxValLen;
     protected boolean keyLenTransitioned = false;
     protected boolean valLenTransitioned = false;
+    protected int firstKeyOffset = -1;
+    protected int firstValOffset = -1;
+    protected int eofPos = -1;
 
     protected Writer(FSDataOutputStream outputStream,
                      CompressionCodec codec,
@@ -415,6 +419,14 @@ public class IFile {
       }
 
       onClose();
+
+      eofPos = (int) decompressedBytesWritten;
+      if (firstKeyOffset < 0) {
+        firstKeyOffset = eofPos;
+      }
+      if (firstValOffset < 0) {
+        firstValOffset = eofPos;
+      }
 
       // Write EOF_MARKER for key/value length
       long combined = ((long) EOF_MARKER << 32) | (EOF_MARKER & 0xFFFFFFFFL);
@@ -543,6 +555,14 @@ public class IFile {
     public long getCompressedLength() {
       return compressedBytesWritten;
     }
+
+    @Nullable
+    public TezOffsetRecord getTezOffsetRecord() {
+      if (eofPos < 0) {
+        return null;
+      }
+      return new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
+    }
   }
 
   public static class WriterDataInputBuffer extends Writer implements WriterAppendDataInputBuffer {
@@ -596,6 +616,7 @@ public class IFile {
     }
 
     public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      int recordStartOffset = (int) decompressedBytesWritten;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
@@ -607,9 +628,11 @@ public class IFile {
       int lengthBytes = 0;
       if (!keyLenTransitioned && keyLength != maxKeyLen) {
         keyLenTransitioned = true;
+        firstKeyOffset = recordStartOffset;
       }
       if (!valLenTransitioned && valueLength != maxValLen) {
         valLenTransitioned = true;
+        firstValOffset = recordStartOffset;
       }
       if (keyLenTransitioned) {
         bufferWriteInt(keyLength);
@@ -663,6 +686,7 @@ public class IFile {
 
     @Override
     protected void onClose() throws IOException {
+      super.onClose();
       if (isRleEnabled) {
         writeValueMarker();
       }
@@ -732,6 +756,7 @@ public class IFile {
     }
 
     public void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException {
+      int recordStartOffset = (int) decompressedBytesWritten;
       int keyLength = key.getLength();
       int valueLength = value.getLength();
 
@@ -743,9 +768,11 @@ public class IFile {
       int lengthBytes = 0;
       if (!keyLenTransitioned && keyLength != maxKeyLen) {
         keyLenTransitioned = true;
+        firstKeyOffset = recordStartOffset;
       }
       if (!valLenTransitioned && valueLength != maxValLen) {
         valLenTransitioned = true;
+        firstValOffset = recordStartOffset;
       }
       if (keyLenTransitioned) {
         bufferWriteInt(keyLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.util.IndexedSortable;
 import org.apache.hadoop.util.IndexedSorter;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.runtime.api.OutputContext;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
@@ -511,6 +512,7 @@ public class PipelinedSorter extends ExternalSorter {
 
     try {
       LOG.info("{}: Spilling single record to {}", outputContext.getDestinationVertexName(), outputFilePath.toString());
+      TezOffsetRecord spillOffsetRecord = null;
       for (int i = 0; i < partitions; ++i) {
         if (isThreadInterrupted()) {
           return;
@@ -541,6 +543,9 @@ public class PipelinedSorter extends ExternalSorter {
             writer.close();
             rawLength = writer.getRawLength();
             partLength = writer.getCompressedLength();
+            if (compositeFetch && i == partition) {
+              spillOffsetRecord = writer.getTezOffsetRecord();
+            }
           }
           adjustSpillCounters(rawLength, partLength);
           // record offsets
@@ -560,7 +565,8 @@ public class PipelinedSorter extends ExternalSorter {
         spillFileIndexPaths.put(numSpills, indexFilename);
         spillRec.writeToFile(indexFilename, localFs, localFsSpillFilePerms);
       } else {
-        ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(outputContext, numSpills, outputFilePath, spillRec, null, null);
+        ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(
+            outputContext, numSpills, outputFilePath, spillRec, null, spillOffsetRecord);
       }
 
       //TODO: honor cache limits
@@ -626,6 +632,8 @@ public class PipelinedSorter extends ExternalSorter {
         LOG.debug("Spilling to {} (use in-memory buffers = {})", spillFileName.toString(), canUseBuffers);
       }
 
+      TezOffsetRecord spillOffsetRecord = null;
+      boolean multipleOffsetRecords = false;
       for (int i = 0; i < partitions; ++i) {
         if (isThreadInterrupted()) {
           return false;
@@ -673,6 +681,15 @@ public class PipelinedSorter extends ExternalSorter {
         // record offsets
         final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
         spillRec.putIndex(rec, i);
+        if (!multipleOffsetRecords && compositeFetch && !isRleEnabled && rec.hasData()) {
+          TezOffsetRecord currentOffsetRecord = writer.getTezOffsetRecord();
+          if (spillOffsetRecord == null) {
+            spillOffsetRecord = currentOffsetRecord;
+          } else {
+            multipleOffsetRecords = true;
+            spillOffsetRecord = null;
+          }
+        }
         if (!isFinalMergeEnabled && reportPartitionStats()) {
           partitionStats[i] += rawLength;
         }
@@ -694,7 +711,7 @@ public class PipelinedSorter extends ExternalSorter {
     } else {
       Path outputFilePath = byteArrayOutput == null ? spillFileName : null;
       ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(
-          outputContext, numSpills, outputFilePath, spillRec, byteArrayOutput, null);
+          outputContext, numSpills, outputFilePath, spillRec, byteArrayOutput, spillOffsetRecord);
     }
     if (isDebugEnabled) {
       LOG.debug("{}: Finished spill {}", outputContext.getDestinationVertexName(), numSpills);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -635,7 +635,9 @@ public class PipelinedSorter extends ExternalSorter {
         LOG.debug("Spilling to {} (use in-memory buffers = {})", spillFileName.toString(), canUseBuffers);
       }
 
-      Map<Integer, TezOffsetRecord> spillOffsetRecordMap = compositeFetch ? new HashMap<>() : null;
+      final boolean isRleEnabled = merger.needsRLE();
+      Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
+          (compositeFetch && !isRleEnabled) ? new HashMap<>() : null;
       for (int i = 0; i < partitions; ++i) {
         if (isThreadInterrupted()) {
           return false;
@@ -645,7 +647,6 @@ public class PipelinedSorter extends ExternalSorter {
         long segmentStart = fsOutput.getPos();
         WriterDataInputBuffer writer = null;
         boolean hasNext = kvIter.hasNext();
-        boolean isRleEnabled = merger.needsRLE();
         if (hasNext || !sendEmptyPartitionDetails) {
           if (codec != null && compressorExternal == null) {
             compressorExternal = CodecUtils.getCompressor(codec);
@@ -940,7 +941,9 @@ public class PipelinedSorter extends ExternalSorter {
       }
 
       final TezSpillRecord spillRec = new TezSpillRecord(partitions);
-      Map<Integer, TezOffsetRecord> offsetRecordMap = compositeFetch ? new HashMap<>() : null;
+      final boolean isFinalMergeRleEnabled = merger.needsRLE();
+      Map<Integer, TezOffsetRecord> offsetRecordMap =
+          (compositeFetch && !isFinalMergeRleEnabled) ? new HashMap<>() : null;
       long finalOutputSize = 0;
       try {
         for (int parts = 0; parts < partitions; parts++) {
@@ -993,7 +996,7 @@ public class PipelinedSorter extends ExternalSorter {
           // record offsets
           final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
           spillRec.putIndex(rec, parts);
-          if (offsetRecordMap != null && !merger.needsRLE() && rec.hasData()) {
+          if (offsetRecordMap != null && rec.hasData()) {
             offsetRecordMap.put(parts, writer.getTezOffsetRecord());
           }
           if (reportPartitionStats()) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -940,6 +940,7 @@ public class PipelinedSorter extends ExternalSorter {
       }
 
       final TezSpillRecord spillRec = new TezSpillRecord(partitions);
+      Map<Integer, TezOffsetRecord> offsetRecordMap = compositeFetch ? new HashMap<>() : null;
       long finalOutputSize = 0;
       try {
         for (int parts = 0; parts < partitions; parts++) {
@@ -970,8 +971,9 @@ public class PipelinedSorter extends ExternalSorter {
           long segmentStart = finalOut.getPos();
           long rawLength = 0;
           long partLength = 0;
+          WriterDataInputBuffer writer = null;
           if (shouldWrite) {
-            WriterDataInputBuffer writer = new WriterDataInputBuffer(
+            writer = new WriterDataInputBuffer(
                 finalOut,
                 codec, spilledRecordsCounter, null, merger.needsRLE(),
                 maxKeyLen, maxValLen,
@@ -991,6 +993,9 @@ public class PipelinedSorter extends ExternalSorter {
           // record offsets
           final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
           spillRec.putIndex(rec, parts);
+          if (offsetRecordMap != null && !merger.needsRLE() && rec.hasData()) {
+            offsetRecordMap.put(parts, writer.getTezOffsetRecord());
+          }
           if (reportPartitionStats()) {
             partitionStats[parts] += rawLength;
           }
@@ -1014,7 +1019,7 @@ public class PipelinedSorter extends ExternalSorter {
       } else {
         Path outputFilePath = byteArrayOutput == null ? finalOutputFile : null;
         ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext,
-            outputFilePath, spillRec, byteArrayOutput, null);
+            outputFilePath, spillRec, byteArrayOutput, offsetRecordMap);
       }
 
       for (int i = 0; i < numSpills; i++) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -26,8 +26,10 @@ import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.concurrent.*;
 import java.util.zip.Deflater;
@@ -512,7 +514,7 @@ public class PipelinedSorter extends ExternalSorter {
 
     try {
       LOG.info("{}: Spilling single record to {}", outputContext.getDestinationVertexName(), outputFilePath.toString());
-      TezOffsetRecord spillOffsetRecord = null;
+      Map<Integer, TezOffsetRecord> spillOffsetRecordMap = null;
       for (int i = 0; i < partitions; ++i) {
         if (isThreadInterrupted()) {
           return;
@@ -544,7 +546,8 @@ public class PipelinedSorter extends ExternalSorter {
             rawLength = writer.getRawLength();
             partLength = writer.getCompressedLength();
             if (compositeFetch && i == partition) {
-              spillOffsetRecord = writer.getTezOffsetRecord();
+              spillOffsetRecordMap = new HashMap<>();
+              spillOffsetRecordMap.put(i, writer.getTezOffsetRecord());
             }
           }
           adjustSpillCounters(rawLength, partLength);
@@ -566,7 +569,7 @@ public class PipelinedSorter extends ExternalSorter {
         spillRec.writeToFile(indexFilename, localFs, localFsSpillFilePerms);
       } else {
         ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(
-            outputContext, numSpills, outputFilePath, spillRec, null, spillOffsetRecord);
+            outputContext, numSpills, outputFilePath, spillRec, null, spillOffsetRecordMap);
       }
 
       //TODO: honor cache limits
@@ -632,8 +635,7 @@ public class PipelinedSorter extends ExternalSorter {
         LOG.debug("Spilling to {} (use in-memory buffers = {})", spillFileName.toString(), canUseBuffers);
       }
 
-      TezOffsetRecord spillOffsetRecord = null;
-      boolean multipleOffsetRecords = false;
+      Map<Integer, TezOffsetRecord> spillOffsetRecordMap = compositeFetch ? new HashMap<>() : null;
       for (int i = 0; i < partitions; ++i) {
         if (isThreadInterrupted()) {
           return false;
@@ -681,14 +683,8 @@ public class PipelinedSorter extends ExternalSorter {
         // record offsets
         final TezIndexRecord rec = new TezIndexRecord(segmentStart, rawLength, partLength);
         spillRec.putIndex(rec, i);
-        if (!multipleOffsetRecords && compositeFetch && !isRleEnabled && rec.hasData()) {
-          TezOffsetRecord currentOffsetRecord = writer.getTezOffsetRecord();
-          if (spillOffsetRecord == null) {
-            spillOffsetRecord = currentOffsetRecord;
-          } else {
-            multipleOffsetRecords = true;
-            spillOffsetRecord = null;
-          }
+        if (spillOffsetRecordMap != null && !isRleEnabled && rec.hasData()) {
+          spillOffsetRecordMap.put(i, writer.getTezOffsetRecord());
         }
         if (!isFinalMergeEnabled && reportPartitionStats()) {
           partitionStats[i] += rawLength;
@@ -711,7 +707,7 @@ public class PipelinedSorter extends ExternalSorter {
     } else {
       Path outputFilePath = byteArrayOutput == null ? spillFileName : null;
       ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(
-          outputContext, numSpills, outputFilePath, spillRec, byteArrayOutput, spillOffsetRecord);
+          outputContext, numSpills, outputFilePath, spillRec, byteArrayOutput, spillOffsetRecordMap);
     }
     if (isDebugEnabled) {
       LOG.debug("{}: Finished spill {}", outputContext.getDestinationVertexName(), numSpills);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -560,7 +560,7 @@ public class PipelinedSorter extends ExternalSorter {
         spillFileIndexPaths.put(numSpills, indexFilename);
         spillRec.writeToFile(indexFilename, localFs, localFsSpillFilePerms);
       } else {
-        ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(outputContext, numSpills, outputFilePath, spillRec, null);
+        ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(outputContext, numSpills, outputFilePath, spillRec, null, null);
       }
 
       //TODO: honor cache limits
@@ -694,7 +694,7 @@ public class PipelinedSorter extends ExternalSorter {
     } else {
       Path outputFilePath = byteArrayOutput == null ? spillFileName : null;
       ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(
-          outputContext, numSpills, outputFilePath, spillRec, byteArrayOutput);
+          outputContext, numSpills, outputFilePath, spillRec, byteArrayOutput, null);
     }
     if (isDebugEnabled) {
       LOG.debug("{}: Finished spill {}", outputContext.getDestinationVertexName(), numSpills);
@@ -1001,7 +1001,7 @@ public class PipelinedSorter extends ExternalSorter {
       } else {
         Path outputFilePath = byteArrayOutput == null ? finalOutputFile : null;
         ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext,
-            outputFilePath, spillRec, byteArrayOutput);
+            outputFilePath, spillRec, byteArrayOutput, null);
       }
 
       for (int i = 0; i < numSpills; i++) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -899,7 +899,12 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
             sr.writeToFile(finalIndexPath, localFs, localFsSpillFilePerms);
             fileOutputBytesCounter.increment(compLen + indexFileSizeEstimate);
           } else {
-            ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext, finalOutPath, sr, null, writer.getTezOffsetRecord());
+            Map<Integer, TezOffsetRecord> offsetRecordMap = null;
+            if (compositeFetch) {
+              offsetRecordMap = new HashMap<>();
+              offsetRecordMap.put(0, writer.getTezOffsetRecord());
+            }
+            ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext, finalOutPath, sr, null, offsetRecordMap);
             fileOutputBytesCounter.increment(compLen);
           }
         }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -67,6 +67,7 @@ import org.apache.tez.runtime.api.ExecutorServiceUserGroupInformation;
 import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
 import org.apache.tez.runtime.api.TaskFailureType;
 import org.apache.tez.runtime.api.OutputContext;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.api.events.CompositeDataMovementEvent;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration.ReportPartitionStats;
@@ -691,6 +692,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         DataInputBuffer val = new DataInputBuffer();
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
+        TezOffsetRecord spillOffsetRecord = null;
+        boolean multipleOffsetRecords = false;
         for (int i = 0; i < numPartitions; i++) {
           WriterDataInputBuffer writer = null;
           try {
@@ -726,6 +729,15 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
               TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getRawLength(),
                   writer.getCompressedLength());
               spillRecord.putIndex(indexRecord, i);
+              if (!multipleOffsetRecords && compositeFetch && !writer.isRleEnabled() && indexRecord.hasData()) {
+                TezOffsetRecord currentOffsetRecord = writer.getTezOffsetRecord();
+                if (spillOffsetRecord == null) {
+                  spillOffsetRecord = currentOffsetRecord;
+                } else {
+                  multipleOffsetRecords = true;
+                  spillOffsetRecord = null;
+                }
+              }
               writer = null;
             }
           } finally {
@@ -748,7 +760,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       spillResult = new SpillResult(compressedLength, this.filledBuffers, canUseBuffers);
 
       // spillPathDetails.spillIndex can be -1 if spillIndex was not used in pathComponent
-      handleSpillIndex(spillPathDetails, spillRecord, byteArrayOutput);
+      handleSpillIndex(spillPathDetails, spillRecord, byteArrayOutput, spillOffsetRecord);
       if (isDebugEnabled) {
         LOG.debug("{}: Finished spill {}", destNameTrimmed, spillPathDetails.spillIndex);
       }
@@ -1434,6 +1446,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       if (isPipelinedShuffle) {
         emptyPartitions = new BitSet(numPartitions);
       }
+      TezOffsetRecord spillOffsetRecord = null;
+      boolean multipleOffsetRecords = false;
       for (int i = 0; i < numPartitions; i++) {
         final long recordStart = out.getPos();
         if (i == partition) {
@@ -1463,6 +1477,15 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
             TezIndexRecord indexRecord = new TezIndexRecord(recordStart, writer.getRawLength(),
                 writer.getCompressedLength());
             spillRecord.putIndex(indexRecord, i);
+            if (!multipleOffsetRecords && compositeFetch && indexRecord.hasData()) {
+              TezOffsetRecord currentOffsetRecord = writer.getTezOffsetRecord();
+              if (spillOffsetRecord == null) {
+                spillOffsetRecord = currentOffsetRecord;
+              } else {
+                multipleOffsetRecords = true;
+                spillOffsetRecord = null;
+              }
+            }
             outSize = writer.getCompressedLength();
             writer = null;
           } finally {
@@ -1478,7 +1501,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       }
 
       // spillPathDetails.spillIndex is never -1
-      handleSpillIndex(spillPathDetails, spillRecord, null);
+      handleSpillIndex(spillPathDetails, spillRecord, null, spillOffsetRecord);
 
       if (isPipelinedShuffle) {
         // This output file is directly served to downstream tasks, so increment fileOutputBytesCounter.
@@ -1502,7 +1525,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
 
   private void handleSpillIndex(
       SpillPathDetails spillPathDetails, TezSpillRecord spillRecord,
-      @Nullable MultiByteArrayOutputStream byteArrayOutput) throws IOException {
+      @Nullable MultiByteArrayOutputStream byteArrayOutput,
+      @Nullable TezOffsetRecord offsetRecord) throws IOException {
     if (spillPathDetails.indexComputed) {
       if (spillPathDetails.indexFilePath != null) {
         // write the index record
@@ -1515,10 +1539,10 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         // must check if spillPathDetails.spillIndex == -1
         if (spillPathDetails.spillIndex < 0) {
           ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext,
-              outputFilePath, spillRecord, byteArrayOutput, null);
+              outputFilePath, spillRecord, byteArrayOutput, offsetRecord);
         } else {
           ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(outputContext,
-              spillPathDetails.spillIndex, outputFilePath, spillRecord, byteArrayOutput, null);
+              spillPathDetails.spillIndex, outputFilePath, spillRecord, byteArrayOutput, offsetRecord);
         }
       }
     } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -892,7 +892,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
             sr.writeToFile(finalIndexPath, localFs, localFsSpillFilePerms);
             fileOutputBytesCounter.increment(compLen + indexFileSizeEstimate);
           } else {
-            ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext, finalOutPath, sr, null);
+            ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext, finalOutPath, sr, null, writer.getTezOffsetRecord());
             fileOutputBytesCounter.increment(compLen);
           }
         }
@@ -1364,7 +1364,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     } else {
       Path outputPath = byteArrayOutput == null ? finalOutPath : null;
       ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext,
-          outputPath, finalSpillRecord, byteArrayOutput);
+          outputPath, finalSpillRecord, byteArrayOutput, null);
     }
     LOG.info("{}: Finished final spill after merging: {} spills", destNameTrimmed, numSpills.get());
   }
@@ -1515,10 +1515,10 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         // must check if spillPathDetails.spillIndex == -1
         if (spillPathDetails.spillIndex < 0) {
           ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext,
-              outputFilePath, spillRecord, byteArrayOutput);
+              outputFilePath, spillRecord, byteArrayOutput, null);
         } else {
           ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(outputContext,
-              spillPathDetails.spillIndex, outputFilePath, spillRecord, byteArrayOutput);
+              spillPathDetails.spillIndex, outputFilePath, spillRecord, byteArrayOutput, null);
         }
       }
     } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -694,7 +694,9 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         DataInputBuffer val = new DataInputBuffer();
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
-        Map<Integer, TezOffsetRecord> spillOffsetRecordMap = compositeFetch ? new HashMap<>() : null;
+        final boolean isRleEnabled = false;
+        Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
+            (compositeFetch && !isRleEnabled) ? new HashMap<>() : null;
         for (int i = 0; i < numPartitions; i++) {
           WriterDataInputBuffer writer = null;
           try {
@@ -730,7 +732,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
               TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getRawLength(),
                   writer.getCompressedLength());
               spillRecord.putIndex(indexRecord, i);
-              if (spillOffsetRecordMap != null && !writer.isRleEnabled() && indexRecord.hasData()) {
+              if (spillOffsetRecordMap != null && indexRecord.hasData()) {
                 spillOffsetRecordMap.put(i, writer.getTezOffsetRecord());
               }
               writer = null;
@@ -1446,7 +1448,9 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       if (isPipelinedShuffle) {
         emptyPartitions = new BitSet(numPartitions);
       }
-      Map<Integer, TezOffsetRecord> spillOffsetRecordMap = compositeFetch ? new HashMap<>() : null;
+      final boolean isRleEnabled = false;
+      Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
+          (compositeFetch && !isRleEnabled) ? new HashMap<>() : null;
       for (int i = 0; i < numPartitions; i++) {
         final long recordStart = out.getPos();
         if (i == partition) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -28,8 +28,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -692,8 +694,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         DataInputBuffer val = new DataInputBuffer();
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
-        TezOffsetRecord spillOffsetRecord = null;
-        boolean multipleOffsetRecords = false;
+        Map<Integer, TezOffsetRecord> spillOffsetRecordMap = compositeFetch ? new HashMap<>() : null;
         for (int i = 0; i < numPartitions; i++) {
           WriterDataInputBuffer writer = null;
           try {
@@ -729,14 +730,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
               TezIndexRecord indexRecord = new TezIndexRecord(segmentStart, writer.getRawLength(),
                   writer.getCompressedLength());
               spillRecord.putIndex(indexRecord, i);
-              if (!multipleOffsetRecords && compositeFetch && !writer.isRleEnabled() && indexRecord.hasData()) {
-                TezOffsetRecord currentOffsetRecord = writer.getTezOffsetRecord();
-                if (spillOffsetRecord == null) {
-                  spillOffsetRecord = currentOffsetRecord;
-                } else {
-                  multipleOffsetRecords = true;
-                  spillOffsetRecord = null;
-                }
+              if (spillOffsetRecordMap != null && !writer.isRleEnabled() && indexRecord.hasData()) {
+                spillOffsetRecordMap.put(i, writer.getTezOffsetRecord());
               }
               writer = null;
             }
@@ -760,7 +755,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       spillResult = new SpillResult(compressedLength, this.filledBuffers, canUseBuffers);
 
       // spillPathDetails.spillIndex can be -1 if spillIndex was not used in pathComponent
-      handleSpillIndex(spillPathDetails, spillRecord, byteArrayOutput, spillOffsetRecord);
+      handleSpillIndex(spillPathDetails, spillRecord, byteArrayOutput, spillOffsetRecordMap);
       if (isDebugEnabled) {
         LOG.debug("{}: Finished spill {}", destNameTrimmed, spillPathDetails.spillIndex);
       }
@@ -1446,8 +1441,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       if (isPipelinedShuffle) {
         emptyPartitions = new BitSet(numPartitions);
       }
-      TezOffsetRecord spillOffsetRecord = null;
-      boolean multipleOffsetRecords = false;
+      Map<Integer, TezOffsetRecord> spillOffsetRecordMap = compositeFetch ? new HashMap<>() : null;
       for (int i = 0; i < numPartitions; i++) {
         final long recordStart = out.getPos();
         if (i == partition) {
@@ -1477,14 +1471,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
             TezIndexRecord indexRecord = new TezIndexRecord(recordStart, writer.getRawLength(),
                 writer.getCompressedLength());
             spillRecord.putIndex(indexRecord, i);
-            if (!multipleOffsetRecords && compositeFetch && indexRecord.hasData()) {
-              TezOffsetRecord currentOffsetRecord = writer.getTezOffsetRecord();
-              if (spillOffsetRecord == null) {
-                spillOffsetRecord = currentOffsetRecord;
-              } else {
-                multipleOffsetRecords = true;
-                spillOffsetRecord = null;
-              }
+            if (spillOffsetRecordMap != null && indexRecord.hasData()) {
+              spillOffsetRecordMap.put(i, writer.getTezOffsetRecord());
             }
             outSize = writer.getCompressedLength();
             writer = null;
@@ -1501,7 +1489,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       }
 
       // spillPathDetails.spillIndex is never -1
-      handleSpillIndex(spillPathDetails, spillRecord, null, spillOffsetRecord);
+      handleSpillIndex(spillPathDetails, spillRecord, null, spillOffsetRecordMap);
 
       if (isPipelinedShuffle) {
         // This output file is directly served to downstream tasks, so increment fileOutputBytesCounter.
@@ -1526,7 +1514,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
   private void handleSpillIndex(
       SpillPathDetails spillPathDetails, TezSpillRecord spillRecord,
       @Nullable MultiByteArrayOutputStream byteArrayOutput,
-      @Nullable TezOffsetRecord offsetRecord) throws IOException {
+      @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) throws IOException {
     if (spillPathDetails.indexComputed) {
       if (spillPathDetails.indexFilePath != null) {
         // write the index record
@@ -1539,10 +1527,10 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         // must check if spillPathDetails.spillIndex == -1
         if (spillPathDetails.spillIndex < 0) {
           ShuffleUtils.writeToIndexPathCacheAndByteCache(outputContext,
-              outputFilePath, spillRecord, byteArrayOutput, offsetRecord);
+              outputFilePath, spillRecord, byteArrayOutput, null);
         } else {
           ShuffleUtils.writeSpillInfoToIndexPathCacheAndByteCache(outputContext,
-              spillPathDetails.spillIndex, outputFilePath, spillRecord, byteArrayOutput, offsetRecord);
+              spillPathDetails.spillIndex, outputFilePath, spillRecord, byteArrayOutput, offsetRecordMap);
         }
       }
     } else {


### PR DESCRIPTION
### Motivation
- Enable deterministic decoding of non-RLE Tez IFile streams by recording writer-produced metadata (max lengths and transition/EOF offsets) required by the new byte layout for `tez` shuffle handler paths. 
- Provide a way to persist that metadata alongside existing spill/index records so the shuffle handler/fetchers can obtain exact `maxKeyLen`, `maxValLen`, `firstKeyOffset`, `firstValOffset`, and `eofPos` for a map output. 
- Implement the writer-side metadata finalization and cache plumbing (Steps 3–6 in the plan) so later work can propagate metadata in headers and readers.

### Description
- Add `TezOffsetRecord` API class to carry the five integers: `maxKeyLen`, `maxValLen`, `firstKeyOffset`, `firstValOffset`, and `eofPos` (`tez-api/src/main/java/org/apache/tez/runtime/api/TezOffsetRecord.java`).
- Extend `IndexPathCache.MapOutputInfo` to optionally hold a `TezOffsetRecord` and update `IndexPathCache.add(...)` to accept an `@Nullable TezOffsetRecord` so metadata can be cached with spill/index info (`tez-api/src/main/java/org/apache/tez/runtime/api/IndexPathCache.java`).
- Instrument `IFile.Writer` to record transition offsets and EOF position: track `firstKeyOffset` / `firstValOffset` at the first `appendNoRleTez(...)` that differs from `maxKeyLen`/`maxValLen`, finalize `eofPos` in `close()`, default unset transitions to `eofPos`, and expose the metadata via `getTezOffsetRecord()` (`tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java`).
- Extend `ShuffleUtils.writeToIndexPathCacheAndByteCache(...)` and `writeSpillInfoToIndexPathCacheAndByteCache(...)` to accept an optional `TezOffsetRecord` and persist it into `IndexPathCache` (`tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java`).
- Update callers to pass the new argument; most call sites pass `null` for now, while the skip-buffer single-partition final output path now provides `writer.getTezOffsetRecord()` so the metadata is stored for that fast-path (`UnorderedPartitionedKVWriter` and `PipelinedSorter` changes). 
- Preserve existing writer behavior: `WriterDataInputBuffer.onClose()` now calls `super.onClose()` to retain zero-record behavior.

### Testing
- Attempted to compile the affected modules with `mvn -pl tez-api,tez-runtime-library -DskipTests compile` to validate API and library changes; the build failed in this environment due to external Maven plugin resolution (HTTP 403 fetching `com.github.os72:protoc-jar-maven-plugin:3.11.4`), not due to source compile errors reported here. 
- No automated unit tests were added in this change set and no other automated tests completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df101a832483288811ab6dfc03f8df)