### PR TITLE
Wire TezOffsetRecord metadata into shuffle readers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -169,11 +169,11 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
     if (fetchedInput.getType() == ShuffleClient.Type.MEMORY) {
       MemoryFetchedInput mfi = (MemoryFetchedInput) fetchedInput;
       return new InMemoryReader(null, mfi.getInputAttemptIdentifier(),
-          mfi.getBytes(), 0, (int) mfi.getSize(), 0);
+          mfi.getBytes(), 0, (int) mfi.getSize(), 0, mfi.getTezOffsetRecord());
     } else {
       return new IFile.Reader(fetchedInput.getInputStream(),
           fetchedInput.getSize(), codec, null, null,
-          ifileReadAhead, ifileReadAheadLength, context);
+          ifileReadAhead, ifileReadAheadLength, context, fetchedInput.getTezOffsetRecord());
     }
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetchedInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetchedInput.java
@@ -23,6 +23,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 
 public abstract class FetchedInput implements ShuffleInput {
@@ -37,6 +38,7 @@ public abstract class FetchedInput implements ShuffleInput {
 
   private final InputAttemptIdentifier inputAttemptIdentifier;
   private final FetchedInputCallback callback;
+  private TezOffsetRecord tezOffsetRecord;
   private final int id;
   private byte state;
 
@@ -83,6 +85,14 @@ public abstract class FetchedInput implements ShuffleInput {
 
   public InputAttemptIdentifier getInputAttemptIdentifier() {
     return this.inputAttemptIdentifier;
+  }
+
+  public TezOffsetRecord getTezOffsetRecord() {
+    return tezOffsetRecord;
+  }
+
+  public void setTezOffsetRecord(TezOffsetRecord tezOffsetRecord) {
+    this.tezOffsetRecord = tezOffsetRecord;
   }
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -59,6 +59,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.tez.dag.api.TezUncheckedException;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;  // TODO: relocate
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
@@ -597,13 +598,16 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
     final long decompressedLength;
     final long compressedLength;
     final int forReduce;
+    final TezOffsetRecord tezOffsetRecord;
 
-    MapOutputStat(InputAttemptIdentifier srcAttemptId, long decompressedLength, long compressedLength, int forReduce) {
+    MapOutputStat(InputAttemptIdentifier srcAttemptId, long decompressedLength, long compressedLength, int forReduce,
+                  TezOffsetRecord tezOffsetRecord) {
       assert srcAttemptId != null;
       this.srcAttemptId = srcAttemptId;
       this.decompressedLength = decompressedLength;
       this.compressedLength = compressedLength;
       this.forReduce = forReduce;
+      this.tezOffsetRecord = tezOffsetRecord;
     }
 
     @Override
@@ -669,7 +673,8 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
           }
 
           mapOutputStat = new MapOutputStat(srcAttemptId,
-              header.getUncompressedLength(), header.getCompressedLength(), header.getPartition());
+              header.getUncompressedLength(), header.getCompressedLength(), header.getPartition(),
+              header.getTezOffsetRecord());
           mapOutputStats.add(mapOutputStat);
           responsePartition = header.getPartition();
         } catch (IllegalArgumentException e) {
@@ -717,6 +722,7 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         {
           fetchedInput = shuffleManager.getInputManager().allocate(
               decompressedLength, compressedLength, srcAttemptId, false);
+          fetchedInput.setTezOffsetRecord(mapOutputStat.tezOffsetRecord);
         }
         if (fetchedInput.getType() == ShuffleClient.Type.WAIT) {
           if (isDebugEnabled) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -39,6 +39,7 @@ import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
 import org.apache.tez.runtime.api.TaskContext;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.FetchResult;
@@ -68,13 +69,15 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     final long decompressedLength;
     final long compressedLength;
     final int forReduce;
+    final TezOffsetRecord tezOffsetRecord;
 
     MapOutputStat(InputAttemptIdentifier srcAttemptId, long decompressedLength, long compressedLength,
-        int forReduce) {
+        int forReduce, TezOffsetRecord tezOffsetRecord) {
       this.srcAttemptId = srcAttemptId;
       this.decompressedLength = decompressedLength;
       this.compressedLength = compressedLength;
       this.forReduce = forReduce;
+      this.tezOffsetRecord = tezOffsetRecord;
     }
 
     @Override
@@ -504,7 +507,8 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
               pathToAttemptMap.get(new PathPartition(header.mapId, header.forReduce)),
               header.uncompressedLength,
               header.compressedLength,
-              header.forReduce);
+              header.forReduce,
+              header.getTezOffsetRecord());
           mapOutputStats.add(mapOutputStat);
         } catch (IllegalArgumentException e) {
           if (!stopped) {
@@ -554,6 +558,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         compressedLength = mapOutputStat.compressedLength;
         try {
           mapOutput = allocator.reserve(srcAttemptId, decompressedLength, compressedLength, fetcherIdentifier);
+          mapOutput.setTezOffsetRecord(mapOutputStat.tezOffsetRecord);
         } catch (IOException e) {
           if (!stopped) {
             // Kill the reduce attempt

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
@@ -154,11 +155,19 @@ public class InMemoryReader implements IFile.KeyValueReader {
   private final int length;
   private final ByteArrayDataInput memDataIn;
   private final boolean isRleEnabled;
+  private final TezOffsetRecord tezOffsetRecord;
+  private final boolean useTezOffsetRecordForNoRle;
 
   private final int usedMemoryForMergeManager;
 
   public InMemoryReader(MergeManager merger, InputAttemptIdentifier taskAttemptId,
                         byte[] data, int start, int length, int usedMemoryForMergeManager) {
+    this(merger, taskAttemptId, data, start, length, usedMemoryForMergeManager, null);
+  }
+
+  public InMemoryReader(MergeManager merger, InputAttemptIdentifier taskAttemptId,
+                        byte[] data, int start, int length, int usedMemoryForMergeManager,
+                        TezOffsetRecord tezOffsetRecord) {
     this.merger = merger;
     this.taskAttemptId = taskAttemptId;
 
@@ -177,6 +186,8 @@ public class InMemoryReader implements IFile.KeyValueReader {
     int dataLength = length - IFile.getHeaderLength();
     this.memDataIn = new ByteArrayDataInput(buffer, dataStart, dataLength);
     this.isRleEnabled = (flag & IFile.FLAG_RLE_ENABLED) != 0;
+    this.tezOffsetRecord = tezOffsetRecord;
+    this.useTezOffsetRecordForNoRle = !isRleEnabled && tezOffsetRecord != null;
 
     this.usedMemoryForMergeManager = usedMemoryForMergeManager;
   }
@@ -208,9 +219,34 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
-    currentKeyLength = dIn.readInt();
-    currentValueLength = dIn.readInt();
-    bytesRead += Integer.BYTES + Integer.BYTES;
+    if (useTezOffsetRecordForNoRle) {
+      int recordOffset = (int) bytesRead;
+
+      if (recordOffset == tezOffsetRecord.getEofPos()) {
+        currentKeyLength = dIn.readInt();
+        currentValueLength = dIn.readInt();
+        bytesRead += Integer.BYTES + Integer.BYTES;
+        return;
+      }
+
+      if (recordOffset < tezOffsetRecord.getFirstKeyOffset()) {
+        currentKeyLength = tezOffsetRecord.getMaxKeyLen();
+      } else {
+        currentKeyLength = dIn.readInt();
+        bytesRead += Integer.BYTES;
+      }
+
+      if (recordOffset < tezOffsetRecord.getFirstValOffset()) {
+        currentValueLength = tezOffsetRecord.getMaxValLen();
+      } else {
+        currentValueLength = dIn.readInt();
+        bytesRead += Integer.BYTES;
+      }
+    } else {
+      currentKeyLength = dIn.readInt();
+      currentValueLength = dIn.readInt();
+      bytesRead += Integer.BYTES + Integer.BYTES;
+    }
   }
 
   private void readKeyValueLengthRle(DataInput dIn) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MapOutput.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.FileChunk;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFiles;
 
@@ -40,6 +41,7 @@ public abstract class MapOutput implements ShuffleInput {
 
   private final int id;
   private InputAttemptIdentifier attemptIdentifier;
+  private TezOffsetRecord tezOffsetRecord;
 
   private final boolean primaryMapOutput;
   protected final FetchedInputAllocatorOrderedGrouped callback;
@@ -139,6 +141,14 @@ public abstract class MapOutput implements ShuffleInput {
 
   public InputAttemptIdentifier getAttemptIdentifier() {
     return this.attemptIdentifier;
+  }
+
+  public TezOffsetRecord getTezOffsetRecord() {
+    return tezOffsetRecord;
+  }
+
+  public void setTezOffsetRecord(TezOffsetRecord tezOffsetRecord) {
+    this.tezOffsetRecord = tezOffsetRecord;
   }
 
   public abstract ShuffleClient.Type getType();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1056,7 +1056,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       final long readerLength = mapOutput.getReaderLength();
       return new IFile.Reader(
           inputStream, readerLength, codec,
-          null, null, ifileReadAhead, ifileReadAheadLength, inputContext) {
+          null, null, ifileReadAhead, ifileReadAheadLength, inputContext, mapOutput.getTezOffsetRecord()) {
         @Override
         public void close() throws IOException {
           try {
@@ -1070,7 +1070,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     byte[] data = mapOutput.getMemory();
     return new InMemoryReader(
         MergeManager.this, mapOutput.getAttemptIdentifier(), data, 0, data.length,
-        (int) mapOutput.getUsedMemoryForMergeManager());
+        (int) mapOutput.getUsedMemoryForMergeManager(), mapOutput.getTezOffsetRecord());
   }
 
   static class RawKVIteratorReader implements IFile.KeyValueReaderDataInputBuffer {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -837,6 +837,8 @@ public class IFile {
     private DataInputStream dataIn;
     private final long fileLength;
     private final boolean isRleEnabled;
+    private final TezOffsetRecord tezOffsetRecord;
+    private final boolean useTezOffsetRecordForNoRle;
 
     private int currentKeyLength;
     private int currentValueLength;
@@ -863,9 +865,19 @@ public class IFile {
         TezCounter readsCounter, TezCounter bytesReadCounter,
         boolean readAhead, int readAheadLength,
         DecompressorPool taskContext) throws IOException {
+      this(in, length, codec, readsCounter, bytesReadCounter,
+          readAhead, readAheadLength, taskContext, null);
+    }
+
+    public Reader(InputStream in, long length,
+                  CompressionCodec codec,
+                  TezCounter readsCounter, TezCounter bytesReadCounter,
+                  boolean readAhead, int readAheadLength,
+                  DecompressorPool taskContext,
+                  TezOffsetRecord tezOffsetRecord) throws IOException {
       this(in, length - HEADER.length, codec,
           readsCounter, bytesReadCounter, readAhead, readAheadLength,
-          taskContext, readHeaderFlag(in));
+          taskContext, readHeaderFlag(in), tezOffsetRecord);
       assert in != null;
       if (bytesReadCounter != null) {
         bytesReadCounter.increment(IFile.HEADER.length);
@@ -886,7 +898,8 @@ public class IFile {
                   CompressionCodec codec,
                   TezCounter readsCounter, TezCounter bytesReadCounter,
                   boolean readAhead, int readAheadLength,
-                  DecompressorPool taskContext, byte headerFlag) throws IOException {
+                  DecompressorPool taskContext, byte headerFlag,
+                  TezOffsetRecord tezOffsetRecord) throws IOException {
       assert in != null;
       boolean isCompressed = (headerFlag & FLAG_COMPRESSED) != 0;
       boolean isRleEnabled = (headerFlag & FLAG_RLE_ENABLED) != 0;
@@ -915,6 +928,8 @@ public class IFile {
       this.dataIn = new DataInputStream(this.in);
       this.fileLength = length;
       this.isRleEnabled = isRleEnabled;
+      this.tezOffsetRecord = tezOffsetRecord;
+      this.useTezOffsetRecordForNoRle = !isRleEnabled && tezOffsetRecord != null;
     }
 
     /**
@@ -1071,10 +1086,43 @@ public class IFile {
     }
 
     private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
-      currentKeyLength = dIn.readInt();
-      currentValueLength = dIn.readInt();
+      if (useTezOffsetRecordForNoRle) {
+        readKeyValueLengthNoRleWithTezOffsetRecord(dIn);
+      } else {
+        currentKeyLength = dIn.readInt();
+        currentValueLength = dIn.readInt();
+        bytesRead += INT_SIZE + INT_SIZE;
+      }
       originalKeyLength = currentKeyLength;
-      bytesRead += INT_SIZE + INT_SIZE;
+    }
+
+    private void readKeyValueLengthNoRleWithTezOffsetRecord(DataInput dIn) throws IOException {
+      int recordOffset = (int) bytesRead;
+
+      if (recordOffset == tezOffsetRecord.getEofPos()) {
+        currentKeyLength = dIn.readInt();
+        currentValueLength = dIn.readInt();
+        bytesRead += INT_SIZE + INT_SIZE;
+        return;
+      }
+
+      int firstKeyOffset = tezOffsetRecord.getFirstKeyOffset();
+      int firstValOffset = tezOffsetRecord.getFirstValOffset();
+      int maxKeyLen = tezOffsetRecord.getMaxKeyLen();
+      int maxValLen = tezOffsetRecord.getMaxValLen();
+
+      if (recordOffset < firstKeyOffset) {
+        currentKeyLength = maxKeyLen;
+      } else {
+        currentKeyLength = dIn.readInt();
+        bytesRead += INT_SIZE;
+      }
+      if (recordOffset < firstValOffset) {
+        currentValueLength = maxValLen;
+      } else {
+        currentValueLength = dIn.readInt();
+        bytesRead += INT_SIZE;
+      }
     }
 
     private void readKeyValueLengthRle(DataInput dIn) throws IOException {


### PR DESCRIPTION
### Motivation
- Enable deterministic decoding of the new non-RLE IFile byte layout by delivering the five metadata fields (`maxKeyLen`, `maxValLen`, `firstKeyOffset`, `firstValOffset`, `eofPos`) parsed from the `ShuffleHeader` to the reader that consumes fetched map outputs. 
- Propagate this metadata along both unordered and ordered-grouped fetch paths so `IFile.Reader` / `InMemoryReader` can decode records using the offset-driven encoding when available while preserving existing RLE and legacy behavior.

### Description
- Added `TezOffsetRecord` storage and accessors to `FetchedInput` and `MapOutput` so parsed offset metadata can be attached to fetched payload holders.
- Updated `FetcherUnordered` and `FetcherOrderedGrouped` to extract `TezOffsetRecord` from `ShuffleHeader` and attach it to the allocated `FetchedInput` / reserved `MapOutput` respectively.
- Propagated the metadata into reader construction sites so readers always receive the optional `TezOffsetRecord` by updating `UnorderedKVReader`, `MergeManager#createMapOutputReader`, and other reader instantiation points to pass the record into `IFile.Reader` and `InMemoryReader`.
- Extended `IFile.Reader` and `InMemoryReader` with constructors that accept `TezOffsetRecord` and implemented decoding for the no-RLE path: when a `TezOffsetRecord` is present (and RLE is not enabled) the reader uses `maxKeyLen`/`maxValLen` and `firstKeyOffset`/`firstValOffset`/`eofPos` to determine whether to use implicit fixed lengths or to read explicit `int` lengths for key/value per the new byte layout; all RLE behavior and checksum handling remain unchanged.

### Testing
- Attempted `mvn -pl tez-runtime-library -DskipTests compile`, but the build failed in this environment due to an external Maven plugin resolution error fetching `com.github.os72:protoc-jar-maven-plugin:3.11.4` (HTTP 403), so a full compile could not be validated here.
- Changes were compiled into the working tree and committed locally; no new automated unit tests were added per the implementation notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4370732c8328a5acba962ebbc4d4)