### PR TITLE
Add `consumeAll` bulk-drain API for key/value iterators and readers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdge.java
@@ -19,11 +19,13 @@
 package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.ReaderEdge;
 
 public abstract class KeyValueReaderEdge extends KeyValueReader implements ReaderEdge {
+  // Contract: next() and consumeAll() are mutually exclusive and must not be mixed.
 
   /**
    * Returns the current key
@@ -44,4 +46,8 @@ public abstract class KeyValueReaderEdge extends KeyValueReader implements Reade
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   @Override
   public abstract BytesWritable getCurrentValue() throws IOException;
+
+  // Invariant:
+  //   The backing byte[] arrays of both BytesWritable arguments are immutable.
+  public abstract int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException;
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
@@ -19,11 +19,13 @@
 package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.ReaderEdge;
 
 public abstract class KeyValuesReaderEdge extends KeyValuesReader implements ReaderEdge {
+  // Contract: next() and consumeAll() are mutually exclusive and must not be mixed.
 
   /**
    * Returns the current key
@@ -42,4 +44,9 @@ public abstract class KeyValuesReaderEdge extends KeyValuesReader implements Rea
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   @Override
   public abstract Iterable<BytesWritable> getCurrentValues() throws IOException;
+
+  // Invariant:
+  //   The backing byte[] arrays of the key and all values are immutable.
+  public abstract long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+      throws IOException;
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -21,6 +21,7 @@ package org.apache.tez.runtime.library.common;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -84,6 +85,38 @@ public class ValuesIterator {
     return more;
   }
 
+  // Invariant:
+  //   The backing byte[] arrays of the key and all values are immutable.
+  public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+      throws IOException {
+    long consumedKeys = 0;
+    if (isFirstRecord) {
+      readNextKey();
+      key = nextKey;
+      nextKey = null;
+      isFirstRecord = false;
+    }
+
+    while (more) {
+      Iterable<BytesWritable> currentValues = createValuesIterable();
+      BytesWritable currentKey = key;
+      consumer.accept(currentKey, currentValues);
+      for (BytesWritable ignored : currentValues) {
+        // drain values for this key to advance the iterator efficiently.
+      }
+      consumedKeys++;
+      if (more) {
+        nextKey();
+      }
+    }
+
+    if (!completedProcessing) {
+      hasCompletedProcessing();
+      completedProcessing = true;
+    }
+    return consumedKeys;
+  }
+
   /** The current key. */
   // Invariant:
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
@@ -94,6 +127,10 @@ public class ValuesIterator {
   // Invariant:
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   public Iterable<BytesWritable> getValues() {
+    return createValuesIterable();
+  }
+
+  private Iterable<BytesWritable> createValuesIterable() {
     return new Iterable<BytesWritable>() {
 
       @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -19,6 +19,7 @@
 package org.apache.tez.runtime.library.common.readers;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.InputContext;
@@ -109,6 +110,19 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   @Override
   public BytesWritable getCurrentValue() throws IOException {
     return value;
+  }
+
+  @Override
+  public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+    assert numRecordsRead == 0;
+    while (moveToNextInput()) {
+      int currentConsumed = currentReader.consumeAll(consumer);
+      inputRecordCounter.increment(currentConsumed);
+      numRecordsRead += currentConsumed;
+    }
+    LOG.info("Num Records read: {}", numRecordsRead);
+    completedProcessing = true;
+    return numRecordsRead;
   }
 
   public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -21,6 +21,7 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -381,6 +382,27 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
     bytesRead += currentValueLength;
     ++recNo;
+  }
+
+  @Override
+  public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+    BytesWritable key = new BytesWritable();
+    BytesWritable value = new BytesWritable();
+    int recordCount = 0;
+    if (isRleEnabled) {
+      while (readRawKeyRle(key) != KeyState.NO_KEY) {
+        nextRawValue(value);
+        consumer.accept(key, value);
+        recordCount++;
+      }
+    } else {
+      while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
+        nextRawValue(value);
+        consumer.accept(key, value);
+        recordCount++;
+      }
+    }
+    return recordCount;
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.BytesWritable;
@@ -908,12 +909,15 @@ public class IFile {
   }
 
   public interface KeyValueReaderBytesWritable extends KeyValueReaderBase {
+    // Contract: readRawKey()/nextRawValue() and consumeAll() are mutually exclusive and must not be mixed.
     // Invariant: key already contains the previous key read from this stream.
     // On the first call, key can be any BytesWritable instance.
     // After readRawKey() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.
     Reader.KeyState readRawKey(BytesWritable key) throws IOException;
     // After readRawValue() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.
     void nextRawValue(BytesWritable value) throws IOException;
+    // Retrieves all key/value pairs, where both BytesWritable arguments are backed by immutable byte[] arrays.
+    int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException;
   }
 
   public interface KeyValueReader extends KeyValueReaderDataInputBuffer, KeyValueReaderBytesWritable {
@@ -1444,6 +1448,27 @@ public class IFile {
 
       ++recNo;
       ++numRecordsRead;
+    }
+
+    @Override
+    public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+      BytesWritable key = new BytesWritable();
+      BytesWritable value = new BytesWritable();
+      int recordCount = 0;
+      if (isRleEnabled) {
+        while (readRawKeyRle(key) != KeyState.NO_KEY) {
+          nextRawValue(value);
+          consumer.accept(key, value);
+          recordCount++;
+        }
+      } else {
+        while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
+          nextRawValue(value);
+          consumer.accept(key, value);
+          recordCount++;
+        }
+      }
+      return recordCount;
     }
 
     private static void verifyHeaderMagic(byte[] header) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import java.util.function.BiConsumer;
 import java.util.concurrent.*;
 import java.util.zip.Deflater;
 
