### PR TITLE
Fix zero-length first record handling in IFile.appendNoRleTez

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -628,11 +628,13 @@ public class IFile {
       }
 
       int lengthBytes = 0;
-      if (!keyLenTransitioned && keyLength != maxKeyLen) {
+      if (!keyLenTransitioned
+          && (keyLength != maxKeyLen || (numRecordsWritten == 0 && keyLength == 0))) {
         keyLenTransitioned = true;
         firstKeyOffset = (int) getDecompressedBytesWritten();
       }
-      if (!valLenTransitioned && valueLength != maxValLen) {
+      if (!valLenTransitioned
+          && (valueLength != maxValLen || (numRecordsWritten == 0 && valueLength == 0))) {
         valLenTransitioned = true;
         firstValOffset = (int) getDecompressedBytesWritten();
       }


### PR DESCRIPTION
### Motivation
- Ensure length-transition markers are set when the first serialized key or value is zero-length so subsequent records are encoded and decoded correctly.

### Description
- Update the transition checks in `appendNoRleTez` to mark `keyLenTransitioned` and `valLenTransitioned` when the length differs from `maxKeyLen`/`maxValLen` or when the first record has a zero-length key/value, and set `firstKeyOffset`/`firstValOffset` accordingly.

### Testing
- Ran unit tests for the runtime library module with `mvn -pl tez-runtime-library -DskipTests=false test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5622c10c083289c3ebb63bf9afff6)