### PR TITLE
Refactor IFile writer modes with explicit useMaxKeyValLen flag

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -857,7 +857,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       long outFileLen = 0;
       try {
         writer = new WriterDataInputBuffer(rfs, outputPath, codec,
-            null, null, true, -1, -1, writeBuffer);
+            null, null, false, true, -1, -1, writeBuffer);
 
         TezRawKeyValueIterator rIter = null;
         LOG.info("Initiating in-memory merge with {} segments", noInMemorySegments);
@@ -981,7 +981,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       outputPath = outputPath.suffix(Constants.MERGED_OUTPUT_PREFIX + mergeFileSequenceId.getAndIncrement());
 
       WriterDataInputBuffer writer = new WriterDataInputBuffer(rfs, outputPath, codec, null,
-          null, true, -1, -1, writeBuffer);
+          null, false, true, -1, -1, writeBuffer);
       tmpDir = new Path(inputContext.getUniqueIdentifier());
       try {
         TezRawKeyValueIterator iter = TezMerger.merge(conf, rfs,
@@ -1148,7 +1148,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             additionalSpillBytesRead, true, inputContext);
         final byte[] writeBuffer = IFile.allocateWriteBuffer();
         final WriterDataInputBuffer writer = new WriterDataInputBuffer(fs, outputPath, codec, null, null,
-            true, -1, -1, writeBuffer);
+            false, true, -1, -1, writeBuffer);
         try {
           TezMerger.writeFile(rIter, writer, progressable,
               TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -181,7 +181,7 @@ public class IFile {
         TezCounter serializedBytesCounter, int cacheSize, int maxKeyLen, int maxValLen,
         byte[] writeBuffer) throws IOException {
       super(new FSDataOutputStream(createBoundedBuffer(cacheSize), null), null,
-          writesCounter, serializedBytesCounter, false, maxKeyLen, maxValLen, writeBuffer, null);
+          writesCounter, serializedBytesCounter, false, false, maxKeyLen, maxValLen, writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
       this.taskOutput = taskOutput;
@@ -318,6 +318,7 @@ public class IFile {
     private final TezCounter serializedUncompressedBytes;
     private final long start;
 
+    protected final boolean useMaxKeyValLen;
     protected final boolean isRleEnabled;
 
     // We use writeBuffer[] to reduce the number of writes to 'out' and thus
@@ -362,6 +363,7 @@ public class IFile {
     protected Writer(FSDataOutputStream outputStream,
                      CompressionCodec codec,
                      TezCounter writesCounter, TezCounter serializedBytesCounter,
+                     boolean useMaxKeyValLen,
                      boolean isRleEnabled,
                      int maxKeyLen, int maxValLen,
                      byte[] writeBuffer,
@@ -371,9 +373,15 @@ public class IFile {
       this.serializedUncompressedBytes = serializedBytesCounter;
       this.start = this.rawOut.getPos();
 
+      this.useMaxKeyValLen = useMaxKeyValLen;
       this.isRleEnabled = isRleEnabled;
       this.maxKeyLen = maxKeyLen;
       this.maxValLen = maxValLen;
+      assert !(useMaxKeyValLen && isRleEnabled);
+      if (!useMaxKeyValLen) {
+        assert maxKeyLen == -1;
+        assert maxValLen == -1;
+      }
 
       this.writeBuffer = writeBuffer;
       this.writeBufferLength = writeBuffer.length;
@@ -504,7 +512,7 @@ public class IFile {
     }
 
     protected void onClose() throws IOException {
-      if (numRecordsWritten == 0) {
+      if (useMaxKeyValLen && numRecordsWritten == 0) {
         maxKeyLen = 0;
         maxValLen = 0;
       }
@@ -568,9 +576,10 @@ public class IFile {
 
     @Nullable
     public TezOffsetRecord getTezOffsetRecord() {
-      if (isRleEnabled) {
+      if (!useMaxKeyValLen) {
         return null;
       } else {
+        assert !isRleEnabled;
         assert eofPos >= 0;   // must be called after close()
         return new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
       }
@@ -592,10 +601,11 @@ public class IFile {
                                  CompressionCodec codec,
                                  TezCounter writesCounter,
                                  TezCounter serializedBytesCounter,
+                                 boolean useMaxKeyValLen,
                                  boolean isRleEnabled,
                                  int maxKeyLen, int maxValLen,
                                  byte[] writeBuffer) throws IOException {
-      this(fs.create(file), codec, writesCounter, serializedBytesCounter, isRleEnabled,
+      this(fs.create(file), codec, writesCounter, serializedBytesCounter, useMaxKeyValLen, isRleEnabled,
           maxKeyLen, maxValLen,
           writeBuffer, null);
       this.ownOutputStream = true;
@@ -605,11 +615,12 @@ public class IFile {
                                  CompressionCodec codec,
                                  TezCounter writesCounter,
                                  TezCounter serializedBytesCounter,
+                                 boolean useMaxKeyValLen,
                                  boolean isRleEnabled,
                                  int maxKeyLen, int maxValLen,
                                  byte[] writeBuffer, @Nullable Compressor compressorExternal)
         throws IOException {
-      super(outputStream, codec, writesCounter, serializedBytesCounter, isRleEnabled,
+      super(outputStream, codec, writesCounter, serializedBytesCounter, useMaxKeyValLen, isRleEnabled,
           maxKeyLen, maxValLen,
           writeBuffer, compressorExternal);
     }
@@ -620,6 +631,7 @@ public class IFile {
 
     public void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       assert !isRleEnabled;
+      assert !useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
@@ -630,6 +642,7 @@ public class IFile {
 
     public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
       assert !isRleEnabled;
+      assert useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
@@ -665,6 +678,7 @@ public class IFile {
 
     public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
       assert isRleEnabled;
+      assert !useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
 
@@ -749,10 +763,11 @@ public class IFile {
         CompressionCodec codec,
         TezCounter writesCounter,
         TezCounter serializedBytesCounter,
+        boolean useMaxKeyValLen,
         boolean isRleEnabled,
         int maxKeyLen, int maxValLen,
         byte[] writeBuffer) throws IOException {
-      this(fs.create(file), codec, writesCounter, serializedBytesCounter, isRleEnabled,
+      this(fs.create(file), codec, writesCounter, serializedBytesCounter, useMaxKeyValLen, isRleEnabled,
           maxKeyLen, maxValLen,
           writeBuffer, null);
       ownOutputStream = true;
@@ -760,11 +775,12 @@ public class IFile {
 
     public WriterBytesWritable(FSDataOutputStream outputStream,
         CompressionCodec codec, TezCounter writesCounter, TezCounter serializedBytesCounter,
+        boolean useMaxKeyValLen,
         boolean isRleEnabled,
         int maxKeyLen, int maxValLen,
         byte[] writeBuffer, @Nullable Compressor compressorExternal)
         throws IOException {
-      super(outputStream, codec, writesCounter, serializedBytesCounter, isRleEnabled,
+      super(outputStream, codec, writesCounter, serializedBytesCounter, useMaxKeyValLen, isRleEnabled,
           maxKeyLen, maxValLen,
           writeBuffer, compressorExternal);
     }
@@ -775,6 +791,7 @@ public class IFile {
 
     public void appendNoRle(BytesWritable key, BytesWritable value) throws IOException {
       assert !isRleEnabled;
+      assert !useMaxKeyValLen;
       int keyLength = key.getLength();
       int valueLength = value.getLength();
 
@@ -784,6 +801,7 @@ public class IFile {
 
     public void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException {
       assert !isRleEnabled;
+      assert useMaxKeyValLen;
       int recordStartOffset = (int) getDecompressedBytesWritten();
       int keyLength = key.getLength();
       int valueLength = value.getLength();
@@ -819,6 +837,7 @@ public class IFile {
 
     public void appendRle(BytesWritable key, BytesWritable value) throws IOException {
       assert isRleEnabled;
+      assert !useMaxKeyValLen;
       int keyLength = key.getLength();
       int valueLength = value.getLength();
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -178,10 +178,12 @@ public class IFile {
      */
     public FileBackedInMemIFileWriter(FileSystem fs, TezTaskOutput taskOutput,
         CompressionCodec codec, TezCounter writesCounter,
-        TezCounter serializedBytesCounter, int cacheSize, int maxKeyLen, int maxValLen,
+        TezCounter serializedBytesCounter, int cacheSize, boolean useMaxKeyValLen,
+        int maxKeyLen, int maxValLen,
         byte[] writeBuffer) throws IOException {
       super(new FSDataOutputStream(createBoundedBuffer(cacheSize), null), null,
-          writesCounter, serializedBytesCounter, false, false, maxKeyLen, maxValLen, writeBuffer, null);
+          writesCounter, serializedBytesCounter, useMaxKeyValLen, false, maxKeyLen, maxValLen,
+          writeBuffer, null);
       this.fs = fs;
       this.cacheStream = (BoundedByteArrayOutputStream) this.rawOut.getWrappedStream();
       this.taskOutput = taskOutput;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -523,8 +523,8 @@ public class PipelinedSorter extends ExternalSorter {
           if (!sendEmptyPartitionDetails || (i == partition)) {
             writer = new WriterBytesWritable(out,
                 codec, spilledRecordsCounter, null,
-                false,
-                key.getLength(), value.getLength(),
+                false, false,
+                -1, -1,
                 writeBuffer, null);
           }
           // we need not check for combiner since its a single record
@@ -644,8 +644,8 @@ public class PipelinedSorter extends ExternalSorter {
           }
           writer = new WriterDataInputBuffer(
               fsOutput,
-              codec, spilledRecordsCounter, null, isRleEnabled,
-              maxKeyLen, maxValLen,
+              codec, spilledRecordsCounter, null, false, isRleEnabled,
+              -1, -1,
               writeBuffer, compressorExternal);
         }
         if (isRleEnabled) {
@@ -960,8 +960,8 @@ public class PipelinedSorter extends ExternalSorter {
           if (shouldWrite) {
             writer = new WriterDataInputBuffer(
                 finalOut,
-                codec, spilledRecordsCounter, null, isFinalMergeRleEnabled,
-                maxKeyLen, maxValLen,
+                codec, spilledRecordsCounter, null, false, isFinalMergeRleEnabled,
+                -1, -1,
                 writeBuffer, null);
             TezMerger.writeFile(kvIter, writer, progressable,
                 TezRuntimeConfiguration.TEZ_RUNTIME_RECORDS_BEFORE_PROGRESS_DEFAULT);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -574,10 +574,10 @@ public class TezMerger {
             byteArrayOutput = new MultiByteArrayOutputStream(fs, outputFile);
             FSDataOutputStream outputStream = new FSDataOutputStream(byteArrayOutput, null);
             writer = new WriterDataInputBuffer(outputStream, codec, writesCounter, null,
-                checkForSameKeys, -1, -1, writeBuffer, null);
+                false, checkForSameKeys, -1, -1, writeBuffer, null);
           } else {
             writer = new WriterDataInputBuffer(fs, outputFile, codec, writesCounter, null,
-                checkForSameKeys, -1, -1, writeBuffer);
+                false, checkForSameKeys, -1, -1, writeBuffer);
           }
 
           writeFile(this, writer, reporter, recordsBeforeProgress);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -265,7 +265,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       } else {
         finalOutPath = outputFileHandler.getOutputFileForWrite();
         writer = new IFile.WriterBytesWritable(rfs, finalOutPath,
-            codec, outputRecordsCounter, outputRecordBytesCounter, false, -1, -1, writeBuffer);
+            codec, outputRecordsCounter, outputRecordBytesCounter, compositeFetch, false, -1, -1,
+            writeBuffer);
         ensureSpillFilePermissions(finalOutPath, rfs, rfsSpillFilePerms);
       }
     } else {
@@ -716,8 +717,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
                 }
                 // all Writer instances share the same FSDataOutputStream out
                 writer = new WriterDataInputBuffer(
-                    fsOutput, codec, null, null, false,
-                    maxKeyLen, maxValLen,
+                    fsOutput, codec, null, null, compositeFetch, false,
+                    -1, -1,
                     writeBuffer, compressorExternal);
               }
               numRecords += writePartition(buffer.partitionHeads[i], buffer, writer, key, val);
@@ -1240,8 +1241,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         }
         // inside close()
         writer = new WriterDataInputBuffer(
-            out, codec, null, null, false,
-            maxKeyLen, maxValLen,
+            out, codec, null, null, compositeFetch, false,
+            -1, -1,
             writeBuffer, null);
         try {
           for (WrappedBuffer buffer : filledBuffers) {
@@ -1474,8 +1475,8 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
           WriterBytesWritable writer = null;
           try {
             writer = new IFile.WriterBytesWritable(out, codec, null, null,
-                false,
-                key.getLength(), value.getLength(),
+                compositeFetch, false,
+                -1, -1,
                 IFile.allocateWriteBufferSingle(), null);
             if (compositeFetch) {
               writer.appendNoRleTez(key, value);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -260,7 +260,7 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
       if (this.useCachedStream) {   // i.e., if dataViaEventsEnabled == true
         writer = new IFile.FileBackedInMemIFileWriter(rfs,
             outputFileHandler, codec, outputRecordsCounter,
-            outputRecordBytesCounter, dataViaEventsMaxSize, -1, -1,
+            outputRecordBytesCounter, dataViaEventsMaxSize, false, -1, -1,
             writeBuffer);
       } else {
         finalOutPath = outputFileHandler.getOutputFileForWrite();


### PR DESCRIPTION
### Motivation
- Introduce an explicit `useMaxKeyValLen` mode to separate Tez-style max-length metadata writes from the RLE/non-RLE writer modes and make the three valid combinations explicit and checkable. 
- Ensure only the correct `append*` variant is callable in each mode so ordered/unordered write paths honor the intended payload formats and metadata (`TezOffsetRecord`).

### Description
- Added a `protected final boolean useMaxKeyValLen` field to `IFile.Writer` and a new constructor parameter `useMaxKeyValLen`, and asserted valid combinations (`useMaxKeyValLen && isRleEnabled` is illegal; when `useMaxKeyValLen==false` then `maxKeyLen/maxValLen` must be `-1`).
- Adjusted `onClose()` and `getTezOffsetRecord()` so Tez offset metadata is produced only when `useMaxKeyValLen` is enabled and initialized only for that mode.
- Threaded `useMaxKeyValLen` through `WriterDataInputBuffer` and `WriterBytesWritable` constructors and hardened append methods with assertions so `appendNoRleTez()` requires `useMaxKeyValLen`, `appendNoRle()` requires `!useMaxKeyValLen`, and `appendRle()` requires `isRleEnabled && !useMaxKeyValLen`.
- Updated all call sites to the new constructor in `UnorderedPartitionedKVWriter`, `PipelinedSorter`, `TezMerger`, `MergeManager`, and the in-memory/file-backed writers so unordered Tez payload paths pass `useMaxKeyValLen = compositeFetch` and ordered paths pass `useMaxKeyValLen = false` while normalizing `maxKeyLen/maxValLen` to `-1` where appropriate.

### Testing
- Ran targeted code searches with `rg` to verify `appendNoRleTez`/`appendNoRle`/`appendRle` dispatch locations and updated constructor usages, and these searches completed successfully against the modified sources.
- Attempted to compile the `tez-runtime-library` module with `mvn -pl tez-runtime-library -DskipTests compile`, which failed due to external Maven plugin resolution returning HTTP 403 for `com.github.os72:protoc-jar-maven-plugin:3.11.4` in this environment; the failure is unrelated to the local source changes and prevented a full compile verification.
- No automated unit/integration test suites were executed due to the build environment dependency resolution issue; local assertions added will surface misuses at runtime or during a normal build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e199e12f348328974b2ff992f27b70)