### PR TITLE
Attach cached spill index to direct-fetch for LOCAL_BYTE_CACHE

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -38,6 +38,7 @@ import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.tez.http.HttpConnectionParams;
 import org.apache.tez.runtime.api.FetcherConfig;
 import org.apache.tez.runtime.api.FetcherConfigCommon;
+import org.apache.tez.runtime.api.IndexPathCache;
 import org.apache.tez.runtime.api.TaskContext;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
@@ -693,6 +694,14 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
             inputFilePath = pair.getValue();
           }
           TezIndexRecord indexRecord = spillRecord.getIndex(reduceId);
+          if (inputFilePath == null) {
+            IndexPathCache.MapOutputInfo mapOutputInfo = taskContext.getIndexPathCache().get(pathComponent);
+            if (mapOutputInfo == null) {
+              throw new IOException("IndexPathCache not found for pathComponent=" + pathComponent);
+            }
+            TezSpillRecord cachedSpillRecord = new TezSpillRecord(mapOutputInfo.getSpillRecord());
+            indexRecord = cachedSpillRecord.getIndex(reduceId);
+          }
           if (!indexRecord.hasData()) {
             continue;
           }


### PR DESCRIPTION
### Motivation
- Direct-fetch of map outputs sourced from `ConcurrentByteCache` (`LOCAL_BYTE_CACHE`) used an index derived from the on-disk path path resolution, which can be missing or inconsistent for the byte-cache path and lead to offset/length misinterpretation.

### Description
- Added an `IndexPathCache` import and, in `FetcherOrderedGrouped`, when `inputFilePath == null` explicitly look up `IndexPathCache.MapOutputInfo` for the `pathComponent` and rebuild a `TezSpillRecord` from the cached bytes.
- Re-derived the per-partition `TezIndexRecord` from the cached `TezSpillRecord` and used that `indexRecord` for the `hasData` check and subsequent `getMapOutputForDirectFetch` call.
- Added a defensive `IOException` when the `IndexPathCache` entry is unexpectedly missing in the `LOCAL_BYTE_CACHE` branch.

### Testing
- Ran `mvn -pl tez-runtime-library -DskipTests compile` to validate the change, but the build could not complete due to external dependency resolution failure for `com.github.os72:protoc-jar-maven-plugin:3.11.4` (Maven Central returned HTTP 403) so compilation could not be verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96e1e60f48328b125294c53924ad0)