### PR TITLE
Use immutable BytesWritable snapshots when starting grouped consumption

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -158,7 +158,9 @@ public class ValuesIterator {
 
     long consumedValues = 0;
     while (moveToNext()) {
-      consumer.startKey(getKey());
+      BytesWritable groupedKeySnapshot = new BytesWritable();
+      groupedKeySnapshot.set(getKey());
+      consumer.startKey(groupedKeySnapshot);
       for (BytesWritable currentValue : getValues()) {
         consumer.consumeValue(currentValue);
         consumedValues++;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -672,6 +672,7 @@ public class TezMerger {
     @Override
     public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
       BytesWritable groupedKey = new BytesWritable();
+      BytesWritable groupedKeySnapshot = new BytesWritable();
       BytesWritable groupedValue = new BytesWritable();
       DataInputBuffer groupedValueBuffer = new DataInputBuffer();
       DataInputBuffer groupedNextKey = new DataInputBuffer();
@@ -685,7 +686,8 @@ public class TezMerger {
         } else {
           copyToWritable(groupedKey, currentKey);
         }
-        consumer.startKey(groupedKey);
+        groupedKeySnapshot.set(groupedKey);
+        consumer.startKey(groupedKeySnapshot);
 
         List<Segment> groupedSegments = new ArrayList<Segment>();
         groupedSegments.add(firstSegment);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -671,7 +671,6 @@ public class TezMerger {
 
     @Override
     public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
-      BytesWritable groupedKey = new BytesWritable();
       BytesWritable groupedKeySnapshot = new BytesWritable();
       BytesWritable groupedValue = new BytesWritable();
       DataInputBuffer groupedValueBuffer = new DataInputBuffer();
@@ -681,12 +680,7 @@ public class TezMerger {
       while (hasNext()) {
         Segment firstSegment = pop();
         KeyValueBuffer currentKey = firstSegment.getKey();
-        if (firstSegment.reader.supportsImmutableRawKeyBuffer()) {
-          groupedKey.setDirect(currentKey.getData(), currentKey.getPosition(), currentKey.getLength());
-        } else {
-          copyToWritable(groupedKey, currentKey);
-        }
-        groupedKeySnapshot.set(groupedKey);
+        copyToWritable(groupedKeySnapshot, currentKey);
         consumer.startKey(groupedKeySnapshot);
 
         List<Segment> groupedSegments = new ArrayList<Segment>();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -696,7 +696,8 @@ public class TezMerger {
           KeyValueBuffer candidateKey = candidate.getKey();
           if (TezBytesComparator.compare(
               candidateKey.getData(), candidateKey.getPosition(), candidateKey.getLength(),
-              currentKey.getData(), currentKey.getPosition(), currentKey.getLength()) != 0) {
+              groupedKeySnapshot.getBytesRaw(), groupedKeySnapshot.getOffset(),
+              groupedKeySnapshot.getLength()) != 0) {
             break;
           }
           groupedSegments.add(pop());

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -671,7 +671,6 @@ public class TezMerger {
 
     @Override
     public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
-      BytesWritable groupedKey = new BytesWritable();
       BytesWritable groupedKeySnapshot = new BytesWritable();
       BytesWritable groupedValue = new BytesWritable();
       DataInputBuffer groupedValueBuffer = new DataInputBuffer();
@@ -682,11 +681,10 @@ public class TezMerger {
         Segment firstSegment = pop();
         KeyValueBuffer currentKey = firstSegment.getKey();
         if (firstSegment.reader.supportsImmutableRawKeyBuffer()) {
-          groupedKey.setDirect(currentKey.getData(), currentKey.getPosition(), currentKey.getLength());
+          groupedKeySnapshot.setDirect(currentKey.getData(), currentKey.getPosition(), currentKey.getLength());
         } else {
-          copyToWritable(groupedKey, currentKey);
+          copyToWritable(groupedKeySnapshot, currentKey);
         }
-        groupedKeySnapshot.set(groupedKey);
         consumer.startKey(groupedKeySnapshot);
 
         List<Segment> groupedSegments = new ArrayList<Segment>();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -671,6 +671,7 @@ public class TezMerger {
 
     @Override
     public long consumeOrderedGrouped(KeyValuesReaderEdge.KeyGroupConsumer consumer) throws Exception {
+      BytesWritable groupedKey = new BytesWritable();
       BytesWritable groupedKeySnapshot = new BytesWritable();
       BytesWritable groupedValue = new BytesWritable();
       DataInputBuffer groupedValueBuffer = new DataInputBuffer();
@@ -680,7 +681,12 @@ public class TezMerger {
       while (hasNext()) {
         Segment firstSegment = pop();
         KeyValueBuffer currentKey = firstSegment.getKey();
-        copyToWritable(groupedKeySnapshot, currentKey);
+        if (firstSegment.reader.supportsImmutableRawKeyBuffer()) {
+          groupedKey.setDirect(currentKey.getData(), currentKey.getPosition(), currentKey.getLength());
+        } else {
+          copyToWritable(groupedKey, currentKey);
+        }
+        groupedKeySnapshot.set(groupedKey);
         consumer.startKey(groupedKeySnapshot);
 
         List<Segment> groupedSegments = new ArrayList<Segment>();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedMergedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedMergedKVInput.java
@@ -148,7 +148,9 @@ public class OrderedGroupedMergedKVInput extends MergedLogicalInput implements L
 
         KeyValuesReaderEdge currentReader = pQueue.poll();
         BytesWritable groupedKey = currentReader.getCurrentKey();
-        consumer.startKey(groupedKey);
+        BytesWritable groupedKeySnapshot = new BytesWritable();
+        groupedKeySnapshot.set(groupedKey);
+        consumer.startKey(groupedKeySnapshot);
 
         do {
           consumedValues += currentReader.consumeCurrentValuesOnly(consumer::consumeValue);
@@ -159,7 +161,7 @@ public class OrderedGroupedMergedKVInput extends MergedLogicalInput implements L
 
           currentReader = pQueue.peek();
           if (currentReader != null
-              && TezBytesComparator.compare(groupedKey, currentReader.getCurrentKey()) == 0) {
+              && TezBytesComparator.compare(groupedKeySnapshot, currentReader.getCurrentKey()) == 0) {
             currentReader = pQueue.poll();
           } else {
             currentReader = null;


### PR DESCRIPTION
### Motivation
- Prevent mutation of reusable `BytesWritable` key buffers from interfering with grouped consumption and key comparisons across readers.
- Ensure consumers receive a stable key instance when `startKey` is called so subsequent buffer reuse does not change delivered keys.

### Description
- In `ValuesIterator.consumeAll`, create a `BytesWritable` snapshot via `set(getKey())` and pass the snapshot to `consumer.startKey` instead of the mutable `getKey()` instance.
- In `TezMerger.consumeOrderedGrouped`, introduce `groupedKeySnapshot` and copy the current `groupedKey` into it before calling `consumer.startKey` to avoid later mutations affecting the started key.
- In `OrderedGroupedMergedKVInput.consumeAll`, create `groupedKeySnapshot` from `currentReader.getCurrentKey()`, use the snapshot for `consumer.startKey`, and use the snapshot in subsequent key comparisons.

### Testing
- Ran the module unit tests for the runtime library with `mvn -pl tez-runtime-library -DskipTests=false test`, and the tests for the modified components completed successfully.
- Verified that the grouped-consume code paths exercise both `consumeAll` and `consumeOrderedGrouped` variants and passed under the unit test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3170892cc832882033d1a1fce95a9)