### PR TITLE
Support streaming merge segments and add mark/reset + seek in MultiBufferRangeInputStream

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
@@ -357,11 +357,9 @@ public class MultiByteArrayOutputStream extends OutputStream {
     private final byte[][] memoryBuffers;
     private final int[] memoryBufferLengths;
     private final long memoryBytes;
-    private final long startPos;
     private final long endPos;
 
     private long globalPos;
-    private long markPos = -1L;
     private int memoryIndex;
     private int offsetInMemoryBuffer;
     private FSDataInputStream spillIn;
@@ -377,7 +375,6 @@ public class MultiByteArrayOutputStream extends OutputStream {
       this.memoryBuffers = memoryBuffers;
       this.memoryBufferLengths = memoryBufferLengths;
       this.memoryBytes = memoryBytes;
-      this.startPos = offset;
       this.globalPos = offset;
       this.endPos = offset + length;
 
@@ -489,53 +486,47 @@ public class MultiByteArrayOutputStream extends OutputStream {
 
     @Override
     public long skip(long n) throws IOException {
-      if (closed) {
-        throw new IOException("Stream closed");
-      }
       if (n <= 0) {
         return 0;
       }
-      long skipped = Math.min(n, endPos - globalPos);
-      if (skipped <= 0) {
+      long toSkip = Math.min(n, endPos - globalPos);
+      if (toSkip <= 0) {
         return 0;
       }
 
-      seekToGlobalPosition(globalPos + skipped);
+      long skipped = 0;
+      if (globalPos < memoryBytes) {
+        while (toSkip > 0 && globalPos < Math.min(memoryBytes, endPos)) {
+          int curLen = memoryBufferLengths[memoryIndex];
+          int availableInCur = curLen - offsetInMemoryBuffer;
+          if (availableInCur <= 0) {
+            memoryIndex++;
+            offsetInMemoryBuffer = 0;
+            continue;
+          }
+          int jump = (int) Math.min((long) availableInCur, toSkip);
+          offsetInMemoryBuffer += jump;
+          globalPos += jump;
+          toSkip -= jump;
+          skipped += jump;
+        }
+      }
+
+      if (toSkip > 0 && globalPos < endPos) {
+        ensureSpillOpen();
+        long targetPosInSpill = (globalPos - memoryBytes) + toSkip;
+        spillIn.seek(targetPosInSpill);
+        globalPos += toSkip;
+        skipped += toSkip;
+      }
+
       return skipped;
     }
 
     @Override
-    public int available() throws IOException {
-      if (closed) {
-        throw new IOException("Stream closed");
-      }
+    public int available() {
       long remaining = endPos - globalPos;
       return (int) Math.min(Integer.MAX_VALUE, Math.max(remaining, 0));
-    }
-
-    // Some streaming consumers (for example IFile readers/codecs layered on top of this stream)
-    // may probe and rewind bytes instead of draining the full range in a single forward-only pass.
-    // Support mark/reset by repositioning the logical stream cursor across both the memory buffers
-    // and the optional spill file.
-    @Override
-    public synchronized void mark(int readlimit) {
-      markPos = globalPos;
-    }
-
-    @Override
-    public synchronized void reset() throws IOException {
-      if (closed) {
-        throw new IOException("Stream closed");
-      }
-      if (markPos < 0) {
-        throw new IOException("Mark has not been set");
-      }
-      seekToGlobalPosition(markPos);
-    }
-
-    @Override
-    public boolean markSupported() {
-      return true;
     }
 
     @Override
@@ -552,38 +543,6 @@ public class MultiByteArrayOutputStream extends OutputStream {
     private void ensureSpillOpen() throws IOException {
       if (spillIn == null) {
         spillIn = fs.open(outputPath);
-      }
-      spillIn.seek(globalPos - memoryBytes);
-    }
-
-    private void seekToGlobalPosition(long targetPos) throws IOException {
-      if (targetPos < startPos || targetPos > endPos) {
-        throw new EOFException(String.format(
-            "Cannot seek outside stream range: target=%d, start=%d, end=%d",
-            targetPos, startPos, endPos));
-      }
-
-      globalPos = targetPos;
-      if (globalPos < memoryBytes) {
-        long scanned = 0;
-        memoryIndex = 0;
-        offsetInMemoryBuffer = 0;
-        while (memoryIndex < memoryBufferLengths.length) {
-          int currentLen = memoryBufferLengths[memoryIndex];
-          if (scanned + currentLen > globalPos) {
-            offsetInMemoryBuffer = (int) (globalPos - scanned);
-            return;
-          }
-          scanned += currentLen;
-          memoryIndex++;
-        }
-        throw new EOFException(String.format(
-            "Cannot seek to in-memory position: target=%d, memoryBytes=%d", targetPos, memoryBytes));
-      }
-
-      memoryIndex = memoryBufferLengths.length;
-      offsetInMemoryBuffer = 0;
-      if (spillIn != null && globalPos < endPos) {
         spillIn.seek(globalPos - memoryBytes);
       }
     }

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
@@ -357,9 +357,11 @@ public class MultiByteArrayOutputStream extends OutputStream {
     private final byte[][] memoryBuffers;
     private final int[] memoryBufferLengths;
     private final long memoryBytes;
+    private final long startPos;
     private final long endPos;
 
     private long globalPos;
+    private long markPos = -1L;
     private int memoryIndex;
     private int offsetInMemoryBuffer;
     private FSDataInputStream spillIn;
@@ -375,6 +377,7 @@ public class MultiByteArrayOutputStream extends OutputStream {
       this.memoryBuffers = memoryBuffers;
       this.memoryBufferLengths = memoryBufferLengths;
       this.memoryBytes = memoryBytes;
+      this.startPos = offset;
       this.globalPos = offset;
       this.endPos = offset + length;
 
@@ -486,47 +489,53 @@ public class MultiByteArrayOutputStream extends OutputStream {
 
     @Override
     public long skip(long n) throws IOException {
+      if (closed) {
+        throw new IOException("Stream closed");
+      }
       if (n <= 0) {
         return 0;
       }
-      long toSkip = Math.min(n, endPos - globalPos);
-      if (toSkip <= 0) {
+      long skipped = Math.min(n, endPos - globalPos);
+      if (skipped <= 0) {
         return 0;
       }
 
-      long skipped = 0;
-      if (globalPos < memoryBytes) {
-        while (toSkip > 0 && globalPos < Math.min(memoryBytes, endPos)) {
-          int curLen = memoryBufferLengths[memoryIndex];
-          int availableInCur = curLen - offsetInMemoryBuffer;
-          if (availableInCur <= 0) {
-            memoryIndex++;
-            offsetInMemoryBuffer = 0;
-            continue;
-          }
-          int jump = (int) Math.min((long) availableInCur, toSkip);
-          offsetInMemoryBuffer += jump;
-          globalPos += jump;
-          toSkip -= jump;
-          skipped += jump;
-        }
-      }
-
-      if (toSkip > 0 && globalPos < endPos) {
-        ensureSpillOpen();
-        long targetPosInSpill = (globalPos - memoryBytes) + toSkip;
-        spillIn.seek(targetPosInSpill);
-        globalPos += toSkip;
-        skipped += toSkip;
-      }
-
+      seekToGlobalPosition(globalPos + skipped);
       return skipped;
     }
 
     @Override
-    public int available() {
+    public int available() throws IOException {
+      if (closed) {
+        throw new IOException("Stream closed");
+      }
       long remaining = endPos - globalPos;
       return (int) Math.min(Integer.MAX_VALUE, Math.max(remaining, 0));
+    }
+
+    // Some streaming consumers (for example IFile readers/codecs layered on top of this stream)
+    // may probe and rewind bytes instead of draining the full range in a single forward-only pass.
+    // Support mark/reset by repositioning the logical stream cursor across both the memory buffers
+    // and the optional spill file.
+    @Override
+    public synchronized void mark(int readlimit) {
+      markPos = globalPos;
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+      if (closed) {
+        throw new IOException("Stream closed");
+      }
+      if (markPos < 0) {
+        throw new IOException("Mark has not been set");
+      }
+      seekToGlobalPosition(markPos);
+    }
+
+    @Override
+    public boolean markSupported() {
+      return true;
     }
 
     @Override
@@ -543,6 +552,38 @@ public class MultiByteArrayOutputStream extends OutputStream {
     private void ensureSpillOpen() throws IOException {
       if (spillIn == null) {
         spillIn = fs.open(outputPath);
+      }
+      spillIn.seek(globalPos - memoryBytes);
+    }
+
+    private void seekToGlobalPosition(long targetPos) throws IOException {
+      if (targetPos < startPos || targetPos > endPos) {
+        throw new EOFException(String.format(
+            "Cannot seek outside stream range: target=%d, start=%d, end=%d",
+            targetPos, startPos, endPos));
+      }
+
+      globalPos = targetPos;
+      if (globalPos < memoryBytes) {
+        long scanned = 0;
+        memoryIndex = 0;
+        offsetInMemoryBuffer = 0;
+        while (memoryIndex < memoryBufferLengths.length) {
+          int currentLen = memoryBufferLengths[memoryIndex];
+          if (scanned + currentLen > globalPos) {
+            offsetInMemoryBuffer = (int) (globalPos - scanned);
+            return;
+          }
+          scanned += currentLen;
+          memoryIndex++;
+        }
+        throw new EOFException(String.format(
+            "Cannot seek to in-memory position: target=%d, memoryBytes=%d", targetPos, memoryBytes));
+      }
+
+      memoryIndex = memoryBufferLengths.length;
+      offsetInMemoryBuffer = 0;
+      if (spillIn != null && globalPos < endPos) {
         spillIn.seek(globalPos - memoryBytes);
       }
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -42,6 +42,7 @@ import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
+import org.apache.tez.runtime.library.common.sort.impl.TezMerger.InputStreamSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.Segment;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFiles;
@@ -105,6 +106,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   // - 1. InputStreamMapOutput.commit()
   //      --> closeInMemoryFile()
   //      --> createMapOutputReader() creates IFile.Reader over InputStream
+  //      --> InputStreamSegment marks it as streaming, not in-memory, for merge buffer reuse
   //      --> stream is consumed while merging
   //      --> IFile.Reader.close() releases stream resources
   // - 2. InputStreamMapOutput.abort()
@@ -750,9 +752,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             }
           } else {
             mergeOutputSize += mo.getSizeForMergeMemoryAccounting();
-            IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mo);
-            inMemorySegments.add(new Segment(reader,
-                (mo.isPrimaryMapOutput() ? mergedMapOutputsCounter : null)));
+            inMemorySegments.add(createMapOutputSegment(mo));
             lastAddedMapOutput = mo;
             it.remove();
             if (isDebugEnabled) {
@@ -1050,13 +1050,20 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       long size = mo.getSizeForMergeMemoryAccounting();
       totalSize += size;
       fullSize -= size;
-      IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mo);
-      inMemorySegments.add(new Segment(reader,
-          (mo.isPrimaryMapOutput() ? mergedMapOutputsCounter : null)));
+      inMemorySegments.add(createMapOutputSegment(mo));
     }
     // Bulk remove removed in-memory map outputs efficiently
     inMemoryMapOutputs.subList(0, inMemoryMapOutputsOffset).clear();
     return totalSize;
+  }
+
+  private Segment createMapOutputSegment(MapOutput mapOutput) throws IOException {
+    IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mapOutput);
+    TezCounter mapOutputsCounter = mapOutput.isPrimaryMapOutput() ? mergedMapOutputsCounter : null;
+    if (mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE) {
+      return new InputStreamSegment(reader, mapOutputsCounter);
+    }
+    return new Segment(reader, mapOutputsCounter);
   }
 
   private IFile.KeyValueReaderDataInputBuffer createMapOutputReader(MapOutput mapOutput) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -251,6 +251,17 @@ public class TezMerger {
     }
   }
 
+  public static final class InputStreamSegment extends Segment {
+    public InputStreamSegment(IFile.KeyValueReaderDataInputBuffer reader, TezCounter mapOutputsCounter) {
+      super(reader, mapOutputsCounter);
+    }
+
+    @Override
+    boolean inMemory() {
+      return false;
+    }
+  }
+
   public static final class IntermediateMemorySegment extends Segment {
     private final MultiByteArrayOutputStream byteArrayOutput;
     private final boolean cleanupOnClose;


### PR DESCRIPTION
### Motivation
- Allow merge codepath to treat local byte-cache inputs as streaming (non-in-memory) so merge buffer reuse and IO behavior match on-disk segments.
- Improve the range input stream used for cached shuffle data to support repositioning and rewinding for consumers that probe and reset bytes.
- Harden stream behavior by validating seeks/operations against the stream range and closed state.

### Description
- Added `InputStreamSegment` (subclass of `TezMerger.Segment`) and used it for `ShuffleClient.Type.LOCAL_BYTE_CACHE` map outputs so they are treated as non-in-memory segments during merge.
- Introduced `createMapOutputSegment(MapOutput)` helper in `MergeManager` and replaced inline segment creation to return `InputStreamSegment` for `LOCAL_BYTE_CACHE` and `Segment` for other types.
- Extended `MultiByteArrayOutputStream.MultiBufferRangeInputStream` with `startPos`, `markPos`, `mark/reset` support, and `markSupported()` returning `true` so readers can rewind; added `seekToGlobalPosition(long)` to centralize seeking and position recalculation across memory buffers and spill file.
- Hardened stream operations by throwing on operations against a closed stream and making `available()` throw `IOException` when closed; `ensureSpillOpen()` now seeks the spill stream to `globalPos - memoryBytes` after opening.
- Updated `skip(long)` to use `seekToGlobalPosition(...)` and added bounds checks that throw an `EOFException` for out-of-range seeks.

### Testing
- Ran the module unit tests and the shuffle/merge related tests via the project test suite (`mvn -DskipTests=false test`); no regressions observed in merge and shuffle tests.
- Built the project packaging (`mvn -Pdist -DskipTests=false package`) to validate compilation and integration across affected modules and the packaging completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1e985a108328ad11b549e62dd460)