### PR TITLE
Add ranged read support to MultiByteArrayOutputStream and replace skip-based seeks

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
@@ -5,22 +5,21 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.handler.ssl.SslHandler;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.ReadaheadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Vector;
 
 /**
  * An OutputStream that grows in fixed-size chunks up to a limit, after which
@@ -302,13 +301,14 @@ public class MultiByteArrayOutputStream extends OutputStream {
   //   1. called only after close() is called
   //   2. on InputStream returned, close() is eventually called.
   //      In the current implementation, Segment.close() eventually calls InputStream.close() in TezMerger.
-  public InputStream createInputStream() throws IOException {
+  // The returned stream reads bytes in [offset, offset + length).
+  public InputStream createInputStreamFrom(long offset, long length) throws IOException {
     List<byte[]> buffersFinal;
     int posInBufFinal;
     long bufferBytesFinal;
     long totalBytesFinal;
 
-    // TODO: synchronized() is unnecessary because createInputStream() is called in the same thread that calls close()
+    // TODO: synchronized() is unnecessary because createInputStreamFrom() is called in the same thread that calls close()
     synchronized (this) {
       buffersFinal = buffers;
       posInBufFinal = posInBuf;
@@ -316,23 +316,246 @@ public class MultiByteArrayOutputStream extends OutputStream {
       totalBytesFinal = totalBytes;
     }
 
-    assert buffersFinal != null;  // because createInputStream() is called before clean()
+    assert buffersFinal != null;  // because createInputStreamFrom() is called before clean()
 
-    Vector<InputStream> streams = new Vector<>();
+    if (offset < 0 || length < 0 || offset > totalBytesFinal || length > totalBytesFinal - offset) {
+      throw new IndexOutOfBoundsException(String.format(
+          "Invalid range: offset=%d, length=%d, totalBytes=%d", offset, length, totalBytesFinal));
+    }
+
+    List<byte[]> memoryBuffers = new ArrayList<>(buffersFinal.size());
+    int numNonEmptyBuffers = 0;
     for (int i = 0; i < buffersFinal.size(); i++) {
       byte[] bufferElement = buffersFinal.get(i);
       int bufferLength = (i < buffersFinal.size() - 1) ? bufferElement.length : posInBufFinal;
       if (bufferLength > 0) {
-        streams.add(new ByteArrayInputStream(bufferElement, 0, bufferLength));
+        numNonEmptyBuffers++;
       }
     }
 
-    if (totalBytesFinal > bufferBytesFinal) {
-      streams.add(fs.open(outputPath));
+    int[] memoryBufferLengths = new int[numNonEmptyBuffers];
+    int outIndex = 0;
+    for (int i = 0; i < buffersFinal.size(); i++) {
+      byte[] bufferElement = buffersFinal.get(i);
+      int bufferLength = (i < buffersFinal.size() - 1) ? bufferElement.length : posInBufFinal;
+      if (bufferLength > 0) {
+        memoryBuffers.add(bufferElement);
+        memoryBufferLengths[outIndex++] = bufferLength;
+      }
     }
 
-    // works okay even when streams.isEmpty(), so no need to return ByteArrayInputStream(new byte[0])
-    return new java.io.SequenceInputStream(Collections.enumeration(streams));
+    return new MultiBufferRangeInputStream(
+        memoryBuffers,
+        memoryBufferLengths,
+        bufferBytesFinal,
+        totalBytesFinal,
+        offset,
+        length);
+  }
+
+  private final class MultiBufferRangeInputStream extends InputStream {
+    private final List<byte[]> memoryBuffers;
+    private final int[] memoryBufferLengths;
+    private final long memoryBytes;
+    private final long endPos;
+
+    private long globalPos;
+    private int memoryIndex;
+    private int offsetInMemoryBuffer;
+    private FSDataInputStream spillIn;
+    private boolean closed;
+
+    private MultiBufferRangeInputStream(
+        List<byte[]> memoryBuffers,
+        int[] memoryBufferLengths,
+        long memoryBytes,
+        long totalBytes,
+        long offset,
+        long length) {
+      this.memoryBuffers = memoryBuffers;
+      this.memoryBufferLengths = memoryBufferLengths;
+      this.memoryBytes = memoryBytes;
+      this.globalPos = offset;
+      this.endPos = offset + length;
+
+      this.memoryIndex = 0;
+      this.offsetInMemoryBuffer = 0;
+
+      long memoryStartPos = Math.min(offset, memoryBytes);
+      long scanned = 0;
+      while (memoryIndex < memoryBufferLengths.length) {
+        int currentLen = memoryBufferLengths[memoryIndex];
+        if (scanned + currentLen > memoryStartPos) {
+          offsetInMemoryBuffer = (int) (memoryStartPos - scanned);
+          break;
+        }
+        scanned += currentLen;
+        memoryIndex++;
+      }
+      if (memoryIndex >= memoryBufferLengths.length) {
+        offsetInMemoryBuffer = 0;
+      }
+
+      assert endPos <= totalBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (closed) {
+        throw new IOException("Stream closed");
+      }
+      if (globalPos >= endPos) {
+        return -1;
+      }
+
+      if (globalPos < memoryBytes) {
+        while (memoryIndex < memoryBuffers.size()) {
+          int curLen = memoryBufferLengths[memoryIndex];
+          if (offsetInMemoryBuffer < curLen) {
+            int result = memoryBuffers.get(memoryIndex)[offsetInMemoryBuffer] & 0xFF;
+            offsetInMemoryBuffer++;
+            globalPos++;
+            return result;
+          }
+          memoryIndex++;
+          offsetInMemoryBuffer = 0;
+        }
+      }
+
+      ensureSpillOpen();
+      int result = spillIn.read();
+      if (result < 0) {
+        throw new EOFException(String.format(
+            "Unexpected EOF while reading spill file: outputPath=%s, position=%d", outputPath, globalPos));
+      }
+      globalPos++;
+      return result;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      if (closed) {
+        throw new IOException("Stream closed");
+      }
+      if (b == null) {
+        throw new NullPointerException("b");
+      }
+      if (off < 0 || len < 0 || len > b.length - off) {
+        throw new IndexOutOfBoundsException();
+      }
+      if (len == 0) {
+        return 0;
+      }
+      if (globalPos >= endPos) {
+        return -1;
+      }
+
+      int copied = 0;
+      while (len > 0 && globalPos < endPos) {
+        if (globalPos < memoryBytes) {
+          if (memoryIndex >= memoryBuffers.size()) {
+            break;
+          }
+          byte[] cur = memoryBuffers.get(memoryIndex);
+          int curLen = memoryBufferLengths[memoryIndex];
+          int availableInCur = curLen - offsetInMemoryBuffer;
+          if (availableInCur <= 0) {
+            memoryIndex++;
+            offsetInMemoryBuffer = 0;
+            continue;
+          }
+
+          int toCopy = (int) Math.min(Math.min((long) len, endPos - globalPos), availableInCur);
+          System.arraycopy(cur, offsetInMemoryBuffer, b, off, toCopy);
+
+          off += toCopy;
+          len -= toCopy;
+          copied += toCopy;
+          globalPos += toCopy;
+          offsetInMemoryBuffer += toCopy;
+        } else {
+          ensureSpillOpen();
+          int toRead = (int) Math.min((long) len, endPos - globalPos);
+          int n = spillIn.read(b, off, toRead);
+          if (n < 0) {
+            throw new EOFException(String.format(
+                "Unexpected EOF while reading spill file: outputPath=%s, position=%d", outputPath, globalPos));
+          }
+          off += n;
+          len -= n;
+          copied += n;
+          globalPos += n;
+        }
+      }
+
+      return copied == 0 ? -1 : copied;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+      if (n <= 0) {
+        return 0;
+      }
+      long toSkip = Math.min(n, endPos - globalPos);
+      if (toSkip <= 0) {
+        return 0;
+      }
+
+      long skipped = 0;
+      if (globalPos < memoryBytes) {
+        while (toSkip > 0 && globalPos < Math.min(memoryBytes, endPos)) {
+          if (memoryIndex >= memoryBufferLengths.length) {
+            break;
+          }
+          int curLen = memoryBufferLengths[memoryIndex];
+          int availableInCur = curLen - offsetInMemoryBuffer;
+          if (availableInCur <= 0) {
+            memoryIndex++;
+            offsetInMemoryBuffer = 0;
+            continue;
+          }
+          int jump = (int) Math.min((long) availableInCur, toSkip);
+          offsetInMemoryBuffer += jump;
+          globalPos += jump;
+          toSkip -= jump;
+          skipped += jump;
+        }
+      }
+
+      if (toSkip > 0 && globalPos < endPos) {
+        ensureSpillOpen();
+        long targetPosInSpill = (globalPos - memoryBytes) + toSkip;
+        spillIn.seek(targetPosInSpill);
+        globalPos += toSkip;
+        skipped += toSkip;
+      }
+
+      return skipped;
+    }
+
+    @Override
+    public int available() {
+      long remaining = endPos - globalPos;
+      return (int) Math.min(Integer.MAX_VALUE, Math.max(remaining, 0));
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (spillIn != null) {
+        spillIn.close();
+      }
+    }
+
+    private void ensureSpillOpen() throws IOException {
+      if (spillIn == null) {
+        spillIn = fs.open(outputPath);
+        spillIn.seek(Math.max(0, globalPos - memoryBytes));
+      }
+    }
   }
 
   // 3. called from ShuffleHandlerDaemonProcessor thread

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
@@ -323,7 +323,6 @@ public class MultiByteArrayOutputStream extends OutputStream {
           "Invalid range: offset=%d, length=%d, totalBytes=%d", offset, length, totalBytesFinal));
     }
 
-    List<byte[]> memoryBuffers = new ArrayList<>(buffersFinal.size());
     int numNonEmptyBuffers = 0;
     for (int i = 0; i < buffersFinal.size(); i++) {
       byte[] bufferElement = buffersFinal.get(i);
@@ -333,13 +332,14 @@ public class MultiByteArrayOutputStream extends OutputStream {
       }
     }
 
+    byte[][] memoryBuffers = new byte[numNonEmptyBuffers][];
     int[] memoryBufferLengths = new int[numNonEmptyBuffers];
     int outIndex = 0;
     for (int i = 0; i < buffersFinal.size(); i++) {
       byte[] bufferElement = buffersFinal.get(i);
       int bufferLength = (i < buffersFinal.size() - 1) ? bufferElement.length : posInBufFinal;
       if (bufferLength > 0) {
-        memoryBuffers.add(bufferElement);
+        memoryBuffers[outIndex] = bufferElement;
         memoryBufferLengths[outIndex++] = bufferLength;
       }
     }
@@ -354,7 +354,7 @@ public class MultiByteArrayOutputStream extends OutputStream {
   }
 
   private final class MultiBufferRangeInputStream extends InputStream {
-    private final List<byte[]> memoryBuffers;
+    private final byte[][] memoryBuffers;
     private final int[] memoryBufferLengths;
     private final long memoryBytes;
     private final long endPos;
@@ -366,7 +366,7 @@ public class MultiByteArrayOutputStream extends OutputStream {
     private boolean closed;
 
     private MultiBufferRangeInputStream(
-        List<byte[]> memoryBuffers,
+        byte[][] memoryBuffers,
         int[] memoryBufferLengths,
         long memoryBytes,
         long totalBytes,
@@ -405,10 +405,10 @@ public class MultiByteArrayOutputStream extends OutputStream {
       }
 
       if (globalPos < memoryBytes) {
-        while (memoryIndex < memoryBuffers.size()) {
+        while (memoryIndex < memoryBuffers.length) {
           int curLen = memoryBufferLengths[memoryIndex];
           if (offsetInMemoryBuffer < curLen) {
-            int result = memoryBuffers.get(memoryIndex)[offsetInMemoryBuffer] & 0xFF;
+            int result = memoryBuffers[memoryIndex][offsetInMemoryBuffer] & 0xFF;
             offsetInMemoryBuffer++;
             globalPos++;
             return result;
@@ -449,7 +449,7 @@ public class MultiByteArrayOutputStream extends OutputStream {
       int copied = 0;
       while (len > 0 && globalPos < endPos) {
         if (globalPos < memoryBytes) {
-          byte[] cur = memoryBuffers.get(memoryIndex);
+          byte[] cur = memoryBuffers[memoryIndex];
           int curLen = memoryBufferLengths[memoryIndex];
           int availableInCur = curLen - offsetInMemoryBuffer;
           if (availableInCur <= 0) {

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
@@ -392,10 +392,6 @@ public class MultiByteArrayOutputStream extends OutputStream {
         scanned += currentLen;
         memoryIndex++;
       }
-      if (memoryIndex >= memoryBufferLengths.length) {
-        offsetInMemoryBuffer = 0;
-      }
-
       assert endPos <= totalBytes;
     }
 
@@ -453,9 +449,6 @@ public class MultiByteArrayOutputStream extends OutputStream {
       int copied = 0;
       while (len > 0 && globalPos < endPos) {
         if (globalPos < memoryBytes) {
-          if (memoryIndex >= memoryBuffers.size()) {
-            break;
-          }
           byte[] cur = memoryBuffers.get(memoryIndex);
           int curLen = memoryBufferLengths[memoryIndex];
           int availableInCur = curLen - offsetInMemoryBuffer;
@@ -504,9 +497,6 @@ public class MultiByteArrayOutputStream extends OutputStream {
       long skipped = 0;
       if (globalPos < memoryBytes) {
         while (toSkip > 0 && globalPos < Math.min(memoryBytes, endPos)) {
-          if (memoryIndex >= memoryBufferLengths.length) {
-            break;
-          }
           int curLen = memoryBufferLengths[memoryIndex];
           int availableInCur = curLen - offsetInMemoryBuffer;
           if (availableInCur <= 0) {
@@ -553,7 +543,7 @@ public class MultiByteArrayOutputStream extends OutputStream {
     private void ensureSpillOpen() throws IOException {
       if (spillIn == null) {
         spillIn = fs.open(outputPath);
-        spillIn.seek(Math.max(0, globalPos - memoryBytes));
+        spillIn.seek(globalPos - memoryBytes);
       }
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
@@ -514,7 +513,7 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
       InputStream inputStream = byteArrayOutput.createInputStreamFrom(
           indexRecord.getStartOffset(), indexRecord.getPartLength());
       fetchedInput = new InputStreamFetchedInput(
-          new BoundedInputStream(inputStream, indexRecord.getPartLength()),
+          inputStream,
           indexRecord.getPartLength(),
           srcAttemptId, NO_OP_FETCHED_INPUT_CALLBACK);
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -511,16 +511,8 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
       if (byteArrayOutput == null) {
         throw new IOException("ConcurrentByteCache not found for pathComponent=" + pathComponent);
       }
-      InputStream inputStream = byteArrayOutput.createInputStream();
-      long remaining = indexRecord.getStartOffset();
-      while (remaining > 0) {
-        long skipped = inputStream.skip(remaining);
-        if (skipped <= 0) {
-          inputStream.close();
-          throw new IOException("Failed to seek spill to offset " + indexRecord.getStartOffset());
-        }
-        remaining -= skipped;
-      }
+      InputStream inputStream = byteArrayOutput.createInputStreamFrom(
+          indexRecord.getStartOffset(), indexRecord.getPartLength());
       fetchedInput = new InputStreamFetchedInput(
           new BoundedInputStream(inputStream, indexRecord.getPartLength()),
           indexRecord.getPartLength(),

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
@@ -772,7 +771,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         indexRecord.getStartOffset(), indexRecord.getPartLength());
     return MapOutput.createInputStreamMapOutput(
         srcAttemptId, allocator,
-        new BoundedInputStream(inputStream, indexRecord.getPartLength()),
+        inputStream,
         indexRecord.getRawLength(),
         indexRecord.getPartLength(),
         true);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -768,16 +768,8 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
     if (byteArrayOutput == null) {
       throw new IOException("ConcurrentByteCache not found for pathComponent=" + pathComponent);
     }
-    InputStream inputStream = byteArrayOutput.createInputStream();
-    long remaining = indexRecord.getStartOffset();
-    while (remaining > 0) {
-      long skipped = inputStream.skip(remaining);
-      if (skipped <= 0) {
-        inputStream.close();
-        throw new IOException("Failed to seek spill to offset " + indexRecord.getStartOffset());
-      }
-      remaining -= skipped;
-    }
+    InputStream inputStream = byteArrayOutput.createInputStreamFrom(
+        indexRecord.getStartOffset(), indexRecord.getPartLength());
     return MapOutput.createInputStreamMapOutput(
         srcAttemptId, allocator,
         new BoundedInputStream(inputStream, indexRecord.getPartLength()),

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -846,17 +846,8 @@ public final class PipelinedSorter {
           true, null, outputContext);
     }
 
-    InputStream input = byteArrayOutput.createInputStream();
-    long remaining = indexRecord.getStartOffset();
-    while (remaining > 0) {
-      long skipped = input.skip(remaining);
-      if (skipped <= 0) {
-        input.close();
-        throw new IOException("Failed to seek spill to offset "
-            + indexRecord.getStartOffset());
-      }
-      remaining -= skipped;
-    }
+    InputStream input = byteArrayOutput.createInputStreamFrom(
+        indexRecord.getStartOffset(), indexRecord.getPartLength());
 
     IFile.KeyValueReaderDataInputBuffer reader = new IFile.Reader(input, indexRecord.getPartLength(),
         codec, null, null, ifileReadAhead, ifileReadAheadLength, outputContext, null);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -583,7 +583,9 @@ public class TezMerger {
             tempSegment = new DiskSegment(fs, outputFile, 0, fs.getFileStatus(outputFile).getLen(), codec,
                 ifileReadAhead, ifileReadAheadLength, false, null, inputContext);
           } else {
-            IFile.KeyValueReaderDataInputBuffer reader = new Reader(byteArrayOutput.createInputStream(), byteArrayOutput.getTotalBytes(),
+            IFile.KeyValueReaderDataInputBuffer reader = new Reader(
+                byteArrayOutput.createInputStreamFrom(0, byteArrayOutput.getTotalBytes()),
+                byteArrayOutput.getTotalBytes(),
                 codec, null, null, ifileReadAhead, ifileReadAheadLength, inputContext);
             tempSegment = new IntermediateMemorySegment(reader, byteArrayOutput, true);
           }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -1415,18 +1415,10 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                   }
                   additionalSpillBytesReadCounter.increment(indexRecord.getPartLength());
                 } else {
-                  InputStream input = spillInfo.byteArrayOutput.createInputStream();
+                  InputStream input = spillInfo.byteArrayOutput.createInputStreamFrom(
+                      indexRecord.getStartOffset(), indexRecord.getPartLength());
                   boolean closeInput = true;
                   try {
-                    long remaining = indexRecord.getStartOffset();
-                    while (remaining > 0) {
-                      long skipped = input.skip(remaining);
-                      if (skipped <= 0) {
-                        throw new IOException("Failed to seek spill to offset "
-                            + indexRecord.getStartOffset());
-                      }
-                      remaining -= skipped;
-                    }
                     IFileInputStream inputStream = IFile.Reader.openIFileInputStream(
                         input, indexRecord.getPartLength(), ifileReadAhead, ifileReadAheadLength);
                     closeInput = false;
@@ -1448,17 +1440,8 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                       additionalSpillBytesReadCounter, ifileReadAhead, ifileReadAheadLength,
                       outputContext, spillOffsetRecord);
                 } else {
-                  InputStream input = spillInfo.byteArrayOutput.createInputStream();
-                  long remaining = indexRecord.getStartOffset();
-                  while (remaining > 0) {
-                    long skipped = input.skip(remaining);
-                    if (skipped <= 0) {
-                      input.close();
-                      throw new IOException("Failed to seek spill to offset "
-                          + indexRecord.getStartOffset());
-                    }
-                    remaining -= skipped;
-                  }
+                  InputStream input = spillInfo.byteArrayOutput.createInputStreamFrom(
+                      indexRecord.getStartOffset(), indexRecord.getPartLength());
                   reader = new IFile.Reader(input, indexRecord.getPartLength(), spillCodecForReader, null, null,
                       ifileReadAhead, ifileReadAheadLength, outputContext, spillOffsetRecord);
                 }


### PR DESCRIPTION
### Motivation

- Avoid using `InputStream.skip()` to seek into in-memory/spilled buffers which is inefficient and error-prone for ranged reads.  
- Provide a direct way to obtain an `InputStream` that reads a specific range `[offset, offset+length)` from `MultiByteArrayOutputStream`.  
- Simplify callers that previously performed manual skip loops and improve EOF handling when reading spilled data.

### Description

- Add a new API `createInputStreamFrom(long offset, long length)` to `MultiByteArrayOutputStream` that returns an `InputStream` for the requested byte range.  
- Implement an inner `MultiBufferRangeInputStream` that transparently serves data from in-memory buffers and the spill `FSDataInputStream`, implementing `read()`, `read(byte[],int,int)`, `skip()`, `available()`, and `close()` with proper seeking and EOF checks.  
- Replace multiple call sites that previously called `createInputStream()` then manually skipped to a start offset with calls to `createInputStreamFrom(offset, length)` in `FetcherUnordered`, `FetcherOrderedGrouped`, `PipelinedSorter`, `TezMerger`, and `UnorderedPartitionedKVWriter`.  
- Add `FSDataInputStream` import and remove obsolete skip-based logic; improve error messages on unexpected EOF when reading spill files.

### Testing

- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb93b55f1c8328afa76072e58c07b1)