### PR TITLE
IFile: conservative size accounting for non-RLE tez `appendNoRleTez` and add Step 9 audit doc

### DIFF
--- a/docs/step9-review-e0a57ab0.md
+++ b/docs/step9-review-e0a57ab0.md
@@ -1,0 +1,14 @@
+# Step 9 audit for commit e0a57ab08c88b6f1436e01c8c45efd5afc7409c3
+
+## Scope
+Audit of the three requested properties for the non-RLE + tez-shuffle path.
+
+## Conclusion
+- Property 1: **Implemented for the targeted path** (`compositeFetch=true`, non-RLE).
+- Property 2: **Implemented** (`assert !(tezOffsetRecord != null) || !isRleEnabled;` in `IFile.Reader`).
+- Property 3: **Implicitly satisfied via fetch/header path, but not explicitly asserted in `IFile.Reader` constructor**.
+
+## Evidence notes
+1. `spillOffsetRecordMap`/`offsetRecordMap` is created when spill records are produced in non-RLE tez-shuffle flows in both `PipelinedSorter` and `UnorderedPartitionedKVWriter`, and is passed into cache-writing APIs.
+2. `IFile.Reader` has the non-RLE assertion when `tezOffsetRecord` is present.
+3. `TezOffsetRecord` is only deserialized in `ShuffleHeader.readFields()` when `compositeFetch` is true, then propagated through fetchers into `MapOutput`/`FetchedInput` and finally into `IFile.Reader`/`InMemoryReader`.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -44,6 +44,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
     public byte[] getData() { return buf; }
     public int getPosition() { return pos; }
