### PR TITLE
Abort in-memory map outputs on shuffle errors and expose memory allocation for ordered grouped fetcher

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -534,11 +534,16 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         inputStream = byteArrayOutput.createInputStreamFrom(
             indexRecord.getStartOffset(), indexRecord.getPartLength());
       }
-      ShuffleUtils.shuffleToMemory(memoryFetchedInput.getBytes(),
-          inputStream, (int) indexRecord.getRawLength(), (int) indexRecord.getPartLength(), codec,
-          fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength, LOG,
-          memoryFetchedInput.getInputAttemptIdentifier(), taskContext, true);
-      return memoryFetchedInput;
+      try {
+        ShuffleUtils.shuffleToMemory(memoryFetchedInput.getBytes(),
+            inputStream, (int) indexRecord.getRawLength(), (int) indexRecord.getPartLength(), codec,
+            fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength, LOG,
+            memoryFetchedInput.getInputAttemptIdentifier(), taskContext, true);
+        return memoryFetchedInput;
+      } catch (IOException | RuntimeException e) {
+        memoryFetchedInput.abort();
+        throw e;
+      }
     }
 
     FetchedInput fetchedInput;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetchedInputAllocatorOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetchedInputAllocatorOrderedGrouped.java
@@ -30,6 +30,10 @@ public interface FetchedInputAllocatorOrderedGrouped {
 
   void closeInMemoryFile(MapOutput mapOutput);
 
+  MapOutput getMemoryMapOutput(InputAttemptIdentifier srcAttemptIdentifier,
+                              long requestedSize,
+                              boolean checkFreeMemory);
+
   FileSystem getLocalFileSystem();
 
   void closeOnDiskFile(FileChunk file);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -770,6 +770,34 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
   private MapOutput getMapOutputForDirectFetch(
       InputAttemptIdentifier srcAttemptId, String pathComponent, Path filename,
       TezIndexRecord indexRecord) throws IOException {
+    MapOutput memoryMapOutput = allocator.getMemoryMapOutput(srcAttemptId, indexRecord.getRawLength(), true);
+    if (memoryMapOutput != null) {
+      InputStream inputStream;
+      if (filename != null) {
+        FSDataInputStream dataInputStream = fetcherConfigCommon.localFs.open(filename);
+        dataInputStream.seek(indexRecord.getStartOffset());
+        inputStream = new BoundedInputStream(dataInputStream, indexRecord.getPartLength());
+      } else {
+        org.apache.tez.runtime.api.MultiByteArrayOutputStream byteArrayOutput =
+            taskContext.getConcurrentByteCache().get(pathComponent);
+        if (byteArrayOutput == null) {
+          throw new IOException("ConcurrentByteCache not found for pathComponent=" + pathComponent);
+        }
+        inputStream = byteArrayOutput.createInputStreamFrom(
+            indexRecord.getStartOffset(), indexRecord.getPartLength());
+      }
+      try {
+        ShuffleUtils.shuffleToMemory(memoryMapOutput.getMemory(),
+            inputStream, (int) indexRecord.getRawLength(), (int) indexRecord.getPartLength(), codec,
+            fetcherConfig.ifileReadAhead, fetcherConfig.ifileReadAheadLength, LOG,
+            srcAttemptId, taskContext, true);
+        return memoryMapOutput;
+      } catch (IOException | RuntimeException e) {
+        memoryMapOutput.abort();
+        throw e;
+      }
+    }
+
     if (filename != null) {
       return MapOutput.createLocalDiskMapOutput(srcAttemptId, allocator, filename,
           indexRecord.getStartOffset(), indexRecord.getPartLength(), true);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -404,7 +404,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     if (actualSize > maxSingleShuffleLimit) {
       if (useFreeMemoryFetchedInput) {
         synchronized (this) {
-          MapOutput result = getMemoryMapOutput(
+          MapOutput result = getMemoryMapOutputInternal(
               srcAttemptIdentifier, 0L, actualSize, true);
           if (result != null) {
             return result;
@@ -436,7 +436,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
           return stallShuffle;
         }
 
-        MapOutput result = getMemoryMapOutput(
+        MapOutput result = getMemoryMapOutputInternal(
             srcAttemptIdentifier, 0L, actualSize, false);
         if (result != null) {
           return result;
@@ -444,7 +444,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         return stallShuffle;
       } else {
         // Allow the in-memory shuffle to progress
-        MapOutput result = getMemoryMapOutput(
+        MapOutput result = getMemoryMapOutputInternal(
             srcAttemptIdentifier, actualSize, actualSize, false);
         if (result != null) {
           return result;
@@ -461,8 +461,16 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     return currentFreeMemory >= freeMemoryThreshold && this.usedMemory + actualSize <= freeMemoryLimit;
   }
 
+  @Override
+  public synchronized MapOutput getMemoryMapOutput(
+      InputAttemptIdentifier srcAttemptIdentifier,
+      long actualSize,
+      boolean checkFreeMemory) {
+    return getMemoryMapOutputInternal(srcAttemptIdentifier, 0L, actualSize, checkFreeMemory);
+  }
+
   // Invariant: inside this.synchronized{}
-  private MapOutput getMemoryMapOutput(
+  private MapOutput getMemoryMapOutputInternal(
       InputAttemptIdentifier srcAttemptIdentifier,
       long usedMemoryForMergeManager, long actualSize,
       boolean checkFreeMemory) {


### PR DESCRIPTION
### Motivation

- Prevent leaked/partially-initialized in-memory fetch objects when `ShuffleUtils.shuffleToMemory` throws an exception. 
- Allow the ordered-grouped fetcher to attempt in-memory allocation for direct/local fetches and fall back to on-disk or stream-based outputs when memory is unavailable.

### Description

- Added a try/catch around `ShuffleUtils.shuffleToMemory` in `FetcherUnordered` to call `memoryFetchedInput.abort()` on `IOException` or `RuntimeException` before rethrowing. 
- Extended the ordered-grouped fetch path in `FetcherOrderedGrouped` to attempt an in-memory `MapOutput` via a new allocator call, read into that memory with `ShuffleUtils.shuffleToMemory`, and `abort()` the `MapOutput` if `shuffleToMemory` fails. 
- Added `getMemoryMapOutput` to `FetchedInputAllocatorOrderedGrouped` and implemented a public `getMemoryMapOutput` in `MergeManager` that delegates to a refactored internal method `getMemoryMapOutputInternal` to centralize memory reservation logic and keep the previous invariant-based behavior. 
- Refactored `MergeManager` internals to expose `getMemoryMapOutputInternal`, rename the internal method, and update callers to use the new path while preserving disk fallback behavior.

### Testing

- Built the runtime library module and executed the module unit tests with `mvn -pl tez-runtime-library -DskipTests=false test` and the test suite completed successfully. 
- Verified compilation of the changed classes and that existing shuffle-related unit tests passed without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80769821083289105e38db1cb12a8)