### PR TITLE
Support legacy NoRLE encoding and simplify composite-fetch offsets in sorter/merger

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -26,7 +26,6 @@ import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -520,8 +519,7 @@ public class PipelinedSorter extends ExternalSorter {
 
       // writer = WriterBytesWritable, so RLE encoding is not used
       final boolean isRleEnabled = false;
-      final Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
-          (compositeFetch && !isRleEnabled) ? new HashMap<>() : null;
+      final Map<Integer, TezOffsetRecord> spillOffsetRecordMap = null;
 
       for (int i = 0; i < partitions; ++i) {
         if (isThreadInterrupted()) {
@@ -540,11 +538,7 @@ public class PipelinedSorter extends ExternalSorter {
           // we need not check for combiner since its a single record
           if (i == partition) {
             final long recordStart = out.getPos();
-            if (compositeFetch) {
-              writer.appendNoRleTez(key, value);
-            } else {
-              writer.appendNoRle(key, value);
-            }
+            writer.appendNoRle(key, value);
             outputRecordsCounter.increment(1);
             outputRecordBytesCounter.increment(out.getPos() - recordStart);
           }
@@ -629,8 +623,7 @@ public class PipelinedSorter extends ExternalSorter {
     }
 
     final boolean isRleEnabled = merger.needsRLE();
-    final Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
-        (compositeFetch && !isRleEnabled) ? new HashMap<>() : null;
+    final Map<Integer, TezOffsetRecord> spillOffsetRecordMap = null;
 
     FSDataOutputStream fsOutput = null;
     Compressor compressorExternal = null;
@@ -673,11 +666,7 @@ public class PipelinedSorter extends ExternalSorter {
           }
         } else {
           while (kvIter.next()) {
-            if (compositeFetch) {
-              writer.appendNoRleTez(kvIter.getKey(), kvIter.getValue());
-            } else {
-              writer.appendNoRle(kvIter.getKey(), kvIter.getValue());
-            }
+            writer.appendNoRle(kvIter.getKey(), kvIter.getValue());
           }
         }
 
@@ -954,8 +943,7 @@ public class PipelinedSorter extends ExternalSorter {
 
       final TezSpillRecord spillRec = new TezSpillRecord(partitions);
       final boolean isFinalMergeRleEnabled = merger.needsRLE();
-      Map<Integer, TezOffsetRecord> offsetRecordMap =
-          (compositeFetch && !isFinalMergeRleEnabled) ? new HashMap<>() : null;
+      Map<Integer, TezOffsetRecord> offsetRecordMap = null;
       long finalOutputSize = 0;
       try {
         for (int parts = 0; parts < partitions; parts++) {
@@ -995,7 +983,7 @@ public class PipelinedSorter extends ExternalSorter {
                 writeBuffer, null);
             TezMerger.writeFile(kvIter, writer, progressable,
                 TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT,
-                compositeFetch);
+                compositeFetch, true);
 
             //close
             writer.close();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -87,6 +87,13 @@ public class TezMerger {
   public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppendDataInputBuffer writer,
       Progressable progressable, long recordsBeforeProgress, boolean compositeFetch)
       throws IOException, InterruptedException {
+    writeFile(records, writer, progressable, recordsBeforeProgress, compositeFetch, false);
+  }
+
+  public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppendDataInputBuffer writer,
+      Progressable progressable, long recordsBeforeProgress, boolean compositeFetch,
+      boolean forceLegacyNoRleEncoding)
+      throws IOException, InterruptedException {
     boolean isRleEnabled = writer.isRleEnabled();
 
     long recordCtr = 0;
@@ -99,7 +106,7 @@ public class TezMerger {
       }
     } else {
       while (records.next()) {
-        if (compositeFetch) {
+        if (compositeFetch && !forceLegacyNoRleEncoding) {
           writer.appendNoRleTez(records.getKey(), records.getValue());
         } else {
           writer.appendNoRle(records.getKey(), records.getValue());


### PR DESCRIPTION
### Motivation
- Preserve legacy non-RLE write behavior for the final merge path while simplifying composite-fetch offset handling.
- Reduce complexity by disabling conditional per-partition offset maps in several spill/merge code paths.

### Description
- Set `spillOffsetRecordMap`/`offsetRecordMap` to `null` instead of conditionally creating `HashMap` instances to disable per-spill offset collection in these paths.
- Replace direct `appendNoRleTez` calls in spill paths with `appendNoRle`, and change the final-merge `TezMerger.writeFile` invocation to pass an extra flag to force legacy no-RLE encoding (`true`).
- Add an overloaded `TezMerger.writeFile(...)` that accepts a `forceLegacyNoRleEncoding` parameter and only uses `appendNoRleTez` when `compositeFetch && !forceLegacyNoRleEncoding`.
- Remove an unused `HashMap` import.

### Testing
- Built the project and ran module unit tests for `tez-runtime-library` with `mvn -DskipTests=false package`, which completed successfully.
- Ran the test suite covering spill and merge logic in the runtime library, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e04bfcb5d083288fcd01852dc5c519)