### PR TITLE
Validate TezOffsetRecord presence for composite local direct fetches

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -455,9 +455,18 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
           TezIndexRecord indexRecord = spillRecord.getIndex(reduceId);
           // TODO: continue if !indexRecord.hasData()
 
+          if (fetcherConfigCommon.compositeFetch && offsetRecordMap == null) {
+            throw new IOException("Missing TezOffsetRecord map for local direct fetch: pathComponent=" + pathComponent);
+          }
+
           fetchedInput = getLocalFetchedInput(srcAttemptId, pathComponent, indexRecord, inputFilePath);
           if (offsetRecordMap != null) {
-            fetchedInput.setTezOffsetRecord(offsetRecordMap.get(reduceId));
+            TezOffsetRecord tezOffsetRecord = offsetRecordMap.get(reduceId);
+            if (fetcherConfigCommon.compositeFetch && tezOffsetRecord == null) {
+              throw new IOException("Missing TezOffsetRecord for local direct fetch: pathComponent="
+                  + pathComponent + ", reduceId=" + reduceId);
+            }
+            fetchedInput.setTezOffsetRecord(tezOffsetRecord);
           }
           long endTime = System.currentTimeMillis();
           fetcherCallback.fetchSucceeded(shuffleClientId, host, srcAttemptId, fetchedInput,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -709,9 +709,18 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
             continue;
           }
 
+          if (fetcherConfigCommon.compositeFetch && offsetRecordMap == null) {
+            throw new IOException("Missing TezOffsetRecord map for local direct fetch: pathComponent=" + pathComponent);
+          }
+
           mapOutput = getMapOutputForDirectFetch(srcAttemptId, pathComponent, inputFilePath, indexRecord);
           if (offsetRecordMap != null) {
-            mapOutput.setTezOffsetRecord(offsetRecordMap.get(reduceId));
+            TezOffsetRecord tezOffsetRecord = offsetRecordMap.get(reduceId);
+            if (fetcherConfigCommon.compositeFetch && tezOffsetRecord == null) {
+              throw new IOException("Missing TezOffsetRecord for local direct fetch: pathComponent="
+                  + pathComponent + ", reduceId=" + reduceId);
+            }
+            mapOutput.setTezOffsetRecord(tezOffsetRecord);
           }
           long endTime = System.currentTimeMillis();
           fetcherCallback.fetchSucceeded(shuffleClientId, host, srcAttemptId, mapOutput,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -1043,7 +1043,6 @@ public class IFile {
       this.dataIn = new DataInputStream(this.in);
       this.fileLength = length;
       this.isRleEnabled = isRleEnabled;
-
       assert !(tezOffsetRecord != null) || !isRleEnabled;
       this.tezOffsetRecord = tezOffsetRecord;
     }


### PR DESCRIPTION
### Motivation
- Ensure correctness and fail fast when performing local direct (composite) fetches by verifying that the `TezOffsetRecord` map and individual `TezOffsetRecord` entries are present before using them.
- Prevent potential NPEs or silent incorrect behavior when `compositeFetch` is enabled and index/offset metadata is missing.

### Description
- Added explicit validation in `FetcherUnordered` to throw an `IOException` when `compositeFetch` is enabled and the `offsetRecordMap` is missing for a `pathComponent`, and to throw when an individual `TezOffsetRecord` is missing for a `reduceId`, before calling `setTezOffsetRecord`.
- Added the same validation in `FetcherOrderedGrouped` and only set the `TezOffsetRecord` after verifying presence and throwing an `IOException` on missing data.
- Small non-functional whitespace cleanup in `IFile` constructor (no behavioral change).

### Testing
- Ran module unit tests for `tez-runtime-library` via `mvn -pl tez-runtime-library -DskipTests=false test`, and the test suite completed successfully.
- Ran existing shuffle-related unit tests locally, and they passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f41fe35e388328be15f4fe85914df3)