### PR TITLE
Attach TezOffsetRecord from IndexPathCache to local fetched inputs for composite fetch

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -427,6 +427,7 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
       String pathComponent = inputAttemptIdentifier.getPathComponent();   // already in expanded form
       TezSpillRecord spillRecord = null;  // specific to each inputAttemptIdentifier/pathComponent
       Path inputFilePath = null;
+      Map<Integer, TezOffsetRecord> offsetRecordMap = null;
 
       boolean hasFailures = false;  // set to true if errors occur inside the inner loop
       for (int k = 0; k < partitionCount; k++) {
@@ -444,11 +445,21 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
                 fetcherConfigCommon.localDirAllocator, fetcherConfigCommon.localFs);
             spillRecord = pair.getKey();
             inputFilePath = pair.getValue();
+            if (fetcherConfigCommon.compositeFetch) {
+              org.apache.tez.runtime.api.IndexPathCache.MapOutputInfo mapOutputInfo =
+                  taskContext.getIndexPathCache().get(pathComponent);
+              if (mapOutputInfo != null) {
+                offsetRecordMap = mapOutputInfo.getOffsetRecordMap();
+              }
+            }
           }
           TezIndexRecord indexRecord = spillRecord.getIndex(reduceId);
           // TODO: continue if !indexRecord.hasData()
 
           fetchedInput = getLocalFetchedInput(srcAttemptId, pathComponent, indexRecord, inputFilePath);
+          if (offsetRecordMap != null) {
+            fetchedInput.setTezOffsetRecord(offsetRecordMap.get(reduceId));
+          }
           long endTime = System.currentTimeMillis();
           fetcherCallback.fetchSucceeded(shuffleClientId, host, srcAttemptId, fetchedInput,
               indexRecord.getPartLength(), indexRecord.getRawLength(), (endTime - startTime));

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -677,6 +677,7 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
       String pathComponent = inputAttemptIdentifier.getPathComponent();   // already in expanded form
       TezSpillRecord spillRecord = null;  // specific to each inputAttemptIdentifier/pathComponent
       Path inputFilePath = null;
+      Map<Integer, TezOffsetRecord> offsetRecordMap = null;
 
       boolean hasFailures = false;
       // Fetch partition count number of map outputs (handles auto-reduce case)
@@ -696,6 +697,13 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
                 fetcherConfigCommon.localDirAllocator, fetcherConfigCommon.localFs);
             spillRecord = pair.getKey();
             inputFilePath = pair.getValue();
+            if (fetcherConfigCommon.compositeFetch) {
+              org.apache.tez.runtime.api.IndexPathCache.MapOutputInfo mapOutputInfo =
+                  taskContext.getIndexPathCache().get(pathComponent);
+              if (mapOutputInfo != null) {
+                offsetRecordMap = mapOutputInfo.getOffsetRecordMap();
+              }
+            }
           }
           TezIndexRecord indexRecord = spillRecord.getIndex(reduceId);
           if (!indexRecord.hasData()) {
@@ -703,6 +711,9 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
           }
 
           mapOutput = getMapOutputForDirectFetch(srcAttemptId, pathComponent, inputFilePath, indexRecord);
+          if (offsetRecordMap != null) {
+            mapOutput.setTezOffsetRecord(offsetRecordMap.get(reduceId));
+          }
           long endTime = System.currentTimeMillis();
           fetcherCallback.fetchSucceeded(shuffleClientId, host, srcAttemptId, mapOutput,
               indexRecord.getPartLength(), indexRecord.getRawLength(), (endTime - startTime));


### PR DESCRIPTION
### Motivation
- Ensure that when `compositeFetch` is enabled, fetchers propagate per-reduce `TezOffsetRecord` metadata from the `IndexPathCache` into local fetched inputs so downstream processing has access to offset information.

### Description
- Added a local `offsetRecordMap` lookup from `taskContext.getIndexPathCache().get(pathComponent)` when `fetcherConfigCommon.compositeFetch` is true and it is present.
- Set the `TezOffsetRecord` on `FetchedInput` in `FetcherUnordered` using `fetchedInput.setTezOffsetRecord(...)` after a successful local read.
- Set the `TezOffsetRecord` on `MapOutput` in `FetcherOrderedGrouped` using `mapOutput.setTezOffsetRecord(...)` after a successful local read.
- All accesses are guarded for nulls so behavior is unchanged when no index cache entry exists.

### Testing
- Ran the project unit test suite via `mvn test` and the build and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8f7e88d88328924ba3735b47d24c)