### PR TITLE
Add ordered-group consumeAll API with in-memory zero-copy fast path

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
@@ -19,6 +19,7 @@
 package org.apache.tez.runtime.library.api;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.tez.runtime.api.ReaderEdge;
@@ -42,4 +43,31 @@ public abstract class KeyValuesReaderEdge extends KeyValuesReader implements Rea
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   @Override
   public abstract Iterable<BytesWritable> getCurrentValues() throws IOException;
+
+  /**
+   * Consume all records while preserving ordered-grouped semantics.
+   *
+   * <p>The callbacks are invoked in this order:
+   * <ul>
+   *   <li>{@code openNewKey.accept(key)} once for each key group,</li>
+   *   <li>{@code consumeValue.accept(value)} for each value in the group,</li>
+   *   <li>{@code closeCurrentKey.run()} when the key group is complete.</li>
+   * </ul>
+   *
+   * @return number of values consumed
+   */
+  public long consumeAll(Consumer<BytesWritable> openNewKey,
+                         Consumer<BytesWritable> consumeValue,
+                         Runnable closeCurrentKey) throws IOException {
+    long consumed = 0;
+    while (next()) {
+      openNewKey.accept(getCurrentKey());
+      for (BytesWritable value : getCurrentValues()) {
+        consumeValue.accept(value);
+        consumed++;
+      }
+      closeCurrentKey.run();
+    }
+    return consumed;
+  }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -21,6 +21,7 @@ package org.apache.tez.runtime.library.common;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -137,6 +138,29 @@ public class ValuesIterator {
     };
   }
 
+  /**
+   * Consume all key groups in order, preserving key-group boundaries.
+   *
+   * @return number of values consumed
+   */
+  public long consumeAll(Consumer<BytesWritable> openNewKey,
+                         Consumer<BytesWritable> consumeValue,
+                         Runnable closeCurrentKey) throws IOException {
+    long consumed = 0;
+    while (moveToNext()) {
+      openNewKey.accept(getKey());
+      while (hasMoreValues) {
+        readNextValue();
+        readNextKey();
+        inputValueCounter.increment(1);
+        consumeValue.accept(value);
+        consumed++;
+      }
+      closeCurrentKey.run();
+    }
+    return consumed;
+  }
+
   /** Start processing next unique key. */
   private void nextKey() throws IOException {
     // read until we find a new key
@@ -159,7 +183,7 @@ public class ValuesIterator {
     if (more) {      
       DataInputBuffer nextKeyBytes = in.getKey();
       if (!in.isSameKey()) {
-        nextKey = copyToWritable(nextKey, nextKeyBytes);
+        nextKey = copyToWritable(nextKey, nextKeyBytes, in.hasStableCurrentBuffer());
         // hasMoreValues = is it first key or is key the same?
         hasMoreValues = (key == null) || (TezBytesComparator.compare(key, nextKey) == 0);
         if (key == null || !hasMoreValues) {
@@ -184,10 +208,11 @@ public class ValuesIterator {
    */
   private void readNextValue() throws IOException {
     DataInputBuffer nextValueBytes = in.getValue();
-    value = copyToWritable(value, nextValueBytes);
+    value = copyToWritable(value, nextValueBytes, in.hasStableCurrentBuffer());
   }
 
-  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source) {
+  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source,
+                                       boolean useDirect) {
     BytesWritable target = writable;
     if (target == null) {
       target = new BytesWritable();
@@ -195,8 +220,12 @@ public class ValuesIterator {
 
     int pos = source.getPosition();
     int length = source.getLength() - pos;
-    byte[] bytes = target.reinitialize(length);
-    System.arraycopy(source.getData(), pos, bytes, 0, length);
+    if (useDirect) {
+      target.setDirect(source.getData(), pos, length);
+    } else {
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
+    }
 
     return target;
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -423,6 +423,11 @@ public class TezMerger {
       return true;
     }
 
+    @Override
+    public boolean hasStableCurrentBuffer() {
+      return minSegment != null && minSegment.inMemory();
+    }
+
     int compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
       byte[] b1 = nextKey.getData();
       byte[] b2 = buf2.getData();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -74,4 +74,16 @@ public interface TezRawKeyValueIterator {
    */
   // false negatives are allowed: two keys are the same, but isSameKey() returns false
   boolean isSameKey();
+
+  /**
+   * Whether the current key/value pair points to an in-memory backing buffer
+   * that can be safely exposed via zero-copy APIs.
+   *
+   * Implementations should return {@code true} only when the backing array is
+   * stable and will not be overwritten/reused while consumers may still hold
+   * references to it.
+   */
+  default boolean hasStableCurrentBuffer() {
+    return false;
+  }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -319,6 +320,13 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
     @SuppressWarnings("unchecked")
     public Iterable<BytesWritable> getCurrentValues() throws IOException {
       return valuesIter.getValues();
+    }
+
+    @Override
+    public long consumeAll(Consumer<BytesWritable> openNewKey,
+                           Consumer<BytesWritable> consumeValue,
+                           Runnable closeCurrentKey) throws IOException {
+      return valuesIter.consumeAll(openNewKey, consumeValue, closeCurrentKey);
     }
   };
 


### PR DESCRIPTION
### Motivation
- Reduce per-record byte[] allocations during ordered grouped key/value iteration by providing a grouped bulk consumer path that can expose in-memory buffers without copying.
- Provide a zero-copy fast path for data originating from stable in-memory readers while preserving immutability guarantees for reusable/disk-backed buffers.
- Preserve existing unordered `consumeAll(BiConsumer<k,v>)` semantics and ensure grouping correctness across merge boundaries.

### Description
- Added an ordered-group specific bulk API to `KeyValuesReaderEdge`: `consumeAll(Consumer<BytesWritable> openNewKey, Consumer<BytesWritable> consumeValue, Runnable closeCurrentKey)` that invokes `openNewKey` once per key group, then `consumeValue` for each value, and `closeCurrentKey` when the group ends.
- Implemented `ValuesIterator.consumeAll(...)` to drain key groups in-order while preserving grouped semantics, input counters, and merge-spanning key coverage, and wired `OrderedGroupedKVInput.OrderedGroupedKeyValuesReader` to delegate to it.
- Introduced `TezRawKeyValueIterator.hasStableCurrentBuffer()` (default `false`) so iterators can signal when the current record buffer is stable for zero-copy exposure, and implemented it in `TezMerger.MergeQueue` to return `true` for in-memory segments only.
- Added a selective zero-copy path in `ValuesIterator.copyToWritable(...)` that calls `BytesWritable.setDirect(...)` when `in.hasStableCurrentBuffer()` is true, falling back to the safe copy path (`reinitialize` + `System.arraycopy`) otherwise.

### Testing
- Attempted to compile the runtime library using `mvn -pl tez-runtime-library -DskipTests compile`; the build failed due to external dependency resolution (HTTP 403 fetching `com.github.os72:protoc-jar-maven-plugin`), so a full compile verification could not complete in this environment.
- No automated unit/integration tests were run in this environment due to the dependency resolution failure; runtime behavior should be validated in CI/build environments where dependencies are resolvable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efff58a78083289fcbde0589528659)