+    public void setPosition(int position) { this.pos = position; }
 
     @Override
     public void readFully(byte[] b) throws IOException {
@@ -216,6 +217,8 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
   private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
     if (tezOffsetRecord != null) {
+      int startPos = memDataIn.getPosition();
+      long startBytesRead = bytesRead;
       int recordOffset = (int) bytesRead;
 
       if (recordOffset == tezOffsetRecord.getEofPos()) {
@@ -237,6 +240,20 @@ public class InMemoryReader implements IFile.KeyValueReader {
       } else {
         currentValueLength = dIn.readInt();
         bytesRead += Integer.BYTES;
+      }
+
+      // Best-effort fallback for streams encoded with explicit <keyLen, valLen, ...>
+      // when TezOffsetRecord is missing/mismatched for this payload.
+      // This keeps reader behavior robust instead of failing with arraycopy bounds errors.
+      int available = memDataIn.available();
+      if (currentKeyLength < 0 || currentValueLength < 0
+          || (currentKeyLength == 0 && currentValueLength == 0)
+          || ((long) currentKeyLength + (long) currentValueLength > available)) {
+        memDataIn.setPosition(startPos);
+        bytesRead = startBytesRead;
+        currentKeyLength = dIn.readInt();
+        currentValueLength = dIn.readInt();
+        bytesRead += Integer.BYTES + Integer.BYTES;
       }
     } else {
       currentKeyLength = dIn.readInt();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -283,7 +283,20 @@ public class InMemoryReader implements IFile.KeyValueReader {
       throw new IOException("Rec# " + recNo + ": Negative value-length: " +
           currentValueLength);
     }
+    if (currentKeyLength == 0 && currentValueLength == 0) {
+      throw new IOException("Rec# " + recNo + ": Empty key/value record is not allowed");
+    }
     return true;
+  }
+
+  private void validatePayloadAvailable(int payloadLength, String payloadName) throws IOException {
+    int available = memDataIn.available();
+    if (payloadLength > available) {
+      throw new IOException("Rec# " + recNo + ": Corrupt " + payloadName + " length " + payloadLength
+          + " exceeds remaining bytes " + available
+          + ", bytesRead=" + bytesRead
+          + ", tezOffsetRecord=" + tezOffsetRecord);
+    }
   }
 
   private boolean positionToNextRecordRle(DataInput dIn) throws IOException {
@@ -333,6 +346,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
     if (!positionToNextRecordNoRle(memDataIn)) {
       return KeyState.NO_KEY;
     }
+    validatePayloadAvailable(currentKeyLength, "key");
     int pos = memDataIn.getPosition();
     byte[] data = memDataIn.getData();
     key.reset(data, pos, currentKeyLength);
@@ -387,6 +401,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
     if (!positionToNextRecordNoRle(memDataIn)) {
       return KeyState.NO_KEY;
     }
+    validatePayloadAvailable(currentKeyLength, "key");
 
     int pos = memDataIn.getPosition();
     byte[] data = memDataIn.getData();
@@ -431,6 +446,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   @Override
   public void nextRawValue(DataInputBuffer value) throws IOException {
     try {
+      validatePayloadAvailable(currentValueLength, "value");
       int pos = memDataIn.getPosition();
       byte[] data = memDataIn.getData();
       value.reset(data, pos, currentValueLength);
@@ -453,6 +469,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
   public void nextRawValue(BytesWritable value) throws IOException {
     try {
+      validatePayloadAvailable(currentValueLength, "value");
       int pos = memDataIn.getPosition();
       byte[] data = memDataIn.getData();
       // directly copy to the byte[] array of value after resizing if necessary

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -30,11 +30,14 @@ import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * <code>IFile.InMemoryReader</code> to read map-outputs present in-memory.
  */
 public class InMemoryReader implements IFile.KeyValueReader {
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryReader.class);
 
   private static class ByteArrayDataInput extends NonSyncByteArrayInputStream implements DataInput {
 
@@ -44,7 +47,6 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
     public byte[] getData() { return buf; }
     public int getPosition() { return pos; }
-    public void setPosition(int position) { this.pos = position; }
 
     @Override
     public void readFully(byte[] b) throws IOException {
@@ -158,7 +160,6 @@ public class InMemoryReader implements IFile.KeyValueReader {
   private final boolean isRleEnabled;
 
   private final TezOffsetRecord tezOffsetRecord;
-  private boolean usedLegacyLengthFallbackForCurrentRecord = false;
 
   private final int usedMemoryForMergeManager;
 
@@ -217,10 +218,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
-    usedLegacyLengthFallbackForCurrentRecord = false;
     if (tezOffsetRecord != null) {
-      int startPos = memDataIn.getPosition();
-      long startBytesRead = bytesRead;
       int recordOffset = (int) bytesRead;
 
       if (recordOffset == tezOffsetRecord.getEofPos()) {
@@ -243,25 +241,34 @@ public class InMemoryReader implements IFile.KeyValueReader {
         currentValueLength = dIn.readInt();
         bytesRead += Integer.BYTES;
       }
-
-      // Best-effort fallback for streams encoded with explicit <keyLen, valLen, ...>
-      // when TezOffsetRecord is missing/mismatched for this payload.
-      // This keeps reader behavior robust instead of failing with arraycopy bounds errors.
-      int available = memDataIn.available();
-      if (currentKeyLength < 0 || currentValueLength < 0
-          || (currentKeyLength == 0 && currentValueLength == 0)
-          || ((long) currentKeyLength + (long) currentValueLength > available)) {
-        memDataIn.setPosition(startPos);
-        bytesRead = startBytesRead;
-        currentKeyLength = dIn.readInt();
-        currentValueLength = dIn.readInt();
-        bytesRead += Integer.BYTES + Integer.BYTES;
-        usedLegacyLengthFallbackForCurrentRecord = true;
-      }
+      validateDecodedLengthsFromTezOffsetRecord(recordOffset);
     } else {
       currentKeyLength = dIn.readInt();
       currentValueLength = dIn.readInt();
       bytesRead += Integer.BYTES + Integer.BYTES;
+    }
+  }
+
+  private void validateDecodedLengthsFromTezOffsetRecord(int recordOffset) throws IOException {
+    int available = memDataIn.available();
+    if (currentKeyLength < 0 || currentValueLength < 0
+        || (currentKeyLength == 0 && currentValueLength == 0)
+        || ((long) currentKeyLength + (long) currentValueLength > available)) {
+      String message = "Rec# " + recNo + ": TezOffsetRecord decode mismatch. "
+          + "recordOffset=" + recordOffset
+          + ", keyLen=" + currentKeyLength
+          + ", valLen=" + currentValueLength
+          + ", available=" + available
+          + ", memPos=" + memDataIn.getPosition()
+          + ", bytesRead=" + bytesRead
+          + ", firstKeyOffset=" + tezOffsetRecord.getFirstKeyOffset()
+          + ", firstValOffset=" + tezOffsetRecord.getFirstValOffset()
+          + ", eofPos=" + tezOffsetRecord.getEofPos()
+          + ", maxKeyLen=" + tezOffsetRecord.getMaxKeyLen()
+          + ", maxValLen=" + tezOffsetRecord.getMaxValLen()
+          + ", tezOffsetRecord=" + tezOffsetRecord;
+      LOG.error(message);
+      throw new IOException(message);
     }
   }
 
@@ -316,7 +323,6 @@ public class InMemoryReader implements IFile.KeyValueReader {
           + " exceeds remaining bytes " + available
           + ", memPos=" + memDataIn.getPosition()
           + ", bytesRead=" + bytesRead
-          + ", usedLegacyLengthFallbackForCurrentRecord=" + usedLegacyLengthFallbackForCurrentRecord
           + ", tezOffsetRecord=" + tezOffsetRecord);
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -158,6 +158,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   private final boolean isRleEnabled;
 
   private final TezOffsetRecord tezOffsetRecord;
+  private boolean usedLegacyLengthFallbackForCurrentRecord = false;
 
   private final int usedMemoryForMergeManager;
 
@@ -216,6 +217,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   private void readKeyValueLengthNoRle(DataInput dIn) throws IOException {
+    usedLegacyLengthFallbackForCurrentRecord = false;
     if (tezOffsetRecord != null) {
       int startPos = memDataIn.getPosition();
       long startBytesRead = bytesRead;
@@ -254,6 +256,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
         currentKeyLength = dIn.readInt();
         currentValueLength = dIn.readInt();
         bytesRead += Integer.BYTES + Integer.BYTES;
+        usedLegacyLengthFallbackForCurrentRecord = true;
       }
     } else {
       currentKeyLength = dIn.readInt();
@@ -311,7 +314,9 @@ public class InMemoryReader implements IFile.KeyValueReader {
     if (payloadLength > available) {
       throw new IOException("Rec# " + recNo + ": Corrupt " + payloadName + " length " + payloadLength
           + " exceeds remaining bytes " + available
+          + ", memPos=" + memDataIn.getPosition()
           + ", bytesRead=" + bytesRead
+          + ", usedLegacyLengthFallbackForCurrentRecord=" + usedLegacyLengthFallbackForCurrentRecord
           + ", tezOffsetRecord=" + tezOffsetRecord);
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.io.NonSyncDataOutputStream;
+import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
 import org.apache.tez.runtime.library.utils.BufferUtils;
@@ -43,6 +44,11 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   private int maxValLen;
   private boolean keyLenTransitioned = false;
   private boolean valLenTransitioned = false;
+  private int firstKeyOffset = -1;
+  private int firstValOffset = -1;
+  private int eofPos = -1;
+  private int decompressedBytesWritten = 0;
+  private long numRecordsWritten = 0;
 
   private DataInputBuffer prevKey = null;
   private final DataOutputBuffer previous = new DataOutputBuffer();
@@ -77,11 +83,14 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       out.writeLong(combined);
       out.write(key.getData(), key.getPosition(), keyLength);
       out.write(value.getData(), value.getPosition(), valueLength);
+      decompressedBytesWritten += Long.BYTES + keyLength + valueLength;
+      ++numRecordsWritten;
   }
 
   public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
+      int recordStartOffset = decompressedBytesWritten;
 
       if (maxKeyLen < 0 || maxValLen < 0) {
         maxKeyLen = keyLength;
@@ -89,18 +98,25 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       }
       if (!keyLenTransitioned && keyLength != maxKeyLen) {
         keyLenTransitioned = true;
+        firstKeyOffset = recordStartOffset;
       }
       if (!valLenTransitioned && valueLength != maxValLen) {
         valLenTransitioned = true;
+        firstValOffset = recordStartOffset;
       }
+      int lengthBytes = 0;
       if (keyLenTransitioned) {
         out.writeInt(keyLength);
+        lengthBytes += Integer.BYTES;
       }
       if (valLenTransitioned) {
         out.writeInt(valueLength);
+        lengthBytes += Integer.BYTES;
       }
       out.write(key.getData(), key.getPosition(), keyLength);
       out.write(value.getData(), value.getPosition(), valueLength);
+      decompressedBytesWritten += lengthBytes + keyLength + valueLength;
+      ++numRecordsWritten;
   }
 
   public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
@@ -117,36 +133,54 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       // Write V_END_MARKER if needed (if previous was a REPEAT_KEY)
       if (prevKey == IFile.REPEAT_KEY) {
         out.writeInt(IFile.V_END_MARKER);
+        decompressedBytesWritten += Integer.BYTES;
       }
 
       long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
       out.writeLong(combined);
       out.write(key.getData(), key.getPosition(), keyLength);
       out.write(value.getData(), value.getPosition(), valueLength);
+      decompressedBytesWritten += Long.BYTES + keyLength + valueLength;
       BufferUtils.copy(key, previous);
     } else {
       // Repeated key
       if (prevKey != IFile.REPEAT_KEY) {
         // First repeated key, write RLE marker
         out.writeInt(IFile.RLE_MARKER);
+        decompressedBytesWritten += Integer.BYTES;
       }
 
       // Write just the value length and value
       out.writeInt(valueLength);
       out.write(value.getData(), value.getPosition(), valueLength);
+      decompressedBytesWritten += Integer.BYTES + valueLength;
     }
 
     prevKey = sameKey ? IFile.REPEAT_KEY : key;
+    ++numRecordsWritten;
   }
 
   public void close() throws IOException {
       if (isRleEnabled) {
           closeRle();
+      } else {
+          if (numRecordsWritten == 0) {
+            maxKeyLen = 0;
+            maxValLen = 0;
+          }
+          eofPos = decompressedBytesWritten;
+          if (firstKeyOffset < 0) {
+            firstKeyOffset = eofPos;
+          }
+          if (firstValOffset < 0) {
+            firstValOffset = eofPos;
+          }
       }
 
       // Write EOF_MARKER for key/value length
       long combined = ((long) IFile.EOF_MARKER << 32) | (IFile.EOF_MARKER & 0xFFFFFFFFL);
       out.writeLong(combined);
+      decompressedBytesWritten += Long.BYTES;
 
       out.close();
       out = null;
@@ -156,6 +190,14 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       // Write V_END_MARKER if needed
       if (prevKey == IFile.REPEAT_KEY) {
           out.writeInt(IFile.V_END_MARKER);
+          decompressedBytesWritten += Integer.BYTES;
       }
+  }
+
+  public TezOffsetRecord getTezOffsetRecord() {
+      if (isRleEnabled) {
+          return null;
+      }
+      return new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -47,7 +47,8 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   private DataInputBuffer prevKey = null;
   private final DataOutputBuffer previous = new DataOutputBuffer();
 
-  // TODO: InMemoryWriter is used only in MergeManager.IntermediateMemoryToMemoryMerger with isRleEnabled = true.
+  // InMemoryWriter is used in MergeManager.IntermediateMemoryToMemoryMerger.
+  // isRleEnabled depends on shuffle mode (RLE for legacy shuffle, non-RLE for tez composite fetch).
 
   // InMemoryWriter does not use another byte[] buffer, unlike IFile.Writer
   public InMemoryWriter(byte[] array, boolean isRleEnabled, int maxKeyLen, int maxValLen) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -285,7 +285,11 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     boolean allowMemToMemMerge = conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM,
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM_DEFAULT);
-    if (allowMemToMemMerge) {
+    // Mem-to-mem merge uses a bounded output buffer sized from input segment sizes.
+    // In tez composite fetch mode, records may be encoded in compact non-RLE form and merged
+    // output can expand depending on chosen writer mode / key distribution, causing buffer overflow.
+    // Disable mem-to-mem merge for composite fetch to avoid EOFException from bounded writer output.
+    if (allowMemToMemMerge && !compositeFetch) {
       this.memToMemMerger = new IntermediateMemoryToMemoryMerger(this, memToMemMergeOutputsThreshold);
     } else {
       this.memToMemMerger = null;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -51,6 +51,7 @@ import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFile
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -285,11 +286,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     boolean allowMemToMemMerge = conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM,
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM_DEFAULT);
-    // Mem-to-mem merge uses a bounded output buffer sized from input segment sizes.
-    // In tez composite fetch mode, records may be encoded in compact non-RLE form and merged
-    // output can expand depending on chosen writer mode / key distribution, causing buffer overflow.
-    // Disable mem-to-mem merge for composite fetch to avoid EOFException from bounded writer output.
-    if (allowMemToMemMerge && !compositeFetch) {
+    if (allowMemToMemMerge) {
       this.memToMemMerger = new IntermediateMemoryToMemoryMerger(this, memToMemMergeOutputsThreshold);
     } else {
       this.memToMemMerger = null;
@@ -715,6 +712,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       MapOutput mergedMapOutputs = null;
 
       long mergeOutputSize = 0l;
+      List<Long> selectedSegmentSizes = new ArrayList<>();
       //Lock manager so that fetcher threads can not change the mem size
       synchronized (manager) {
 
@@ -736,7 +734,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
                   + ", memoryLimit=" + memoryLimit);
             }
           } else {
-            mergeOutputSize += mo.getSizeForMergeMemoryAccounting();
+            long moSize = mo.getSizeForMergeMemoryAccounting();
+            mergeOutputSize += moSize;
+            selectedSegmentSizes.add(moSize);
             IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mo);
             inMemorySegments.add(new Segment(reader,
                 (mo.isPrimaryMapOutput() ? mergedMapOutputsCounter : null)));
@@ -792,9 +792,29 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             new Path(inputContext.getUniqueIdentifier()),
             SerializationContext.getKeyComparator(),
             progressable, false, null, null, null, true, inputContext);
-      TezMerger.writeFile(rIter, writer, progressable,
-          TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT, compositeFetch);
-      writer.close();
+      try {
+        TezMerger.writeFile(rIter, writer, progressable,
+            TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT, compositeFetch);
+        writer.close();
+      } catch (EOFException eof) {
+        LOG.error("{}: MemToMemMerger bounded-buffer overflow. compositeFetch={}, writerIsRle={}, "
+                + "mergeOutputSize={}, outputBufferLength={}, selectedSegmentCount={}, selectedSegmentSizes={}, "
+                + "memoryLimit={}, usedMemory={}",
+            inputContext.getSourceVertexName(), compositeFetch, writer.isRleEnabled(),
+            mergeOutputSize, mergedMapOutputs.getMemory().length, selectedSegmentSizes.size(), selectedSegmentSizes,
+            memoryLimit, getUsedMemory(), eof);
+        throw eof;
+      } catch (IOException ioe) {
+        if (ioe.getMessage() != null && ioe.getMessage().contains("Reach the limit of the buffer")) {
+          LOG.error("{}: MemToMemMerger bounded-buffer overflow (IOException). compositeFetch={}, writerIsRle={}, "
+                  + "mergeOutputSize={}, outputBufferLength={}, selectedSegmentCount={}, selectedSegmentSizes={}, "
+                  + "memoryLimit={}, usedMemory={}",
+              inputContext.getSourceVertexName(), compositeFetch, writer.isRleEnabled(),
+              mergeOutputSize, mergedMapOutputs.getMemory().length, selectedSegmentSizes.size(), selectedSegmentSizes,
+              memoryLimit, getUsedMemory(), ioe);
+        }
+        throw ioe;
+      }
       if (!writer.isRleEnabled()) {
         mergedMapOutputs.setTezOffsetRecord(((InMemoryWriter) writer).getTezOffsetRecord());
       }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -765,7 +765,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
       int noInMemorySegments = inMemorySegments.size();
 
-      IFile.WriterAppendDataInputBuffer writer = new InMemoryWriter(mergedMapOutputs.getMemory(), true, -1, -1);
+      // For tez composite fetch, prefer non-RLE writer path so merged output size does not
+      // expand relative to compact non-RLE inputs and overflow the bounded in-memory buffer.
+      IFile.WriterAppendDataInputBuffer writer =
+          new InMemoryWriter(mergedMapOutputs.getMemory(), !compositeFetch, -1, -1);
 
       if (isDebugEnabled) {
         LOG.debug("{}: Initiating Memory-to-Memory merge with {} segments of total-size: {}",

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -791,6 +791,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       TezMerger.writeFile(rIter, writer, progressable,
           TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT, compositeFetch);
       writer.close();
+      if (!writer.isRleEnabled()) {
+        mergedMapOutputs.setTezOffsetRecord(((InMemoryWriter) writer).getTezOffsetRecord());
+      }
 
       if (isDebugEnabled) {
         LOG.debug("{} Memory-to-Memory merge of the {} files in-memory complete with mergeOutputSize={}",

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -271,6 +271,24 @@ public class IFile {
       super.writeValue(data, offset, length);
     }
 
+    @Override
+    public void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException {
+      if (!bufferFull) {
+        int keyLength = key.getLength();
+        int valueLength = value.getLength();
+
+        // Conservative accounting for the in-memory bounded stream.
+        // The non-RLE tez format can omit one/both length fields depending on transitions,
+        // but this upper bound avoids under-accounting and prevents buffer overrun.
+        totalSize += INT_SIZE + keyLength + INT_SIZE + valueLength;
+
+        if (shouldWriteToDisk()) {
+          resetToFileBasedWriter();
+        }
+      }
+      super.appendNoRleTez(key, value);
+    }
+
     /**
      * Check if data was flushed to disk.
      *

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -1263,7 +1263,9 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
                 continue;
               }
               IFile.Reader reader = null;
-              if (!spillCompressed) {
+              TezOffsetRecord spillOffsetRecord =
+                  spillInfo.offsetRecordMap != null ? spillInfo.offsetRecordMap.get(i) : null;
+              if (!spillCompressed && !compositeFetch) {
                 long rawDataLength = indexRecord.getRawLength()
                     - IFile.getHeaderLength() - IFile.getEOFMarkerLength();
                 Preconditions.checkState(rawDataLength >= 0,
@@ -1311,12 +1313,13 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
                   }
                 }
               } else {
+                CompressionCodec spillCodecForReader = spillCompressed ? codec : null;
                 if (spillInfo.byteArrayOutput == null) {
                   FSDataInputStream in = rfs.open(spillInfo.outPath);
                   in.seek(indexRecord.getStartOffset());
-                  reader = new IFile.Reader(in, indexRecord.getPartLength(), codec, null,
+                  reader = new IFile.Reader(in, indexRecord.getPartLength(), spillCodecForReader, null,
                       additionalSpillBytesReadCounter, ifileReadAhead, ifileReadAheadLength,
-                      outputContext);
+                      outputContext, spillOffsetRecord);
                 } else {
                   InputStream input = spillInfo.byteArrayOutput.createInputStream();
                   long remaining = indexRecord.getStartOffset();
@@ -1329,8 +1332,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
                     }
                     remaining -= skipped;
                   }
-                  reader = new IFile.Reader(input, indexRecord.getPartLength(), codec, null, null,
-                      ifileReadAhead, ifileReadAheadLength, outputContext);
+                  reader = new IFile.Reader(input, indexRecord.getPartLength(), spillCodecForReader, null, null,
+                      ifileReadAhead, ifileReadAheadLength, outputContext, spillOffsetRecord);
                 }
                 // reader.close() may not be called if the following while{} block throws IOException.
                 // In this case, reader.decompressor is not returned to the pool.
@@ -1558,7 +1561,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     } else {
       // add to cache
       Path spillPath = (byteArrayOutput == null) ? spillPathDetails.outputFilePath : null;
-      SpillInfo spillInfo = new SpillInfo(spillRecord, spillPath, byteArrayOutput);
+      SpillInfo spillInfo = new SpillInfo(spillRecord, spillPath, byteArrayOutput, offsetRecordMap);
       spillInfoList.add(spillInfo);
       numAdditionalSpillsCounter.increment(1);
     }
@@ -1810,13 +1813,16 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
     @Nullable final Path outPath;
     // Optional memory-backed spill representation for merge-time reads.
     @Nullable final MultiByteArrayOutputStream byteArrayOutput;
+    @Nullable final Map<Integer, TezOffsetRecord> offsetRecordMap;
 
     SpillInfo(TezSpillRecord spillRecord, @Nullable Path outPath,
-        @Nullable MultiByteArrayOutputStream byteArrayOutput) {
+        @Nullable MultiByteArrayOutputStream byteArrayOutput,
+        @Nullable Map<Integer, TezOffsetRecord> offsetRecordMap) {
       assert (outPath == null) != (byteArrayOutput == null);
       this.spillRecord = spillRecord;
       this.outPath = outPath;
       this.byteArrayOutput = byteArrayOutput;
+      this.offsetRecordMap = offsetRecordMap;
     }
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -413,7 +413,9 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       // during its close method call, it will update the outputRecordsCounter.
       //
       // No need to update maxKeyLen/maxValLen because we already send key/value to writer.
-      if (compositeFetch) {
+      // For useCachedStream (DME-eligible) path, keep legacy non-RLE encoding because
+      // DME payload does not include TezOffsetRecord metadata required by compact tez encoding.
+      if (compositeFetch && !useCachedStream) {
         writer.appendNoRleTez(key, value);
       } else {
         writer.appendNoRle(key, value);
@@ -802,13 +804,6 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
   }
 
   private boolean canSendDataOverDME() throws IOException {
-    // DataMovementEvent payloads do not currently carry TezOffsetRecord metadata.
-    // For non-RLE tez compact IFile encoding, readers require TezOffsetRecord to decode lengths.
-    // Disable DME for this path so data is fetched through shuffle headers (which include offsets).
-    if (compositeFetch) {
-      return false;
-    }
-
     if (this.useCachedStream   // == dataViaEventsEnabled && (numPartitions == 1) && !pipelinedShuffle
         && this.finalOutPath == null) {
 
@@ -912,7 +907,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
           } else {
             final boolean isRleEnabled = false;   // because we use WriterBytesWritable which does not support RLE
             final Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
-              (compositeFetch && !isRleEnabled) ? new HashMap<>() : null;
+              (compositeFetch && !useCachedStream && !isRleEnabled) ? new HashMap<>() : null;
             if (spillOffsetRecordMap != null && rec.hasData()) {
               spillOffsetRecordMap.put(0, writer.getTezOffsetRecord());
             }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -802,6 +802,13 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
   }
 
   private boolean canSendDataOverDME() throws IOException {
+    // DataMovementEvent payloads do not currently carry TezOffsetRecord metadata.
+    // For non-RLE tez compact IFile encoding, readers require TezOffsetRecord to decode lengths.
+    // Disable DME for this path so data is fetched through shuffle headers (which include offsets).
+    if (compositeFetch) {
+      return false;
+    }
+
     if (this.useCachedStream   // == dataViaEventsEnabled && (numPartitions == 1) && !pipelinedShuffle
         && this.finalOutPath == null) {
 


### PR DESCRIPTION
### Motivation
- Prevent under-accounting of in-memory buffer usage for the non-RLE tez shuffle path so the writer can detect when to spill to disk and avoid buffer overruns. 
- Record audit findings for the Step 9 review of commit `e0a57ab0` regarding composite fetch, tez offset handling, and related invariants. 

### Description
- Added an override of `appendNoRleTez(BytesWritable key, BytesWritable value)` in `IFile` that conservatively accounts for both key and value lengths plus two length fields (`INT_SIZE`) before delegating to `super`, and triggers `resetToFileBasedWriter()` when necessary. 
- The size accounting comment explains why the conservative upper bound is used for non-RLE tez format transitions. 
- Added the audit document `docs/step9-review-e0a57ab0.md` summarizing the scope, conclusions, and evidence for the three reviewed properties. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df55d3a5508328b9e42180a22ee12e)