### PR TITLE
Short-circuit constructor for cached-stream (DME) path in UnorderedPartitionedKVWriter

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -290,12 +290,6 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       this.ifileReadAheadLength = 0;
     }
 
-    try {
-      this.partitioner = TezRuntimeUtils.instantiatePartitioner(this.conf);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-
     this.auxiliaryService = ShuffleUtils.getTezShuffleHandlerServiceId(conf);
     this.compositeFetch = ShuffleUtils.isTezShuffleHandler(conf);
 
@@ -322,14 +316,6 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
 
     this.writeSpillRecord = !this.compositeFetch;
 
-    if (isPipelinedShuffle) {
-      this.spillCompressed = codec != null;
-    } else {
-      this.spillCompressed = conf.getBoolean(
-          TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_NON_PIPELINED_SPILL_COMPRESS,
-          TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_NON_PIPELINED_SPILL_COMPRESS_DEFAULT) && codec != null;
-    }
-
     if (availableMemoryBytes == 0) {
       Preconditions.checkArgument(((numPartitions == 1) && !isPipelinedShuffle),
         "availableMemory can be set to 0 only when numPartitions=1 and pipeline shuffle disabled");
@@ -350,22 +336,48 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     this.rfsSpillFilePerms = TezSpillRecord.SPILL_FILE_PERMS.equals(
         TezSpillRecord.SPILL_FILE_PERMS.applyUMask(FsPermission.getUMask(this.rfs.getConf())));
 
+    if (this.useCachedStream) {
+      this.partitioner = null;
+      this.spillCompressed = false;
+      skipBuffers = true;
+      byte[] writeBuffer = IFile.allocateWriteBuffer();
+      writer = new IFile.FileBackedInMemIFileWriter(rfs,
+          outputFileHandler, codec, outputRecordsCounter,
+          outputRecordBytesCounter, dataViaEventsMaxSize,
+          writeBuffer);
+      baos = null;
+      numRecordsPerPartition = null;
+      reportPartitionStats = ReportPartitionStats.fromString(conf.get(
+          TezRuntimeConfiguration.TEZ_RUNTIME_REPORT_PARTITION_STATS,
+          TezRuntimeConfiguration.TEZ_RUNTIME_REPORT_PARTITION_STATS_DEFAULT));
+      sizePerPartition = (reportPartitionStats.isEnabled()) ? new long[numPartitions] : null;
+      indexFileSizeEstimate = numPartitions * Constants.MAP_OUTPUT_INDEX_RECORD_LENGTH;
+      return;
+    }
+
+    try {
+      this.partitioner = TezRuntimeUtils.instantiatePartitioner(this.conf);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    if (isPipelinedShuffle) {
+      this.spillCompressed = codec != null;
+    } else {
+      this.spillCompressed = conf.getBoolean(
+          TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_NON_PIPELINED_SPILL_COMPRESS,
+          TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_NON_PIPELINED_SPILL_COMPRESS_DEFAULT) && codec != null;
+    }
+
     if (numPartitions == 1 && !isPipelinedShuffle) {
       // special case, where in only one partition is available.
       skipBuffers = true;
       byte[] writeBuffer = IFile.allocateWriteBuffer();
-      if (this.useCachedStream) {   // i.e., if dataViaEventsEnabled == true
-        writer = new IFile.FileBackedInMemIFileWriter(rfs,
-            outputFileHandler, codec, outputRecordsCounter,
-            outputRecordBytesCounter, dataViaEventsMaxSize,
-            writeBuffer);
-      } else {
-        finalOutPath = outputFileHandler.getOutputFileForWrite();
-        writer = new IFile.WriterBytesWritable(rfs, finalOutPath,
-            codec, outputRecordsCounter, outputRecordBytesCounter, compositeFetch, false, -1, -1,
-            writeBuffer);
-        ensureSpillFilePermissions(finalOutPath, rfs, rfsSpillFilePerms);
-      }
+      finalOutPath = outputFileHandler.getOutputFileForWrite();
+      writer = new IFile.WriterBytesWritable(rfs, finalOutPath,
+          codec, outputRecordsCounter, outputRecordBytesCounter, compositeFetch, false, -1, -1,
+          writeBuffer);
+      ensureSpillFilePermissions(finalOutPath, rfs, rfsSpillFilePerms);
     } else {
       skipBuffers = false;
       writer = null;


### PR DESCRIPTION
### Motivation
- Avoid initializing members that are unused when `useCachedStream` is true to reduce unnecessary work and clarify ownership of fields for the DME/cached-stream fast path.
- Ensure the constructor only sets up the minimal state required for the file-backed in-memory writer path and returns early to avoid allocating buffer/spill infrastructure.
- Make the non-cached (normal) initialization explicit and local to the branch where those resources are required.

### Description
- Added an early-return fast path guarded by `if (this.useCachedStream) { ... return; }` after the common initialization of `useCachedStream` and `trackMaxKeyValLen`.
- In the cached-stream branch the code now sets `this.partitioner = null`, `this.spillCompressed = false`, `skipBuffers = true`, allocates the DME-capable `IFile.FileBackedInMemIFileWriter` into `writer`, sets `baos = null` and `numRecordsPerPartition = null`, initializes `reportPartitionStats`/`sizePerPartition` as needed and computes `indexFileSizeEstimate`, then returns early.
- Deferred initialization of non-cached-only members to after the fast-path return, including instantiation of the `partitioner`, computing `spillCompressed` from configuration, and the full buffer/spill/executor setup used when `useCachedStream == false`.
- Simplified the single-partition non-cached path so the `IFile.WriterBytesWritable` is created only in the non-cached branch and the prior conditional duplication is removed.

### Testing
- Ran `mvn -pl tez-runtime-library -DskipTests compile` to validate project compilation, which failed due to an external dependency resolution error (`403 Forbidden` when fetching `com.github.os72:protoc-jar-maven-plugin:3.11.4`), not due to compilation errors in the changed class.
- No automated unit tests were executed in this environment due to the Maven dependency resolution failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e424fc3483289df4dad3db661d9e)