### PR TITLE
Add grouped event-stream consumeAll for OrderedGroupedKVInput

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
@@ -19,6 +19,7 @@
 package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.ReaderEdge;
@@ -42,4 +43,38 @@ public abstract class KeyValuesReaderEdge extends KeyValuesReader implements Rea
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   @Override
   public abstract Iterable<BytesWritable> getCurrentValues() throws IOException;
+
+  /**
+   * Consume all key-groups as an event stream.
+   *
+   * <p>Lifecycle contract for each non-empty key-group:
+   * <ol>
+   *   <li>{@code openNewKey.accept(key)} is invoked exactly once.</li>
+   *   <li>{@code consumeValue.accept(value)} is invoked for every value in the key-group.</li>
+   *   <li>{@code closeCurrentKey.run()} is invoked exactly once.</li>
+   * </ol>
+   *
+   * <p>{@link #next()} and {@code consumeAll(...)} are mutually exclusive and must not be mixed.
+   *
+   * @return number of consumed key-groups
+   */
+  public long consumeAll(Consumer<BytesWritable> openNewKey,
+                         Consumer<BytesWritable> consumeValue,
+                         Runnable closeCurrentKey) throws IOException {
+    long groups = 0;
+    while (next()) {
+      openNewKey.accept(getCurrentKey());
+      boolean consumedAnyValue = false;
+      for (BytesWritable value : getCurrentValues()) {
+        consumeValue.accept(value);
+        consumedAnyValue = true;
+      }
+      if (!consumedAnyValue) {
+        throw new IOException("Encountered key-group with no values");
+      }
+      closeCurrentKey.run();
+      groups++;
+    }
+    return groups;
+  }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.comparator.TezBytesComparator;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
 
@@ -434,15 +435,34 @@ public class InMemoryReader implements IFile.KeyValueReader {
         groupCount++;
       }
     } else {
+      BytesWritable previousKey = new BytesWritable();
+      if (readRawKeyNoRle(key) == KeyState.NO_KEY) {
+        return 0;
+      }
+      openNewKey.accept(key);
+      nextRawValue(value);
+      consumeValue.accept(value);
+      groupCount++;
+      copyWritable(previousKey, key);
+
       while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
-        openNewKey.accept(key);
+        if (TezBytesComparator.compare(previousKey, key) != 0) {
+          closeCurrentKey.run();
+          openNewKey.accept(key);
+          groupCount++;
+          copyWritable(previousKey, key);
+        }
         nextRawValue(value);
         consumeValue.accept(value);
-        closeCurrentKey.run();
-        groupCount++;
       }
+      closeCurrentKey.run();
     }
     return groupCount;
+  }
+
+  private static void copyWritable(BytesWritable target, BytesWritable source) {
+    byte[] bytes = target.reinitialize(source.getLength());
+    System.arraycopy(source.getBytesRaw(), source.getOffset(), bytes, 0, source.getLength());
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -404,6 +405,41 @@ public class InMemoryReader implements IFile.KeyValueReader {
       }
     }
     return recordCount;
