### PR TITLE
Refactor grouped consume to propagate checked exceptions

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
@@ -25,6 +25,12 @@ import org.apache.tez.runtime.api.ReaderEdge;
 
 public abstract class KeyValuesReaderEdge extends KeyValuesReader implements ReaderEdge {
 
+  public interface KeyGroupConsumer {
+    void startKey(BytesWritable key) throws IOException;
+    void consumeValue(BytesWritable value) throws IOException;
+    void endKey() throws IOException;
+  }
+
   /**
    * Returns the current key
    * @return the current key
@@ -42,4 +48,9 @@ public abstract class KeyValuesReaderEdge extends KeyValuesReader implements Rea
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   @Override
   public abstract Iterable<BytesWritable> getCurrentValues() throws IOException;
+
+  public long consumeAll(KeyGroupConsumer consumer) throws IOException {
+    throw new UnsupportedOperationException(
+        "consumeAll(KeyGroupConsumer) is not supported by " + getClass().getName());
+  }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java
@@ -26,9 +26,14 @@ import org.apache.tez.runtime.api.ReaderEdge;
 public abstract class KeyValuesReaderEdge extends KeyValuesReader implements ReaderEdge {
 
   public interface KeyGroupConsumer {
-    void startKey(BytesWritable key) throws IOException;
-    void consumeValue(BytesWritable value) throws IOException;
-    void endKey() throws IOException;
+    void startKey(BytesWritable key) throws Exception;
+    void consumeValue(BytesWritable value) throws Exception;
+    void endKey() throws Exception;
+  }
+
+  @FunctionalInterface
+  public interface ThrowingConsumer<T> {
+    void accept(T t) throws Exception;
   }
 
   /**
@@ -49,7 +54,7 @@ public abstract class KeyValuesReaderEdge extends KeyValuesReader implements Rea
   @Override
   public abstract Iterable<BytesWritable> getCurrentValues() throws IOException;
 
-  public long consumeAll(KeyGroupConsumer consumer) throws IOException {
+  public long consumeAll(KeyGroupConsumer consumer) throws Exception {
     throw new UnsupportedOperationException(
         "consumeAll(KeyGroupConsumer) is not supported by " + getClass().getName());
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -138,7 +138,7 @@ public class ValuesIterator {
     };
   }
 
-  public long consumeAll(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws IOException {
+  public long consumeAll(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
     if (in.supportsOrderedGroupedConsume()) {
       long consumedValues = in.consumeOrderedGrouped(consumer);
       completedProcessing = true;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -25,6 +25,7 @@ import java.util.NoSuchElementException;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.counters.TezCounter;
+import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
 import org.apache.tez.runtime.library.common.comparator.TezBytesComparator;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
@@ -135,6 +136,25 @@ public class ValuesIterator {
         };
       }
     };
+  }
+
+  public long consumeAll(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws IOException {
+    if (in.supportsOrderedGroupedConsume()) {
+      long consumedValues = in.consumeOrderedGrouped(consumer);
+      completedProcessing = true;
+      return consumedValues;
+    }
+
+    long consumedValues = 0;
+    while (moveToNext()) {
+      consumer.startKey(getKey());
+      for (BytesWritable currentValue : getValues()) {
+        consumer.consumeValue(currentValue);
+        consumedValues++;
+      }
+      consumer.endKey();
+    }
+    return consumedValues;
   }
 
   /** Start processing next unique key. */

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -21,13 +21,13 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
+import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
@@ -414,7 +414,8 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
   @Override
   public IFile.KeyStateCount consumeValuesForCurrentKey(
-      BytesWritable key, BytesWritable value, Consumer<BytesWritable> consumer) throws IOException {
+      BytesWritable key, BytesWritable value, KeyValuesReaderEdge.ThrowingConsumer<BytesWritable> consumer)
+      throws Exception {
     long count = 0;
     KeyState nextKeyState;
     if (isRleEnabled) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -21,6 +21,7 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
@@ -369,6 +370,11 @@ public class InMemoryReader implements IFile.KeyValueReader {
     ++recNo;
   }
 
+  @Override
+  public boolean supportsImmutableRawKeyBuffer() {
+    return true;
+  }
+
   public void nextRawValue(BytesWritable value) throws IOException {
     int pos = memDataIn.getPosition();
     byte[] data = memDataIn.getData();
@@ -404,6 +410,29 @@ public class InMemoryReader implements IFile.KeyValueReader {
       }
     }
     return recordCount;
+  }
+
+  @Override
+  public IFile.KeyStateCount consumeValuesForCurrentKey(
+      BytesWritable key, BytesWritable value, Consumer<BytesWritable> consumer) throws IOException {
+    long count = 0;
+    KeyState nextKeyState;
+    if (isRleEnabled) {
+      do {
+        nextRawValue(value);
+        consumer.accept(value);
+        count++;
+        nextKeyState = readRawKeyRle(key);
+      } while (nextKeyState == KeyState.SAME_KEY);
+    } else {
+      do {
+        nextRawValue(value);
+        consumer.accept(value);
+        count++;
+        nextKeyState = readRawKeyNoRle(key);
+      } while (nextKeyState == KeyState.SAME_KEY);
+    }
+    return new IFile.KeyStateCount(nextKeyState, count);
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.BytesWritable;
@@ -902,23 +903,59 @@ public class IFile {
     void close() throws IOException;
   }
 
+  // If KeyValueReaderBase implements both KeyValueReaderDataInputBuffer and KeyValueReaderBytesWritable,
+  // mixing DataInputBuffer and BytesWritable key/value APIs is allowed.
+  // Example: readRawKey(DataInputBuffer) + nextRawValue(BytesWritable) is valid.
+
   public interface KeyValueReaderDataInputBuffer extends KeyValueReaderBase {
+
     Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
+
     void nextRawValue(DataInputBuffer value) throws IOException;
+
+    default boolean supportsImmutableRawKeyBuffer() {
+      return false;
+    }
+  }
+
+  public static class KeyStateCount {
+    public final Reader.KeyState keyState;
+    public final long count;
+
+    public KeyStateCount(Reader.KeyState keyState, long count) {
+      this.keyState = keyState;
+      this.count = count;
+    }
   }
 
   public interface KeyValueReaderBytesWritable extends KeyValueReaderBase {
     // Contract: readRawKey()/nextRawValue() and consumeAll() are mutually exclusive and must not be mixed.
+
     // Invariant: key already contains the previous key read from this stream.
     // On the first call, key can be any BytesWritable instance.
     // After readRawKey() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.
     Reader.KeyState readRawKey(BytesWritable key) throws IOException;
+
     // After readRawValue() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.
     void nextRawValue(BytesWritable value) throws IOException;
 
     // Retrieves all key/value pairs, where both BytesWritable arguments are backed by immutable byte[] arrays.
     // consumeAll() must not be mixed with readRawKey()/nextRawValue().
     long consumeAll(KeyValueReaderEdge.ThrowingBiConsumer<BytesWritable, BytesWritable> consumer) throws Exception;
+
+    // Contract: key currently stores this key-group key and is updated to the next key when NEW_KEY is returned.
+    default KeyStateCount consumeValuesForCurrentKey(
+        BytesWritable key, BytesWritable value, Consumer<BytesWritable> consumer) throws IOException {
+      Reader.KeyState nextKeyState;
+      long count = 0;
+      do {
+        nextRawValue(value);
+        consumer.accept(value);
+        count++;
+        nextKeyState = readRawKey(key);
+      } while (nextKeyState == Reader.KeyState.SAME_KEY);
+      return new KeyStateCount(nextKeyState, count);
+    }
   }
 
   public interface KeyValueReader extends KeyValueReaderDataInputBuffer, KeyValueReaderBytesWritable {
@@ -1470,6 +1507,29 @@ public class IFile {
         }
       }
       return numRecordsRead;
+    }
+
+    @Override
+    public KeyStateCount consumeValuesForCurrentKey(
+        BytesWritable key, BytesWritable value, Consumer<BytesWritable> consumer) throws IOException {
+      long count = 0;
+      KeyState nextKeyState;
+      if (isRleEnabled) {
+        do {
+          nextRawValue(value);
+          consumer.accept(value);
+          count++;
+          nextKeyState = readRawKeyRle(key);
+        } while (nextKeyState == KeyState.SAME_KEY);
+      } else {
+        do {
+          nextRawValue(value);
+          consumer.accept(value);
+          count++;
+          nextKeyState = readRawKeyNoRle(key);
+        } while (nextKeyState == KeyState.SAME_KEY);
+      }
+      return new KeyStateCount(nextKeyState, count);
     }
 
     private static void verifyHeaderMagic(byte[] header) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -25,7 +25,6 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.BytesWritable;
@@ -34,6 +33,7 @@ import org.apache.tez.runtime.api.TaskContext;
 import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.api.TezTaskOutput;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
+import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -945,7 +945,8 @@ public class IFile {
 
     // Contract: key currently stores this key-group key and is updated to the next key when NEW_KEY is returned.
     default KeyStateCount consumeValuesForCurrentKey(
-        BytesWritable key, BytesWritable value, Consumer<BytesWritable> consumer) throws IOException {
+        BytesWritable key, BytesWritable value, KeyValuesReaderEdge.ThrowingConsumer<BytesWritable> consumer)
+        throws Exception {
       Reader.KeyState nextKeyState;
       long count = 0;
       do {
@@ -1511,7 +1512,8 @@ public class IFile {
 
     @Override
     public KeyStateCount consumeValuesForCurrentKey(
-        BytesWritable key, BytesWritable value, Consumer<BytesWritable> consumer) throws IOException {
+        BytesWritable key, BytesWritable value, KeyValuesReaderEdge.ThrowingConsumer<BytesWritable> consumer)
+        throws Exception {
       long count = 0;
       KeyState nextKeyState;
       if (isRleEnabled) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -18,6 +18,7 @@
 package org.apache.tez.runtime.library.common.sort.impl;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -33,6 +34,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -40,6 +42,7 @@ import org.apache.hadoop.util.PriorityQueue;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
+import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.comparator.TezBytesComparator;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
@@ -660,6 +663,112 @@ public class TezMerger {
       }
 
       return true;
+    }
+
+    @Override
+    public boolean supportsOrderedGroupedConsume() {
+      return true;
+    }
+
+    @Override
+    public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws IOException {
+      BytesWritable groupedKey = new BytesWritable();
+      BytesWritable groupedValue = new BytesWritable();
+      DataInputBuffer groupedValueBuffer = new DataInputBuffer();
+      DataInputBuffer groupedNextKey = new DataInputBuffer();
+      long consumedValues = 0;
+
+      while (hasNext()) {
+        Segment firstSegment = pop();
+        KeyValueBuffer currentKey = firstSegment.getKey();
+        if (firstSegment.reader.supportsImmutableRawKeyBuffer()) {
+          groupedKey.setDirect(currentKey.getData(), currentKey.getPosition(), currentKey.getLength());
+        } else {
+          copyToWritable(groupedKey, currentKey);
+        }
+        consumer.startKey(groupedKey);
+
+        List<Segment> groupedSegments = new ArrayList<Segment>();
+        groupedSegments.add(firstSegment);
+        Segment candidate = top();
+        while (candidate != null) {
+          KeyValueBuffer candidateKey = candidate.getKey();
+          if (TezBytesComparator.compare(
+              candidateKey.getData(), candidateKey.getPosition(), candidateKey.getLength(),
+              currentKey.getData(), currentKey.getPosition(), currentKey.getLength()) != 0) {
+            break;
+          }
+          groupedSegments.add(pop());
+          candidate = top();
+        }
+
+        for (Segment segment : groupedSegments) {
+          if (segment.reader instanceof IFile.KeyValueReaderBytesWritable) {
+            BytesWritable segmentKey = new BytesWritable();
+            KeyValueBuffer segmentCurrentKey = segment.getKey();
+            segmentKey.setDirect(
+                segmentCurrentKey.getData(), segmentCurrentKey.getPosition(), segmentCurrentKey.getLength());
+            IFile.KeyStateCount keyStateCount;
+            try {
+              // Deliberately mixed API usage:
+              // segment keys are tracked via DataInputBuffer in MergeQueue, while values can be drained
+              // through BytesWritable for lower-copy delivery when supported by the reader.
+              keyStateCount = ((IFile.KeyValueReaderBytesWritable) segment.reader)
+                  .consumeValuesForCurrentKey(segmentKey, groupedValue, value -> {
+                    try {
+                      consumer.consumeValue(value);
+                    } catch (IOException ioe) {
+                      throw new UncheckedIOException(ioe);
+                    }
+                  });
+            } catch (UncheckedIOException uioe) {
+              throw uioe.getCause();
+            }
+            consumedValues += keyStateCount.count;
+            if (keyStateCount.keyState == KeyState.NEW_KEY) {
+              segment.getKey().reset(segmentKey.getBytesRaw(), segmentKey.getOffset(), segmentKey.getLength());
+              put(segment);
+            } else {
+              segment.close();
+            }
+          } else {
+            while (true) {
+              segment.nextRawValue(groupedValueBuffer);
+              copyToWritable(groupedValue, groupedValueBuffer);
+              consumer.consumeValue(groupedValue);
+              consumedValues++;
+
+              KeyState keyState = segment.readRawKey(groupedNextKey);
+              if (keyState == KeyState.SAME_KEY) {
+                continue;
+              }
+              if (keyState == KeyState.NEW_KEY) {
+                put(segment);
+              } else {
+                segment.close();
+              }
+              break;
+            }
+          }
+        }
+
+        consumer.endKey();
+        minSegment = null;
+      }
+      return consumedValues;
+    }
+
+    private static void copyToWritable(BytesWritable writable, DataInputBuffer source) {
+      int position = source.getPosition();
+      int length = source.getLength() - position;
+      byte[] bytes = writable.reinitialize(length);
+      System.arraycopy(source.getData(), position, bytes, 0, length);
+    }
+
+    private static void copyToWritable(BytesWritable writable, KeyValueBuffer source) {
+      int length = source.getLength();
+      byte[] bytes = writable.reinitialize(length);
+      System.arraycopy(source.getData(), source.getPosition(), bytes, 0, length);
     }
 
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -18,7 +18,6 @@
 package org.apache.tez.runtime.library.common.sort.impl;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -671,7 +670,7 @@ public class TezMerger {
     }
 
     @Override
-    public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws IOException {
+    public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
       BytesWritable groupedKey = new BytesWritable();
       BytesWritable groupedValue = new BytesWritable();
       DataInputBuffer groupedValueBuffer = new DataInputBuffer();
@@ -708,22 +707,11 @@ public class TezMerger {
             KeyValueBuffer segmentCurrentKey = segment.getKey();
             segmentKey.setDirect(
                 segmentCurrentKey.getData(), segmentCurrentKey.getPosition(), segmentCurrentKey.getLength());
-            IFile.KeyStateCount keyStateCount;
-            try {
-              // Deliberately mixed API usage:
-              // segment keys are tracked via DataInputBuffer in MergeQueue, while values can be drained
-              // through BytesWritable for lower-copy delivery when supported by the reader.
-              keyStateCount = ((IFile.KeyValueReaderBytesWritable) segment.reader)
-                  .consumeValuesForCurrentKey(segmentKey, groupedValue, value -> {
-                    try {
-                      consumer.consumeValue(value);
-                    } catch (IOException ioe) {
-                      throw new UncheckedIOException(ioe);
-                    }
-                  });
-            } catch (UncheckedIOException uioe) {
-              throw uioe.getCause();
-            }
+            // Deliberately mixed API usage:
+            // segment keys are tracked via DataInputBuffer in MergeQueue, while values can be drained
+            // through BytesWritable for lower-copy delivery when supported by the reader.
+            IFile.KeyStateCount keyStateCount = ((IFile.KeyValueReaderBytesWritable) segment.reader)
+                .consumeValuesForCurrentKey(segmentKey, groupedValue, consumer::consumeValue);
             consumedValues += keyStateCount.count;
             if (keyStateCount.keyState == KeyState.NEW_KEY) {
               segment.getKey().reset(segmentKey.getBytesRaw(), segmentKey.getOffset(), segmentKey.getLength());

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -80,7 +80,7 @@ public interface TezRawKeyValueIterator {
     return false;
   }
 
-  default long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws IOException {
+  default long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
     throw new UnsupportedOperationException("Ordered grouped consume is not supported");
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -20,6 +20,7 @@ package org.apache.tez.runtime.library.common.sort.impl;
 import java.io.IOException;
 
 import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.api.KeyValuesReaderEdge;
 
 /**
  * <code>TezRawKeyValueIterator</code> is an iterator used to iterate over
@@ -74,4 +75,12 @@ public interface TezRawKeyValueIterator {
    */
   // false negatives are allowed: two keys are the same, but isSameKey() returns false
   boolean isSameKey();
+
+  default boolean supportsOrderedGroupedConsume() {
+    return false;
+  }
+
+  default long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws IOException {
+    throw new UnsupportedOperationException("Ordered grouped consume is not supported");
+  }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -320,6 +320,11 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput implements Logic
     public Iterable<BytesWritable> getCurrentValues() throws IOException {
       return valuesIter.getValues();
     }
+
+    @Override
+    public long consumeAll(KeyGroupConsumer consumer) throws IOException {
+      return valuesIter.consumeAll(consumer);
+    }
   };
 
   private static final Set<String> confKeys = new HashSet<String>();


### PR DESCRIPTION
### Motivation
- Remove the `UncheckedIOException` wrap/unwrap hack in grouped-value draining so checked exceptions can be propagated naturally. 
- Allow consumer callbacks used by fast-path readers to throw checked exceptions so callers don't need local try/catch glue. 

### Description
- Updated `KeyValuesReaderEdge.KeyGroupConsumer` so `startKey`, `consumeValue`, and `endKey` throw `Exception`, and added a `ThrowingConsumer<T>` functional interface in `tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesReaderEdge.java`.
- Broadened grouped-consume signatures to throw `Exception` in `ValuesIterator.consumeAll` and `TezRawKeyValueIterator.consumeOrderedGrouped` to propagate exceptions through the call chain.
- Simplified `TezMerger.consumeOrderedGrouped` by removing the `UncheckedIOException` conversion and invoking the consumer directly via method reference (`consumer::consumeValue`) for the `IFile.KeyValueReaderBytesWritable` fast path, and removed the unused `UncheckedIOException` import.
- Adjusted `consumeAll` default/unsupported implementations to match the new checked-exception propagation.

### Testing
- Attempted to compile the `tez-runtime-library` module using `mvn -pl tez-runtime-library -DskipTests compile`, which failed due to Maven plugin resolution (HTTP 403 fetching `com.github.os72:protoc-jar-maven-plugin:3.11.4`), so the module build could not be validated in this environment.
- No automated unit tests were run due to the interrupted build; no test failures were observed in local code edits prior to the build attempt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e540eac08328864b7fbf60caa1af)