@@ -1681,6 +1682,50 @@ public final class PipelinedSorter {
       return false;
     }
 
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      long consumedKeys = 0;
+      BytesWritable keyWritable = new BytesWritable();
+      List<BytesWritable> values = new ArrayList<BytesWritable>();
+      while (next()) {
+        DataInputBuffer currentKey = getKey();
+        if (values.isEmpty() || !sameKey(keyWritable, currentKey)) {
+          if (!values.isEmpty()) {
+            consumer.accept(keyWritable, values);
+            consumedKeys++;
+            values = new ArrayList<BytesWritable>();
+          }
+          copyToWritable(keyWritable, currentKey);
+        }
+        BytesWritable valueWritable = new BytesWritable();
+        copyToWritable(valueWritable, getValue());
+        values.add(valueWritable);
+      }
+      if (!values.isEmpty()) {
+        consumer.accept(keyWritable, values);
+        consumedKeys++;
+      }
+      return consumedKeys;
+    }
+
+    private boolean sameKey(BytesWritable keyWritable, DataInputBuffer keyBuffer) {
+      int keyLength = keyBuffer.getLength() - keyBuffer.getPosition();
+      if (keyWritable.getLength() != keyLength) {
+        return false;
+      }
+      return TezBytesComparator.compare(
+          keyWritable.getBytes(), 0, keyWritable.getLength(),
+          keyBuffer.getData(), keyBuffer.getPosition(), keyLength) == 0;
+    }
+
+    private void copyToWritable(BytesWritable target, DataInputBuffer source) {
+      int pos = source.getPosition();
+      int length = source.getLength() - pos;
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
+    }
+
     public int getPartition() {
       final int partition = FastByteComparisons.theUnsafe.getInt(
           span.kvmetaArray, span.offsetForIntIndex(span.offsetFor(kvindex) + PARTITION));
@@ -1824,6 +1869,39 @@ public final class PipelinedSorter {
         }
       }
       return false;