+  }
+
+  @Override
+  public long consumeAllGrouped(Consumer<BytesWritable> openNewKey,
+                                Consumer<BytesWritable> consumeValue,
+                                Runnable closeCurrentKey) throws IOException {
+    assert recNo == 1;  // must not be mixed with next()/consumeAll()
+    BytesWritable key = new BytesWritable();
+    BytesWritable value = new BytesWritable();
+    long groupCount = 0;
+    if (isRleEnabled) {
+      KeyState keyState = readRawKeyRle(key);
+      while (keyState != KeyState.NO_KEY) {
+        if (keyState != KeyState.NEW_KEY) {
+          throw new IOException("RLE stream cannot start a key-group with SAME_KEY");
+        }
+        openNewKey.accept(key);
+        do {
+          nextRawValue(value);
+          consumeValue.accept(value);
+          keyState = readRawKeyRle(key);
+        } while (keyState == KeyState.SAME_KEY);
+        closeCurrentKey.run();
+        groupCount++;
+      }
+    } else {
+      while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
+        openNewKey.accept(key);
+        nextRawValue(value);
+        consumeValue.accept(value);
+        closeCurrentKey.run();
+        groupCount++;
+      }
+    }
+    return groupCount;
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -415,6 +415,9 @@ public class InMemoryReader implements IFile.KeyValueReader {
     BytesWritable key = new BytesWritable();
     BytesWritable value = new BytesWritable();
     long groupCount = 0;
+    // Ordered/grouped in-memory segments are frequently RLE-encoded (e.g. MergeManager/InMemoryWriter paths),
+    // but this reader can also consume map outputs whose IFile header disables RLE.
+    // Keep both branches to match the on-stream flag.
     if (isRleEnabled) {
       KeyState keyState = readRawKeyRle(key);
       while (keyState != KeyState.NO_KEY) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -443,14 +443,14 @@ public class InMemoryReader implements IFile.KeyValueReader {
       nextRawValue(value);
       consumeValue.accept(value);
       groupCount++;
-      copyWritable(previousKey, key);
+      previousKey.setDirect(key.getBytesRaw(), key.getOffset(), key.getLength());
 
       while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
         if (TezBytesComparator.compare(previousKey, key) != 0) {
           closeCurrentKey.run();
           openNewKey.accept(key);
           groupCount++;
-          copyWritable(previousKey, key);
+          previousKey.setDirect(key.getBytesRaw(), key.getOffset(), key.getLength());
         }
         nextRawValue(value);
         consumeValue.accept(value);
@@ -458,11 +458,6 @@ public class InMemoryReader implements IFile.KeyValueReader {
       closeCurrentKey.run();
     }
     return groupCount;
-  }
-
-  private static void copyWritable(BytesWritable target, BytesWritable source) {
-    byte[] bytes = target.reinitialize(source.getLength());
-    System.arraycopy(source.getBytesRaw(), source.getOffset(), bytes, 0, source.getLength());
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/GroupedConsumeTezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/GroupedConsumeTezRawKeyValueIterator.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.sort.impl;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+
+import org.apache.hadoop.io.BytesWritable;
+
+/**
+ * Optional grouped bulk-consume API for {@link TezRawKeyValueIterator}.
+ */
+public interface GroupedConsumeTezRawKeyValueIterator extends TezRawKeyValueIterator {
+
+  long consumeAllGrouped(Consumer<BytesWritable> openNewKey,
+                         Consumer<BytesWritable> consumeValue,
+                         Runnable closeCurrentKey) throws IOException;
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.BytesWritable;
@@ -919,6 +920,12 @@ public class IFile {
     // Retrieves all key/value pairs, where both BytesWritable arguments are backed by immutable byte[] arrays.
     // consumeAll() must not be mixed with readRawKey()/nextRawValue().
     long consumeAll(BiConsumer<BytesWritable, BytesWritable> consumer) throws IOException;
+
+    // Retrieves all key/value pairs grouped by key.
+    // readRawKey()/nextRawValue()/consumeAll() and consumeAllGrouped() are mutually exclusive and must not be mixed.
+    long consumeAllGrouped(Consumer<BytesWritable> openNewKey,
+                           Consumer<BytesWritable> consumeValue,
+                           Runnable closeCurrentKey) throws IOException;
   }
 
   public interface KeyValueReader extends KeyValueReaderDataInputBuffer, KeyValueReaderBytesWritable {
@@ -1470,6 +1477,43 @@ public class IFile {
         }
       }
       return numRecordsRead;
+    }
+
+    @Override
+    public long consumeAllGrouped(Consumer<BytesWritable> openNewKey,
+                                  Consumer<BytesWritable> consumeValue,
+                                  Runnable closeCurrentKey) throws IOException {
+      assert numRecordsRead == 0;   // must not be mixed with nextRawValue()/consumeAll()
+      BytesWritable key = new BytesWritable();
+      BytesWritable value = new BytesWritable();
+      long groupCount = 0;
+      if (isRleEnabled) {
+        KeyState keyState = readRawKeyRle(key);
+        while (keyState != KeyState.NO_KEY) {
+          if (keyState != KeyState.NEW_KEY) {
+            throw new IOException("RLE stream cannot start a key-group with SAME_KEY");
+          }
+          openNewKey.accept(key);
+          do {
+            nextRawValue(value);
+            consumeValue.accept(value);
+            numRecordsRead++;
+            keyState = readRawKeyRle(key);
+          } while (keyState == KeyState.SAME_KEY);
+          closeCurrentKey.run();
+          groupCount++;
+        }
+      } else {
+        while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
+          openNewKey.accept(key);
+          nextRawValue(value);
+          consumeValue.accept(value);
+          numRecordsRead++;
+          closeCurrentKey.run();
+          groupCount++;
+        }
+      }
+      return groupCount;
     }
 
     private static void verifyHeaderMagic(byte[] header) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.tez.runtime.library.utils.BufferUtils;
 import org.apache.tez.runtime.library.utils.CodecUtils;
+import org.apache.tez.runtime.library.common.comparator.TezBytesComparator;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -1504,16 +1505,36 @@ public class IFile {
           groupCount++;
         }
       } else {
+        BytesWritable previousKey = new BytesWritable();
+        if (readRawKeyNoRle(key) == KeyState.NO_KEY) {
+          return 0;
+        }
+        openNewKey.accept(key);
+        nextRawValue(value);
+        consumeValue.accept(value);
+        numRecordsRead++;
+        groupCount++;
+        copyWritable(previousKey, key);
+
         while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
-          openNewKey.accept(key);
+          if (TezBytesComparator.compare(previousKey, key) != 0) {
+            closeCurrentKey.run();
+            openNewKey.accept(key);
+            groupCount++;
+            copyWritable(previousKey, key);
+          }
           nextRawValue(value);
           consumeValue.accept(value);
           numRecordsRead++;
-          closeCurrentKey.run();
-          groupCount++;
         }
+        closeCurrentKey.run();
       }
       return groupCount;
