### PR TITLE
Include TezOffsetRecord metadata in composite shuffle headers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 
 /**
  * Shuffle Header information that is sent by the TaskTracker and 
@@ -48,6 +49,7 @@ public class ShuffleHeader implements Writable {
   long uncompressedLength;
   long compressedLength;
   int forReduce;
+  TezOffsetRecord tezOffsetRecord;
 
   private boolean compositeFetch;
 
@@ -63,10 +65,16 @@ public class ShuffleHeader implements Writable {
   // ShuffleHeader created used by MR3 ShuffleHandler (but not by Hadoop shuffle service)
   public ShuffleHeader(String mapId, long compressedLength,
       long uncompressedLength, int forReduce) {
+    this(mapId, compressedLength, uncompressedLength, forReduce, null);
+  }
+
+  public ShuffleHeader(String mapId, long compressedLength,
+      long uncompressedLength, int forReduce, TezOffsetRecord tezOffsetRecord) {
     this.mapId = mapId;
     this.compressedLength = compressedLength;
     this.uncompressedLength = uncompressedLength;
     this.forReduce = forReduce;
+    this.tezOffsetRecord = tezOffsetRecord;
   }
   
   public String getMapId() {
@@ -85,6 +93,10 @@ public class ShuffleHeader implements Writable {
     return compressedLength;
   }
 
+  public TezOffsetRecord getTezOffsetRecord() {
+    return tezOffsetRecord;
+  }
+
   public void readFields(DataInput in) throws IOException {
     if (compositeFetch) {   // ShuffleHeader created by MR3 ShuffleHandler
       int length = in.readInt();  // Cf. WritableUtils.readStringSafely() calls readVInt()
@@ -99,6 +111,16 @@ public class ShuffleHeader implements Writable {
       compressedLength = in.readLong();
       uncompressedLength = in.readLong();
       forReduce = in.readInt();
+      int maxKeyLen = in.readInt();
+      int maxValLen = in.readInt();
+      int firstKeyOffset = in.readInt();
+      int firstValOffset = in.readInt();
+      int eofPos = in.readInt();
+      if (maxKeyLen >= 0) {
+        tezOffsetRecord = new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
+      } else {
+        tezOffsetRecord = null;
+      }
     } else {  // ShuffleHeader created by Hadoop shuffle service
       mapId = WritableUtils.readStringSafely(in, MAX_ID_LENGTH);
       compressedLength = WritableUtils.readVLong(in);
@@ -112,6 +134,7 @@ public class ShuffleHeader implements Writable {
   public int writeLength() throws IOException {
     int length = Text.encode(mapId).limit();
     length += 4 + 8 + 8 + 4;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce
+    length += 5 * 4;  // encoding of TezOffsetRecord
     return length;
   }
 
@@ -127,5 +150,18 @@ public class ShuffleHeader implements Writable {
     out.writeLong(compressedLength);
     out.writeLong(uncompressedLength);
     out.writeInt(forReduce);
+    if (tezOffsetRecord != null) {
+      out.writeInt(tezOffsetRecord.getMaxKeyLen());
+      out.writeInt(tezOffsetRecord.getMaxValLen());
+      out.writeInt(tezOffsetRecord.getFirstKeyOffset());
+      out.writeInt(tezOffsetRecord.getFirstValOffset());
+      out.writeInt(tezOffsetRecord.getEofPos());
+    } else {
+      out.writeInt(-1);
+      out.writeInt(-1);
+      out.writeInt(-1);
+      out.writeInt(-1);
+      out.writeInt(-1);
+    }
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -17,7 +17,6 @@ package org.apache.tez.shufflehandler;
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.ReadaheadPool;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.util.DiskChecker;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -62,6 +61,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.tez.runtime.api.ConcurrentByteCache;
 import org.apache.tez.runtime.api.IndexPathCache;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.common.security.SecureShuffleUtils;
 import org.apache.tez.runtime.library.common.shuffle.api.ShuffleHandlerError;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
@@ -1015,6 +1015,7 @@ public class ShuffleHandler {
 
       Path dataPath = mapOutputInfo.getMapOutputFilePath();   // dataPath can be null
       TezSpillRecord spillRecord = new TezSpillRecord(mapOutputInfo.getSpillRecord());
+      Map<Integer, TezOffsetRecord> offsetRecordMap = mapOutputInfo.getOffsetRecordMap();
       MultiByteArrayOutputStream byteArrayOutput = concurrentByteCache.get(mapId);
 
       if (isLogDebugEnabled) {
@@ -1023,9 +1024,10 @@ public class ShuffleHandler {
 
       MapOutputInfo outputInfo;
       if (reduceRange.first == reduceRange.last) {
-        outputInfo = new MapOutputInfo(dataPath, spillRecord.getIndex(reduceRange.first), reduceRange, byteArrayOutput);
+        outputInfo = new MapOutputInfo(
+            dataPath, spillRecord.getIndex(reduceRange.first), reduceRange, byteArrayOutput, offsetRecordMap);
       } else {
-        outputInfo = new MapOutputInfo(dataPath, spillRecord, reduceRange, byteArrayOutput);
+        outputInfo = new MapOutputInfo(dataPath, spillRecord, reduceRange, byteArrayOutput, offsetRecordMap);
       }
       return outputInfo;
     }
@@ -1057,14 +1059,11 @@ public class ShuffleHandler {
         if (mapOutputInfoMap.size() < mapOutputMetaInfoCacheSize) {
           mapOutputInfoMap.put(mapId, outputInfo);
         }
-        int lengthInitial = Text.encode(mapId).limit();
         for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
           TezIndexRecord indexRecord = outputInfo.getIndex(reduce);
-
-          // contentLength += (new ShuffleHeader(mapId, indexRecord.getPartLength(), indexRecord.getRawLength(), reduce)).writeLength();
-          int length = lengthInitial;
-          length += 4 + 8 + 8 + 4;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce
-          contentLength += length;
+          TezOffsetRecord offsetRecord = outputInfo.getTezOffsetRecord(reduce);
+          contentLength += new ShuffleHeader(
+              mapId, indexRecord.getPartLength(), indexRecord.getRawLength(), reduce, offsetRecord).writeLength();
 
           contentLength += indexRecord.getPartLength();
         }
@@ -1094,23 +1093,29 @@ public class ShuffleHandler {
       private TezIndexRecord indexRecord;
       private final Range reduceRange;
       private final MultiByteArrayOutputStream byteArrayOutput;
+      @Nullable
+      private final Map<Integer, TezOffsetRecord> offsetRecordMap;
 
       MapOutputInfo(@Nullable Path mapOutputFileName,
                     TezIndexRecord indexRecord, Range reduceRange,
-                    @Nullable MultiByteArrayOutputStream byteArrayOutput) {
+                    @Nullable MultiByteArrayOutputStream byteArrayOutput,
+                    @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
         this.mapOutputFileName = mapOutputFileName;
         this.indexRecord = indexRecord;
         this.reduceRange = reduceRange;
         this.byteArrayOutput = byteArrayOutput;
+        this.offsetRecordMap = offsetRecordMap;
       }
 
       MapOutputInfo(@Nullable Path mapOutputFileName,
                     TezSpillRecord spillRecord, Range reduceRange,
-                    @Nullable MultiByteArrayOutputStream byteArrayOutput) {
+                    @Nullable MultiByteArrayOutputStream byteArrayOutput,
+                    @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
         this.mapOutputFileName = mapOutputFileName;
         this.spillRecord = spillRecord;
         this.reduceRange = reduceRange;
         this.byteArrayOutput = byteArrayOutput;
+        this.offsetRecordMap = offsetRecordMap;
       }
 
       TezIndexRecord getIndex(int index) {
@@ -1122,6 +1127,14 @@ public class ShuffleHandler {
         } else {
           return indexRecord;
         }
+      }
+
+      @Nullable
+      TezOffsetRecord getTezOffsetRecord(int index) {
+        if (offsetRecordMap == null) {
+          return null;
+        }
+        return offsetRecordMap.get(index);
       }
 
       public void finish() {
@@ -1190,7 +1203,9 @@ public class ShuffleHandler {
           lastIndex = index;
         }
 
-        ShuffleHeader header = new ShuffleHeader(mapId, index.getPartLength(), index.getRawLength(), reduce);
+        TezOffsetRecord offsetRecord = outputInfo.getTezOffsetRecord(reduce);
+        ShuffleHeader header = new ShuffleHeader(
+            mapId, index.getPartLength(), index.getRawLength(), reduce, offsetRecord);
         dob.reset();
         header.write(dob);
         // Free the memory needed to store the spill and index records

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -1024,8 +1024,9 @@ public class ShuffleHandler {
 
       MapOutputInfo outputInfo;
       if (reduceRange.first == reduceRange.last) {
+        TezOffsetRecord offsetRecord = offsetRecordMap != null ? offsetRecordMap.get(reduceRange.first) : null;
         outputInfo = new MapOutputInfo(
-            dataPath, spillRecord.getIndex(reduceRange.first), reduceRange, byteArrayOutput, offsetRecordMap);
+            dataPath, spillRecord.getIndex(reduceRange.first), reduceRange, byteArrayOutput, offsetRecord);
       } else {
         outputInfo = new MapOutputInfo(dataPath, spillRecord, reduceRange, byteArrayOutput, offsetRecordMap);
       }
@@ -1094,17 +1095,20 @@ public class ShuffleHandler {
       private final Range reduceRange;
       private final MultiByteArrayOutputStream byteArrayOutput;
       @Nullable
+      private final TezOffsetRecord offsetRecord;
+      @Nullable
       private final Map<Integer, TezOffsetRecord> offsetRecordMap;
 
       MapOutputInfo(@Nullable Path mapOutputFileName,
                     TezIndexRecord indexRecord, Range reduceRange,
                     @Nullable MultiByteArrayOutputStream byteArrayOutput,
-                    @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
+                    @Nullable TezOffsetRecord offsetRecord) {
         this.mapOutputFileName = mapOutputFileName;
         this.indexRecord = indexRecord;
         this.reduceRange = reduceRange;
         this.byteArrayOutput = byteArrayOutput;
-        this.offsetRecordMap = offsetRecordMap;
+        this.offsetRecord = offsetRecord;
+        this.offsetRecordMap = null;
       }
 
       MapOutputInfo(@Nullable Path mapOutputFileName,
@@ -1115,6 +1119,7 @@ public class ShuffleHandler {
         this.spillRecord = spillRecord;
         this.reduceRange = reduceRange;
         this.byteArrayOutput = byteArrayOutput;
+        this.offsetRecord = null;
         this.offsetRecordMap = offsetRecordMap;
       }
 
@@ -1131,6 +1136,9 @@ public class ShuffleHandler {
 
       @Nullable
       TezOffsetRecord getTezOffsetRecord(int index) {
+        if (offsetRecord != null) {
+          return offsetRecord;
+        }
         if (offsetRecordMap == null) {
           return null;
         }


### PR DESCRIPTION
### Motivation

- Carry the per-map/per-partition Tez IFile offset metadata (maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos) from the shuffle server to fetchers so non-RLE Tez readers receive exact decoding metadata. 

### Description

- Added optional `TezOffsetRecord` support to `ShuffleHeader` with a new constructor and getter, and extended MR3 composite header wire format to append five `int`s (`maxKeyLen`, `maxValLen`, `firstKeyOffset`, `firstValOffset`, `eofPos`) when present.
- `ShuffleHeader.readFields()` now reconstructs a `TezOffsetRecord` from the five ints (treating `maxKeyLen < 0` as absent) and `write()` writes five `-1` sentinels when metadata is not available.
- `ShuffleHandler` now reads `offsetRecordMap` from `IndexPathCache.MapOutputInfo`, carries it in its internal `MapOutputInfo`, and attaches the per-reduce `TezOffsetRecord` to each emitted `ShuffleHeader` in `sendMapOutput()`.
- Content-length accounting for keep-alive responses is updated to call `ShuffleHeader.writeLength()` with the optional `TezOffsetRecord` so `Content-Length` matches the new header shape.

### Testing

- Attempted to compile the modified module with `mvn -pl tez-runtime-library -DskipTests compile`, which failed during plugin resolution due to an external repository error (`protoc-jar-maven-plugin` returned HTTP 403), so no successful module build artifacts could be produced in this environment.
- No automated unit tests were added per the implementation plan and none were executed successfully due to the external dependency error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df39e42790832885af92e773f4070b)