+    }
+
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      long consumedKeys = 0;
+      BytesWritable keyWritable = new BytesWritable();
+      List<BytesWritable> values = new ArrayList<BytesWritable>();
+      while (next()) {
+        if (values.isEmpty() || !isSameKey()) {
+          if (!values.isEmpty()) {
+            consumer.accept(keyWritable, values);
+            consumedKeys++;
+            values = new ArrayList<BytesWritable>();
+          }
+          copyToWritable(keyWritable, getKey());
+        }
+        BytesWritable valueWritable = new BytesWritable();
+        copyToWritable(valueWritable, getValue());
+        values.add(valueWritable);
+      }
+      if (!values.isEmpty()) {
+        consumer.accept(keyWritable, values);
+        consumedKeys++;
+      }
+      return consumedKeys;
+    }
+
+    private void copyToWritable(BytesWritable target, DataInputBuffer source) {
+      int pos = source.getPosition();
+      int length = source.getLength() - pos;
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
     }
 
     public void reset(int partition) {
@@ -2005,6 +2083,50 @@ public final class PipelinedSorter {
     @Override
     public boolean isSameKey() {
       return false;
+    }
+
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      long consumedKeys = 0;
+      BytesWritable keyWritable = new BytesWritable();
+      List<BytesWritable> values = new ArrayList<BytesWritable>();
+      while (next()) {
+        DataInputBuffer currentKey = getKey();
+        if (values.isEmpty() || !sameKey(keyWritable, currentKey)) {
+          if (!values.isEmpty()) {
+            consumer.accept(keyWritable, values);
+            consumedKeys++;
+            values = new ArrayList<BytesWritable>();
+          }
+          copyToWritable(keyWritable, currentKey);
+        }
+        BytesWritable valueWritable = new BytesWritable();
+        copyToWritable(valueWritable, getValue());
+        values.add(valueWritable);
+      }
+      if (!values.isEmpty()) {
+        consumer.accept(keyWritable, values);
+        consumedKeys++;
+      }
+      return consumedKeys;
+    }
+
+    private boolean sameKey(BytesWritable keyWritable, DataInputBuffer keyBuffer) {
+      int keyLength = keyBuffer.getLength() - keyBuffer.getPosition();
+      if (keyWritable.getLength() != keyLength) {
+        return false;
+      }
+      return TezBytesComparator.compare(
+          keyWritable.getBytes(), 0, keyWritable.getLength(),
+          keyBuffer.getData(), keyBuffer.getPosition(), keyLength) == 0;
+    }
+
+    private void copyToWritable(BytesWritable target, DataInputBuffer source) {
+      int pos = source.getPosition();
+      int length = source.getLength() - pos;
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
     }
 
     public TezRawKeyValueIterator filter(int partition) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.apache.tez.runtime.api.DecompressorPool;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -662,6 +664,39 @@ public class TezMerger {
       return true;
     }
 
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      long consumedKeys = 0;
+      BytesWritable keyWritable = new BytesWritable();
+      List<BytesWritable> values = new ArrayList<BytesWritable>();
+      while (next()) {
+        if (values.isEmpty() || !isSameKey()) {
+          if (!values.isEmpty()) {
+            consumer.accept(keyWritable, values);
+            consumedKeys++;
+            values = new ArrayList<BytesWritable>();
+          }
+          copyToWritable(keyWritable, getKey());
+        }
+        BytesWritable valueWritable = new BytesWritable();
+        copyToWritable(valueWritable, getValue());
+        values.add(valueWritable);
+      }
+      if (!values.isEmpty()) {
+        consumer.accept(keyWritable, values);
+        consumedKeys++;
+      }
+      return consumedKeys;
+    }
+
+    private void copyToWritable(BytesWritable target, DataInputBuffer source) {
+      int pos = source.getPosition();
+      int length = source.getLength() - pos;
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
+    }
+
   }
 
   private static class EmptyIterator implements TezRawKeyValueIterator {
@@ -683,6 +718,12 @@ public class TezMerger {
     @Override
     public boolean hasNext() throws IOException {
       return false;
+    }
+
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      return 0;
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -18,7 +18,9 @@
 package org.apache.tez.runtime.library.common.sort.impl;
 
 import java.io.IOException;
+import java.util.function.BiConsumer;
 
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 
 /**
@@ -59,6 +61,8 @@ public interface TezRawKeyValueIterator {
    * @throws IOException
    */
   boolean hasNext() throws IOException;
+
+  long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer) throws IOException;
 
   /** 
    * Closes the iterator so that the underlying streams can be closed.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValueInput.java
@@ -20,6 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.dag.api.GroupInputEdge;
@@ -84,6 +85,30 @@ public class ConcatenatedMergedKeyValueInput extends MergedLogicalInput implemen
     @Override
     public BytesWritable getCurrentValue() throws IOException {
       return currentReader.getCurrentValue();
+    }
+
+    @Override
+    public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+      int consumedRecords = 0;
+      for (; currentReaderIndex < getInputs().size(); currentReaderIndex++) {
+        try {
+          Reader reader = getInputs().get(currentReaderIndex).getReader();
+          if (!(reader instanceof KeyValueReaderEdge)) {
+            throw new TezUncheckedException("Expected KeyValueReaderEdge. "
+                + "Got: " + reader.getClass().getName());
+          }
+          consumedRecords += ((KeyValueReaderEdge) reader).consumeAll(consumer);
+        } catch (Exception e) {
+          if (e instanceof IOException) {
+            throw (IOException) e;
+          } else {
+            throw new IOException(e);
+          }
+        }
+      }
+      hasCompletedProcessing();
+      completedProcessing = true;
+      return consumedRecords;
     }
 
     public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValuesInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/ConcatenatedMergedKeyValuesInput.java
@@ -20,6 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.dag.api.GroupInputEdge;
@@ -86,6 +87,31 @@ public class ConcatenatedMergedKeyValuesInput extends MergedLogicalInput impleme
     @Override
     public Iterable<BytesWritable> getCurrentValues() throws IOException {
       return currentReader.getCurrentValues();
+    }
+
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      long consumedKeys = 0;
+      for (; currentReaderIndex < getInputs().size(); currentReaderIndex++) {
+        try {
+          Reader reader = getInputs().get(currentReaderIndex).getReader();
+          if (!(reader instanceof KeyValuesReaderEdge)) {
+            throw new TezUncheckedException("Expected KeyValuesReader. "
+                + "Got: " + reader.getClass().getName());
+          }
+          consumedKeys += ((KeyValuesReaderEdge) reader).consumeAll(consumer);
+        } catch (Exception e) {
+          if (e instanceof IOException) {
+            throw (IOException) e;
+          } else {
+            throw new IOException(e);
+          }
+        }
+      }
+      hasCompletedProcessing();
+      completedProcessing = true;
+      return consumedKeys;
     }
 
     public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -233,6 +234,14 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
           public Iterable<BytesWritable> getCurrentValues() throws IOException {
             throw new RuntimeException("No data available in Input");
           }
+
+          @Override
+          public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+              throws IOException {
+            hasCompletedProcessing();
+            completedProcessing = true;
+            return 0;
+          }
         };
       }
     }
@@ -319,6 +328,12 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
     @SuppressWarnings("unchecked")
     public Iterable<BytesWritable> getCurrentValues() throws IOException {
       return valuesIter.getValues();
+    }
+
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      return valuesIter.consumeAll(consumer);
     }
   };
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedMergedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedMergedKVInput.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
@@ -136,6 +137,37 @@ public class OrderedGroupedMergedKVInput extends MergedLogicalInput implements L
     @Override
     public Iterable<BytesWritable> getCurrentValues() throws IOException {
       return currentValues;
+    }
+
+    @Override
+    public long consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>> consumer)
+        throws IOException {
+      long consumedKeys = 0;
+      while (true) {
+        // Skip values of current key if not consumed by the user
+        currentValues.discardCurrent();
+
+        for (KeyValuesReaderEdge reader : finishedReaders) {
+          // add them back to queue
+          advanceAndAddToQueue(reader);
+        }
+        finishedReaders.clear();
+
+        nextKVReader = pQueue.poll();
+        if (nextKVReader == null) {
+          hasCompletedProcessing();
+          completedProcessing = true;
+          return consumedKeys;
+        }
+
+        currentKey = nextKVReader.getCurrentKey();
+        currentValues.moveToNext();
+        consumer.accept(currentKey, currentValues);
+        for (BytesWritable ignored : currentValues) {
+          // drain values for current key to advance the merged reader.
+        }
+        consumedKeys++;
+      }
     }
 
     private class ValuesIterable implements Iterable<BytesWritable> {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
@@ -20,6 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.function.BiConsumer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -180,6 +181,13 @@ public class UnorderedKVInput extends AbstractLogicalInput implements LogicalInp
         @Override
         public BytesWritable getCurrentValue() throws IOException {
           throw new RuntimeException("No data available in Input");
+        }
+
+        @Override
+        public int consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException {
+          hasCompletedProcessing();
+          completedProcessing = true;
+          return 0;
         }
       };
     }


### PR DESCRIPTION
### Motivation
- Provide a bulk consumption API to efficiently drain keys and their value-iterables from raw and merged key/value iterators without interleaving `next()`/`getValues()` calls. 
- Make it possible for merged/concatenated inputs to forward-through and drain entire readers more efficiently for performance and simpler caller code. 
- Clarify and document the contract/invariants around immutability of backing `byte[]` buffers when handing out `BytesWritable` instances.

### Description
- Added a new `consumeAll(BiConsumer<BytesWritable, Iterable<BytesWritable>>)` method to `TezRawKeyValueIterator` and `KeyValuesReaderEdge`, and documented the immutability invariant and contract that `next()` and `consumeAll()` are mutually exclusive. 
- Implemented `consumeAll` in `ValuesIterator`, `PipelinedSorter` (span/partition iterators and merger-facing iterators), `TezMerger`, and the `EmptyIterator` to iterate through keys and supply an `Iterable<BytesWritable>` of values to the provided `BiConsumer`, using helper logic (`copyToWritable`, `sameKey`) to materialize `BytesWritable` instances as needed. 
- Updated merged/concatenated input implementations (`ConcatenatedMergedKeyValuesInput`, `OrderedGroupedKVInput`, `OrderedGroupedMergedKVInput`) to forward `consumeAll` to underlying readers or iterators so callers can drain entire logical inputs. 
- Added necessary imports for `java.util.function.BiConsumer` and adjusted `ValuesIterator.getValues()` to return a reuseable `Iterable` implementation and expose a new `consumeAll` path that drains values efficiently.

### Testing
- Performed a module build and ran the runtime library unit tests with `mvn -DskipTests=false test` on the `tez-runtime-library` module. 
- All compiled changes and existing unit tests in the module completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed95610a0c83289b01f161f84f6a57)