+    }
+
+    private static void copyWritable(BytesWritable target, BytesWritable source) {
+      byte[] bytes = target.reinitialize(source.getLength());
+      System.arraycopy(source.getBytesRaw(), source.getOffset(), bytes, 0, source.getLength());
     }
 
     private static void verifyHeaderMagic(byte[] header) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -1514,14 +1514,14 @@ public class IFile {
         consumeValue.accept(value);
         numRecordsRead++;
         groupCount++;
-        copyWritable(previousKey, key);
+        previousKey.setDirect(key.getBytesRaw(), key.getOffset(), key.getLength());
 
         while (readRawKeyNoRle(key) != KeyState.NO_KEY) {
           if (TezBytesComparator.compare(previousKey, key) != 0) {
             closeCurrentKey.run();
             openNewKey.accept(key);
             groupCount++;
-            copyWritable(previousKey, key);
+            previousKey.setDirect(key.getBytesRaw(), key.getOffset(), key.getLength());
           }
           nextRawValue(value);
           consumeValue.accept(value);
@@ -1530,11 +1530,6 @@ public class IFile {
         closeCurrentKey.run();
       }
       return groupCount;
-    }
-
-    private static void copyWritable(BytesWritable target, BytesWritable source) {
-      byte[] bytes = target.reinitialize(source.getLength());
-      System.arraycopy(source.getBytesRaw(), source.getOffset(), bytes, 0, source.getLength());
     }
 
     private static void verifyHeaderMagic(byte[] header) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.apache.tez.runtime.api.DecompressorPool;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -275,7 +277,7 @@ public class TezMerger {
   }
 
   static class MergeQueue<K extends Object, V extends Object>
-  extends PriorityQueue<Segment> implements TezRawKeyValueIterator {
+  extends PriorityQueue<Segment> implements GroupedConsumeTezRawKeyValueIterator {
     final Configuration conf;
     final FileSystem fs;
     final CompressionCodec codec;
@@ -662,9 +664,46 @@ public class TezMerger {
       return true;
     }
 
+    @Override
+    public long consumeAllGrouped(Consumer<BytesWritable> openNewKey,
+                                  Consumer<BytesWritable> consumeValue,
+                                  Runnable closeCurrentKey) throws IOException {
+      BytesWritable keyWritable = new BytesWritable();
+      BytesWritable valueWritable = new BytesWritable();
+      boolean keyOpen = false;
+      long groupCount = 0;
+      while (next()) {
+        if (!isSameKey()) {
+          if (keyOpen) {
+            closeCurrentKey.run();
+          }
+          copyToWritable(keyWritable, getKey());
+          openNewKey.accept(keyWritable);
+          keyOpen = true;
+          groupCount++;
+        }
+        if (!keyOpen) {
+          throw new IOException("Received value before opening a key-group");
+        }
+        copyToWritable(valueWritable, getValue());
+        consumeValue.accept(valueWritable);
+      }
+      if (keyOpen) {
+        closeCurrentKey.run();
+      }
+      return groupCount;
+    }
+
+    private static void copyToWritable(BytesWritable target, DataInputBuffer source) {
+      int pos = source.getPosition();
+      int length = source.getLength() - pos;
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
+    }
+
   }
 
-  private static class EmptyIterator implements TezRawKeyValueIterator {
+  private static class EmptyIterator implements GroupedConsumeTezRawKeyValueIterator {
     @Override
     public DataInputBuffer getKey() throws IOException {
       throw new RuntimeException("No keys on an empty iterator");
@@ -692,6 +731,13 @@ public class TezMerger {
     @Override
     public boolean isSameKey() {
       throw new UnsupportedOperationException("isSameKey is not supported");
+    }
+
+    @Override
+    public long consumeAllGrouped(Consumer<BytesWritable> openNewKey,
+                                  Consumer<BytesWritable> consumeValue,
+                                  Runnable closeCurrentKey) {
+      return 0;
     }
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.library.api.LogicalInputEdge;
@@ -48,6 +49,7 @@ import org.apache.tez.runtime.library.common.MemoryUpdateCallbackHandler;
 import org.apache.tez.runtime.library.common.ValuesIterator;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.Shuffle;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
+import org.apache.tez.runtime.library.common.sort.impl.GroupedConsumeTezRawKeyValueIterator;
 
 import org.apache.tez.common.Preconditions;
 
@@ -233,6 +235,15 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
           public Iterable<BytesWritable> getCurrentValues() throws IOException {
             throw new RuntimeException("No data available in Input");
           }
+
+          @Override
+          public long consumeAll(Consumer<BytesWritable> openNewKey,
+                                 Consumer<BytesWritable> consumeValue,
+                                 Runnable closeCurrentKey) throws IOException {
+            hasCompletedProcessing();
+            completedProcessing = true;
+            return 0;
+          }
         };
       }
     }
@@ -300,6 +311,8 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
   private static class OrderedGroupedKeyValuesReader extends KeyValuesReaderEdge {
 
     private final ValuesIterator valuesIter;
+    private boolean usedNextApi;
+    private boolean usedConsumeAllApi;
 
     OrderedGroupedKeyValuesReader(ValuesIterator valuesIter) {
       this.valuesIter = valuesIter;
@@ -307,7 +320,11 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
 
     @Override
     public boolean next() throws IOException {
-      return valuesIter.moveToNext();
+      if (usedConsumeAllApi) {
+        throw new IOException("next() and consumeAll(...) are mutually exclusive");
+      }
+      usedNextApi = true;
+      return moveNextInternal();
     }
 
     @Override
@@ -319,6 +336,100 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
     @SuppressWarnings("unchecked")
     public Iterable<BytesWritable> getCurrentValues() throws IOException {
       return valuesIter.getValues();
+    }
+
+    @Override
+    public long consumeAll(Consumer<BytesWritable> openNewKey,
+                           Consumer<BytesWritable> consumeValue,
+                           Runnable closeCurrentKey) throws IOException {
+      if (usedConsumeAllApi) {
+        hasCompletedProcessing();
+      }
+      if (usedNextApi) {
+        throw new IOException("next() and consumeAll(...) are mutually exclusive");
+      }
+      usedConsumeAllApi = true;
+
+      final KeyGroupLifecycle lifecycle = new KeyGroupLifecycle(openNewKey, consumeValue, closeCurrentKey);
+      try {
+        TezRawKeyValueIterator rawIterator = valuesIter.getRawIterator();
+        if (rawIterator instanceof GroupedConsumeTezRawKeyValueIterator) {
+          long groups = ((GroupedConsumeTezRawKeyValueIterator) rawIterator)
+              .consumeAllGrouped(lifecycle::open, lifecycle::consume, lifecycle::close);
+          lifecycle.finish();
+          completedProcessing = true;
+          return groups;
+        }
+
+        long groups = 0;
+        while (moveNextInternal()) {
+          lifecycle.open(getCurrentKey());
+          for (BytesWritable value : getCurrentValues()) {
+            lifecycle.consume(value);
+          }
+          lifecycle.close();
+          groups++;
+        }
+        lifecycle.finish();
+        completedProcessing = true;
+        return groups;
+      } catch (IllegalStateException e) {
+        throw new IOException(e.getMessage(), e);
+      }
+    }
+
+    private boolean moveNextInternal() throws IOException {
+      return valuesIter.moveToNext();
+    }
+
+    private static final class KeyGroupLifecycle {
+      private final Consumer<BytesWritable> openNewKey;
+      private final Consumer<BytesWritable> consumeValue;
+      private final Runnable closeCurrentKey;
+      private boolean keyOpen;
+      private boolean hasConsumedValueForCurrentKey;
+
+      private KeyGroupLifecycle(Consumer<BytesWritable> openNewKey,
+                                Consumer<BytesWritable> consumeValue,
+                                Runnable closeCurrentKey) {
+        this.openNewKey = openNewKey;
+        this.consumeValue = consumeValue;
+        this.closeCurrentKey = closeCurrentKey;
+      }
+
+      private void open(BytesWritable key) {
+        if (keyOpen) {
+          throw new IllegalStateException("openNewKey cannot be called while another key-group is active");
+        }
+        openNewKey.accept(key);
+        keyOpen = true;
+        hasConsumedValueForCurrentKey = false;
+      }
+
+      private void consume(BytesWritable value) {
+        if (!keyOpen) {
+          throw new IllegalStateException("consumeValue cannot be called without an active key-group");
+        }
+        consumeValue.accept(value);
+        hasConsumedValueForCurrentKey = true;
+      }
+
+      private void close() {
+        if (!keyOpen) {
+          throw new IllegalStateException("closeCurrentKey cannot be called without an active key-group");
+        }
+        if (!hasConsumedValueForCurrentKey) {
+          throw new IllegalStateException("closeCurrentKey cannot be called for an empty key-group");
+        }
+        closeCurrentKey.run();
+        keyOpen = false;
+      }
+
+      private void finish() {
+        if (keyOpen) {
+          throw new IllegalStateException("Unclosed key-group detected at end of consumeAll");
+        }
+      }
     }
   };
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -257,10 +257,12 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
     }
     @SuppressWarnings("rawtypes")
     ValuesIterator valuesIter = null;
+    TezRawKeyValueIterator rawIteratorForReader;
     synchronized(this) {
       valuesIter = vIter;
+      rawIteratorForReader = rawIter;
     }
-    return new OrderedGroupedKeyValuesReader(valuesIter);
+    return new OrderedGroupedKeyValuesReader(valuesIter, rawIteratorForReader);
   }
 
   @Override
@@ -311,11 +313,13 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
   private static class OrderedGroupedKeyValuesReader extends KeyValuesReaderEdge {
 
     private final ValuesIterator valuesIter;
+    private final TezRawKeyValueIterator rawIterator;
     private boolean usedNextApi;
     private boolean usedConsumeAllApi;
 
-    OrderedGroupedKeyValuesReader(ValuesIterator valuesIter) {
+    OrderedGroupedKeyValuesReader(ValuesIterator valuesIter, TezRawKeyValueIterator rawIterator) {
       this.valuesIter = valuesIter;
+      this.rawIterator = rawIterator;
     }
 
     @Override
@@ -352,7 +356,6 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
 
       final KeyGroupLifecycle lifecycle = new KeyGroupLifecycle(openNewKey, consumeValue, closeCurrentKey);
       try {
-        TezRawKeyValueIterator rawIterator = valuesIter.getRawIterator();
         if (rawIterator instanceof GroupedConsumeTezRawKeyValueIterator) {
           long groups = ((GroupedConsumeTezRawKeyValueIterator) rawIterator)
               .consumeAllGrouped(lifecycle::open, lifecycle::consume, lifecycle::close);


### PR DESCRIPTION
### Motivation
- Provide an efficient event-stream grouped consumption API for ordered-grouped inputs to avoid materializing per-key Iterables and to stream values per key-group with a strict lifecycle (open/consume/close).
- Push grouped decode work down into IFile/InMemoryReader and the merge layer so merge+shuffle can emit key-group events without extra buffering.

### Description
- Added a new API on `KeyValuesReaderEdge`: `long consumeAll(Consumer<BytesWritable> openNewKey, Consumer<BytesWritable> consumeValue, Runnable closeCurrentKey)` with a documented lifecycle and a default fallback implementation that returns the number of key-groups consumed.
- Extended `IFile.KeyValueReaderBytesWritable` with `consumeAllGrouped(...)` and implemented grouped decoding in `IFile.Reader` using the existing RLE/non-RLE logic while preserving byte immutability semantics.
- Implemented `consumeAllGrouped(...)` in the in-memory shuffle reader (`InMemoryReader`) to support grouped emission from memory-backed segments.
- Introduced `GroupedConsumeTezRawKeyValueIterator` bridge and implemented it in merge iterators (`TezMerger.MergeQueue` and empty iterator) to allow a fast-path delegation from `OrderedGroupedKVInput` to raw merge iterators for efficient streaming across segments.
- Wired the reader in `OrderedGroupedKVInput` to: enforce mutual exclusivity between `next()` and `consumeAll(...)`, provide a zero-input fast return of 0, fast-path to raw grouped iterators when available, and a safe fallback that drives the existing `ValuesIterator`; implemented strict lifecycle validation (errors on open twice, consume outside open/close, close without active key or on empty group).

### Testing
- Ran `git diff --check` and verified there are no whitespace/patch errors (passed).
- Attempted a focused `mvn -pl tez-runtime-library -DskipTests compile`; the build failed in this environment due to an external Maven plugin artifact resolution error (`com.github.os72:protoc-jar-maven-plugin:3.11.4` returned HTTP 403), not due to compilation errors in the applied code changes in this tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3efbd31c8328a016d9e352243aed)