### PR TITLE
Add `consumeAll` BiConsumer API to key/value readers and implement for in-memory and ifile readers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdge.java
@@ -19,6 +19,7 @@
 package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.ReaderEdge;
@@ -44,4 +45,8 @@ public abstract class KeyValueReaderEdge extends KeyValueReader implements Reade
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   @Override
   public abstract BytesWritable getCurrentValue() throws IOException;
+
+  // Invariant:
+  //   The backing byte[] arrays of both BytesWritable arguments are immutable.
+  public abstract int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException;
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdge.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.ReaderEdge;
 
 public abstract class KeyValueReaderEdge extends KeyValueReader implements ReaderEdge {
+  // Contract: next() and consumeAll() are mutually exclusive and must not be mixed.
 
   /**
    * Returns the current key

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -114,16 +114,15 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
 
   @Override
   public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
-    int consumedRecords = 0;
+    assert numRecordsRead == 0;
     while (moveToNextInput()) {
       int currentConsumed = currentReader.consumeAll(consumer);
       inputRecordCounter.increment(currentConsumed);
       numRecordsRead += currentConsumed;
-      consumedRecords += currentConsumed;
     }
     LOG.info("Num Records read: " + numRecordsRead);
     completedProcessing = true;
-    return consumedRecords;
+    return numRecordsRead;
   }
 
   public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -19,6 +19,7 @@
 package org.apache.tez.runtime.library.common.readers;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.InputContext;
@@ -109,6 +110,29 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   @Override
   public BytesWritable getCurrentValue() throws IOException {
     return value;
+  }
+
+  @Override
+  public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+    int consumedRecords = 0;
+    while (true) {
+      if (currentReader == null && !moveToNextInput()) {
+        LOG.info("Num Records read: " + numRecordsRead);
+        completedProcessing = true;
+        return consumedRecords;
+      }
+
+      int currentConsumed = currentReader.consumeAll(consumer);
+      inputRecordCounter.increment(currentConsumed);
+      numRecordsRead += currentConsumed;
+      consumedRecords += currentConsumed;
+
+      if (!moveToNextInput()) {
+        LOG.info("Num Records read: " + numRecordsRead);
+        completedProcessing = true;
+        return consumedRecords;
+      }
+    }
   }
 
   public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -115,24 +115,15 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   @Override
   public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
     int consumedRecords = 0;
-    while (true) {
-      if (currentReader == null && !moveToNextInput()) {
-        LOG.info("Num Records read: " + numRecordsRead);
-        completedProcessing = true;
-        return consumedRecords;
-      }
-
+    while (moveToNextInput()) {
       int currentConsumed = currentReader.consumeAll(consumer);
       inputRecordCounter.increment(currentConsumed);
       numRecordsRead += currentConsumed;
       consumedRecords += currentConsumed;
-
-      if (!moveToNextInput()) {
-        LOG.info("Num Records read: " + numRecordsRead);
-        completedProcessing = true;
-        return consumedRecords;
-      }
     }
+    LOG.info("Num Records read: " + numRecordsRead);
+    completedProcessing = true;
+    return consumedRecords;
   }
 
   public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -21,6 +21,7 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -381,6 +382,27 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
     bytesRead += currentValueLength;
     ++recNo;
+  }
+
+  @Override
+  public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+    BytesWritable key = new BytesWritable();
+    BytesWritable value = new BytesWritable();
+    int recordCount = 0;
+    if (isRleEnabled) {
+      while (readRawKeyRle(key) != KeyState.NO_KEY) {
+        nextRawValue(value);
+        consumer.accept(key, value);
+        recordCount++;
+      }
+    } else {
+      while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
+        nextRawValue(value);
+        consumer.accept(key, value);
+        recordCount++;
+      }
+    }
+    return recordCount;
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.BytesWritable;
@@ -914,6 +915,8 @@ public class IFile {
     Reader.KeyState readRawKey(BytesWritable key) throws IOException;
     // After readRawValue() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.
     void nextRawValue(BytesWritable value) throws IOException;
+    // Retrieves all key/value pairs, where both BytesWritable arguments are backed by immutable byte[] arrays.
+    int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException;
   }
 
   public interface KeyValueReader extends KeyValueReaderDataInputBuffer, KeyValueReaderBytesWritable {
@@ -1444,6 +1447,27 @@ public class IFile {
 
       ++recNo;
       ++numRecordsRead;
+    }
+
+    @Override
+    public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+      BytesWritable key = new BytesWritable();
+      BytesWritable value = new BytesWritable();
+      int recordCount = 0;
+      if (isRleEnabled) {
+        while (readRawKeyRle(key) != KeyState.NO_KEY) {
+          nextRawValue(value);
+          consumer.accept(key, value);
+          recordCount++;
+        }
+      } else {
+        while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
+          nextRawValue(value);
+          consumer.accept(key, value);
+          recordCount++;
+        }
+      }
+      return recordCount;
     }
 
     private static void verifyHeaderMagic(byte[] header) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -909,6 +909,7 @@ public class IFile {
   }
 
   public interface KeyValueReaderBytesWritable extends KeyValueReaderBase {
+    // Contract: readRawKey()/nextRawValue() and consumeAll() are mutually exclusive and must not be mixed.
     // Invariant: key already contains the previous key read from this stream.
     // On the first call, key can be any BytesWritable instance.
     // After readRawKey() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
@@ -90,32 +90,25 @@ public class ConcatenatedMergedKeyValueInput extends MergedLogicalInput implemen
     @Override
     public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
       int consumedRecords = 0;
-      while (true) {
-        while (currentReader == null) {
-          if (currentReaderIndex == getInputs().size()) {
-            hasCompletedProcessing();
-            completedProcessing = true;
-            return consumedRecords;
+      for (; currentReaderIndex < getInputs().size(); currentReaderIndex++) {
+        try {
+          Reader reader = getInputs().get(currentReaderIndex).getReader();
+          if (!(reader instanceof KeyValueReaderEdge)) {
+            throw new TezUncheckedException("Expected KeyValueReaderEdge. "
+                + "Got: " + reader.getClass().getName());
           }
-          try {
-            Reader reader = getInputs().get(currentReaderIndex).getReader();
-            if (!(reader instanceof KeyValueReaderEdge)) {
-              throw new TezUncheckedException("Expected KeyValueReaderEdge. "
-                  + "Got: " + reader.getClass().getName());
-            }
-            currentReader = (KeyValueReaderEdge) reader;
-            currentReaderIndex++;
-          } catch (Exception e) {
-            if (e instanceof IOException) {
-              throw (IOException) e;
-            } else {
-              throw new IOException(e);
-            }
+          consumedRecords += ((KeyValueReaderEdge) reader).consumeAll(consumer);
+        } catch (Exception e) {
+          if (e instanceof IOException) {
+            throw (IOException) e;
+          } else {
+            throw new IOException(e);
           }
         }
-        consumedRecords += currentReader.consumeAll(consumer);
-        currentReader = null;
       }
+      hasCompletedProcessing();
+      completedProcessing = true;
+      return consumedRecords;
     }
 
     public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
@@ -20,6 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.dag.api.GroupInputEdge;
@@ -84,6 +85,37 @@ public class ConcatenatedMergedKeyValueInput extends MergedLogicalInput implemen
     @Override
     public BytesWritable getCurrentValue() throws IOException {
       return currentReader.getCurrentValue();
+    }
+
+    @Override
+    public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+      int consumedRecords = 0;
+      while (true) {
+        while (currentReader == null) {
+          if (currentReaderIndex == getInputs().size()) {
+            hasCompletedProcessing();
+            completedProcessing = true;
+            return consumedRecords;
+          }
+          try {
+            Reader reader = getInputs().get(currentReaderIndex).getReader();
+            if (!(reader instanceof KeyValueReaderEdge)) {
+              throw new TezUncheckedException("Expected KeyValueReaderEdge. "
+                  + "Got: " + reader.getClass().getName());
+            }
+            currentReader = (KeyValueReaderEdge) reader;
+            currentReaderIndex++;
+          } catch (Exception e) {
+            if (e instanceof IOException) {
+              throw (IOException) e;
+            } else {
+              throw new IOException(e);
+            }
+          }
+        }
+        consumedRecords += currentReader.consumeAll(consumer);
+        currentReader = null;
+      }
     }
 
     public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
@@ -20,6 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -180,6 +181,13 @@ public class UnorderedKVInput extends AbstractLogicalInput implements LogicalInp
         @Override
         public BytesWritable getCurrentValue() throws IOException {
           throw new RuntimeException("No data available in Input");
+        }
+
+        @Override
+        public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+          hasCompletedProcessing();
+          completedProcessing = true;
+          return 0;
         }
       };
     }


### PR DESCRIPTION
### Motivation

- Provide a bulk-consumption API to efficiently stream all key/value pairs from readers using a `BiConsumer` callback to avoid per-record caller loops. 
- Expose the contract that the backing `byte[]` arrays of `BytesWritable` arguments are immutable so consumers may retain pointers to the data. 

### Description

- Added an abstract `consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer)` method to `KeyValueReaderEdge` with an invariant comment about immutable backing arrays. 
- Extended the `IFile.KeyValueReaderBytesWritable` interface to declare `int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException`. 
- Implemented `consumeAll` in `IFile.Reader` and `InMemoryReader` to iterate all records (handling RLE/no-RLE paths) and invoke the supplied `BiConsumer`, returning the number of records consumed. 
- Implemented `consumeAll` in `UnorderedKVReader` to delegate to underlying readers, update `inputRecordCounter` and `numRecordsRead`, and return total consumed records. 
- Implemented `consumeAll` in `ConcatenatedMergedKeyValueInput.ConcatenatedMergedKeyValueReader` to concatenate underlying readers and in `UnorderedKVInput`'s empty-reader case to return 0 while marking completion. 
- Added required `java.util.function.BiConsumer` imports and small logging/progress updates while consuming records. 

### Testing

- Ran the module unit tests with `mvn test` against the modified `tez-runtime-library` and observed that the existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed810defe88328b7eeec68602bdfb6)