### PR TITLE
Optimize composite shuffle headers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -667,10 +667,12 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
       long startTime = System.currentTimeMillis();
       int partitionCount = 1;   // single partition only when using Hadoop shuffle service
 
-      // read the first part - partitionCount
+      // read the first part - partitionCount and, for composite fetches, the shared map id
+      String sharedMapId = null;
       if (fetcherConfigCommon.compositeFetch) {
         // multiple partitions are fetched
         partitionCount = input.readInt();
+        sharedMapId = ShuffleHeader.readMapId(input);
       }
 
       // read the second part - ShuffleHeader[]
@@ -684,7 +686,11 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
         // build srcAttemptId and MapOutputStat
         try {
           ShuffleHeader header = new ShuffleHeader(fetcherConfigCommon.compositeFetch);
-          header.readFields(input);
+          if (fetcherConfigCommon.compositeFetch) {
+            header.readCompositeFields(input, sharedMapId);
+          } else {
+            header.readFields(input);
+          }
           pathComponent = header.getMapId();
           if (!pathComponent.startsWith(InputAttemptIdentifier.PATH_PREFIX_MR3) && !pathComponent.startsWith(InputAttemptIdentifier.PATH_PREFIX)) {
             shuffleErrorCounterGroup.badIdErrs.increment(1);
@@ -699,15 +705,15 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
                 + " while fetching " + inputAttemptIdentifier);
           }
 
+          if (header.getCompressedLength() == 0) {
+            // empty partitions are already accounted for
+            continue;
+          }
+
           srcAttemptId = pathToAttemptMap.get(new PathPartition(pathComponent, header.getPartition()));
           if (srcAttemptId == null) {
             throw new IllegalArgumentException("Source attempt not found for map id: " + header.getMapId() +
                 ", partition: " + header.getPartition() + " while fetching " + inputAttemptIdentifier);
-          }
-
-          if (header.getCompressedLength() == 0) {
-            // empty partitions are already accounted for
-            continue;
           }
 
           mapOutputStat = new MapOutputStat(srcAttemptId,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -466,9 +466,11 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
       long startTime = System.currentTimeMillis();
       int partitionCount = 1;   // single partition only when using Hadoop shuffle service
 
+      String sharedMapId = null;
       if (fetcherConfigCommon.compositeFetch) {
         // Multiple partitions are fetched
         partitionCount = input.readInt();
+        sharedMapId = ShuffleHeader.readMapId(input);
       }
       ArrayList<MapOutputStat> mapOutputStats = new ArrayList<>(partitionCount);
       for (int mapOutputIndex = 0; mapOutputIndex < partitionCount; mapOutputIndex++) {
@@ -477,7 +479,11 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
           // Read the shuffle header
           ShuffleHeader header = new ShuffleHeader(fetcherConfigCommon.compositeFetch);
           // TODO Review: Multiple header reads in case of status WAIT ?
-          header.readFields(input);
+          if (fetcherConfigCommon.compositeFetch) {
+            header.readCompositeFields(input, sharedMapId);
+          } else {
+            header.readFields(input);
+          }
           if (!header.mapId.startsWith(InputAttemptIdentifier.PATH_PREFIX_MR3) && !header.mapId.startsWith(InputAttemptIdentifier.PATH_PREFIX)) {
             if (!stopped) {
               shuffleErrorCounterGroup.badIdErrs.increment(1);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -94,34 +94,58 @@ public class ShuffleHeader implements Writable {
 
   public void readFields(DataInput in) throws IOException {
     if (compositeFetch) {   // ShuffleHeader created by MR3 ShuffleHandler
-      int length = in.readInt();  // Cf. WritableUtils.readStringSafely() calls readVInt()
-      if (length < 0 || length > MAX_ID_LENGTH) {
-        throw new IllegalArgumentException("Encoded byte size for String was " + length +
-                                           ", which is outside of 0.." + MAX_ID_LENGTH + " range.");
-      }
-      byte [] bytes = new byte[length];
-      in.readFully(bytes, 0, length);
-      mapId = Text.decode(bytes);
-
-      compressedLength = in.readLong();
-      uncompressedLength = in.readLong();
-      forReduce = in.readInt();
-      int maxKeyLen = in.readInt();
-      int maxValLen = in.readInt();
-      int firstKeyOffset = in.readInt();
-      int firstValOffset = in.readInt();
-      int eofPos = in.readInt();
-      if (eofPos >= 0) {
-        tezOffsetRecord = new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
-      } else {
-        tezOffsetRecord = null;
-      }
+      readCompositeFields(in, readMapId(in));
     } else {  // ShuffleHeader created by Hadoop shuffle service
       mapId = WritableUtils.readStringSafely(in, MAX_ID_LENGTH);
       compressedLength = WritableUtils.readVLong(in);
       uncompressedLength = WritableUtils.readVLong(in);
       forReduce = WritableUtils.readVInt(in);
     }
+  }
+
+  public void readCompositeFields(DataInput in, String sharedMapId) throws IOException {
+    mapId = sharedMapId;
+    compressedLength = in.readLong();
+    if (compressedLength == 0) {
+      uncompressedLength = 0;
+      forReduce = -1;
+      tezOffsetRecord = null;
+      return;
+    }
+    uncompressedLength = in.readLong();
+    forReduce = in.readInt();
+    int maxKeyLen = in.readInt();
+    if (maxKeyLen < 0) {
+      tezOffsetRecord = null;
+    } else {
+      int maxValLen = in.readInt();
+      int firstKeyOffset = in.readInt();
+      int firstValOffset = in.readInt();
+      int eofPos = in.readInt();
+      tezOffsetRecord = new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
+    }
+  }
+
+  public static String readMapId(DataInput in) throws IOException {
+    int length = in.readInt();  // Cf. WritableUtils.readStringSafely() calls readVInt()
+    if (length < 0 || length > MAX_ID_LENGTH) {
+      throw new IllegalArgumentException("Encoded byte size for String was " + length +
+                                         ", which is outside of 0.." + MAX_ID_LENGTH + " range.");
+    }
+    byte [] bytes = new byte[length];
+    in.readFully(bytes, 0, length);
+    return Text.decode(bytes);
+  }
+
+  public static void writeMapId(DataOutput out, String mapId) throws IOException {
+    ByteBuffer bytes = Text.encode(mapId);
+    int length = bytes.limit();
+    out.writeInt(length);
+    out.write(bytes.array(), 0, length);
+  }
+
+  public static int mapIdWriteLength(String mapId) throws IOException {
+    return 4 + Text.encode(mapId).limit();
   }
 
   // called by MR3 ShuffleHandler (but not by Hadoop shuffle service)
@@ -133,14 +157,20 @@ public class ShuffleHeader implements Writable {
     return length;
   }
 
+  public int compositePartitionWriteLength() {
+    int length = 8;  // compressedLength
+    if (compressedLength != 0) {
+      length += 8 + 4;  // uncompressedLength, forReduce
+      length += tezOffsetRecord != null ? 5 * 4 : 4;
+    }
+    return length;
+  }
+
   // called by MR3 ShuffleHandler (but not by Hadoop shuffle service)
   // do not use WritableUtils.writeVLong/Int()
   public void write(DataOutput out) throws IOException {
     // Text.writeString(out, mapId);
-    ByteBuffer bytes = Text.encode(mapId);
-    int length = bytes.limit();
-    out.writeInt(length);
-    out.write(bytes.array(), 0, length);
+    writeMapId(out, mapId);
 
     out.writeLong(compressedLength);
     out.writeLong(uncompressedLength);
@@ -156,6 +186,24 @@ public class ShuffleHeader implements Writable {
       out.writeInt(-1);
       out.writeInt(-1);
       out.writeInt(-1);
+      out.writeInt(-1);
+    }
+  }
+
+  public void writeCompositePartition(DataOutput out) throws IOException {
+    out.writeLong(compressedLength);
+    if (compressedLength == 0) {
+      return;
+    }
+    out.writeLong(uncompressedLength);
+    out.writeInt(forReduce);
+    if (tezOffsetRecord != null) {
+      out.writeInt(tezOffsetRecord.getMaxKeyLen());
+      out.writeInt(tezOffsetRecord.getMaxValLen());
+      out.writeInt(tezOffsetRecord.getFirstKeyOffset());
+      out.writeInt(tezOffsetRecord.getFirstValOffset());
+      out.writeInt(tezOffsetRecord.getEofPos());
+    } else {
       out.writeInt(-1);
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -137,15 +137,18 @@ public class ShuffleHeader implements Writable {
     return Text.decode(bytes);
   }
 
-  public static void writeMapId(DataOutput out, String mapId) throws IOException {
-    ByteBuffer bytes = Text.encode(mapId);
-    int length = bytes.limit();
-    out.writeInt(length);
-    out.write(bytes.array(), 0, length);
+  public static ByteBuffer encodeMapId(String mapId) throws IOException {
+    return Text.encode(mapId);
   }
 
-  public static int mapIdWriteLength(String mapId) throws IOException {
-    return 4 + Text.encode(mapId).limit();
+  public static void writeMapId(DataOutput out, ByteBuffer mapIdBytes) throws IOException {
+    int length = mapIdBytes.limit();
+    out.writeInt(length);
+    out.write(mapIdBytes.array(), 0, length);
+  }
+
+  public static int mapIdWriteLength(ByteBuffer mapIdBytes) {
+    return 4 + mapIdBytes.limit();
   }
 
   // called by MR3 ShuffleHandler (but not by Hadoop shuffle service)
@@ -170,7 +173,8 @@ public class ShuffleHeader implements Writable {
   // do not use WritableUtils.writeVLong/Int()
   public void write(DataOutput out) throws IOException {
     // Text.writeString(out, mapId);
-    writeMapId(out, mapId);
+    ByteBuffer mapIdBytes = encodeMapId(mapId);
+    writeMapId(out, mapIdBytes);
 
     out.writeLong(compressedLength);
     out.writeLong(uncompressedLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -1061,7 +1061,8 @@ public class ShuffleHandler {
         if (mapOutputInfoMap.size() < mapOutputMetaInfoCacheSize) {
           mapOutputInfoMap.put(mapId, outputInfo);
         }
-        contentLength += ShuffleHeader.mapIdWriteLength(mapId);
+        ByteBuffer mapIdBytes = ShuffleHeader.encodeMapId(mapId);
+        contentLength += ShuffleHeader.mapIdWriteLength(mapIdBytes);
         for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
           TezIndexRecord indexRecord = outputInfo.getIndex(reduce);
           TezOffsetRecord offsetRecord = outputInfo.getTezOffsetRecord(reduce);
@@ -1201,7 +1202,8 @@ public class ShuffleHandler {
       DataOutputBuffer dob = new DataOutputBuffer();
       // Indicate how many records are in this composite block, followed by the shared map id.
       dob.writeInt(reduceRange.getLast() - reduceRange.getFirst() + 1);
-      ShuffleHeader.writeMapId(dob, mapId);
+      ByteBuffer mapIdBytes = ShuffleHeader.encodeMapId(mapId);
+      ShuffleHeader.writeMapId(dob, mapIdBytes);
       // DataOutputBuffer is reused below, so copy bytes before enqueuing async channel write.
       ChannelFuture writeFuture = ch.write(Unpooled.copiedBuffer(dob.getData(), 0, dob.getLength()));
       for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
@@ -1291,7 +1293,8 @@ public class ShuffleHandler {
       ShuffleHeader header = new ShuffleHeader(message, -1, -1, -1, null);
       DataOutputBuffer out = new DataOutputBuffer();
       out.writeInt(1);
-      ShuffleHeader.writeMapId(out, message);
+      ByteBuffer mapIdBytes = ShuffleHeader.encodeMapId(message);
+      ShuffleHeader.writeMapId(out, mapIdBytes);
       header.writeCompositePartition(out);
 
       sendError(ctx, wrappedBuffer(out.getData(), 0, out.getLength()), fullResponse);

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -336,11 +336,13 @@ public class ShuffleHandler {
     private Range reduceRange;
     private ChannelHandlerContext ctx;
     private Map<String, Shuffle.MapOutputInfo> infoMap;
+    private Map<String, ByteBuffer> mapIdBytesMap;
     private final boolean keepAlive;
 
     public ReduceContext(List<String> mapIds, Range reduceRange,
                          ChannelHandlerContext context,
                          Map<String, Shuffle.MapOutputInfo> mapOutputInfoMap,
+                         Map<String, ByteBuffer> mapIdBytesMap,
                          boolean keepAlive) {
 
       this.mapIds = mapIds;
@@ -360,6 +362,7 @@ public class ShuffleHandler {
       this.mapsToSend = new AtomicInteger(0);
       this.ctx = context;
       this.infoMap = mapOutputInfoMap;
+      this.mapIdBytesMap = mapIdBytesMap;
       this.keepAlive = keepAlive;
     }
 
@@ -373,6 +376,10 @@ public class ShuffleHandler {
 
     public Map<String, Shuffle.MapOutputInfo> getInfoMap() {
       return infoMap;
+    }
+
+    public Map<String, ByteBuffer> getMapIdBytesMap() {
+      return mapIdBytesMap;
     }
 
     public List<String> getMapIds() {
@@ -917,13 +924,14 @@ public class ShuffleHandler {
       }
 
       Map<String, MapOutputInfo> mapOutputInfoMap = new HashMap<String, MapOutputInfo>();
+      Map<String, ByteBuffer> mapIdBytesMap = new HashMap<String, ByteBuffer>();
       Channel ch = ctx.channel();
       ChannelPipeline pipeline = ch.pipeline();
       TimeoutHandler timeoutHandler = (TimeoutHandler)pipeline.get(TIMEOUT_HANDLER);
       timeoutHandler.setEnabledTimeout(false);
 
       try {
-        populateHeaders(mapIds, reduceRange, response, keepAliveParam, mapOutputInfoMap);
+        populateHeaders(mapIds, reduceRange, response, keepAliveParam, mapOutputInfoMap, mapIdBytesMap);
       } catch (DiskChecker.DiskErrorException e) {  // fatal error: fetcher should be aware of that
         LOG.error("Shuffle error in populating headers (fatal: DiskErrorException):", e);
         String errorMessage = getErrorMessage(e);
@@ -942,7 +950,8 @@ public class ShuffleHandler {
       ch.write(response);
       //Initialize one ReduceContext object per channelRead call
       boolean keepAlive = keepAliveParam || connectionKeepAliveEnabled;
-      ReduceContext reduceContext = new ReduceContext(mapIds, reduceRange, ctx, mapOutputInfoMap, keepAlive);
+      ReduceContext reduceContext = new ReduceContext(
+          mapIds, reduceRange, ctx, mapOutputInfoMap, mapIdBytesMap, keepAlive);
       for (int i = 0; i < Math.min(maxSessionOpenFiles, mapIds.size()); i++) {
         ChannelFuture nextMap = sendMap(reduceContext);
         if(nextMap == null) {
@@ -975,8 +984,14 @@ public class ShuffleHandler {
             info = getMapOutputInfo(mapId, reduceContext.getReduceRange());
           }
 
+          ByteBuffer mapIdBytes = reduceContext.getMapIdBytesMap().get(mapId);
+          if (mapIdBytes == null) {
+            mapIdBytes = ShuffleHeader.encodeMapId(mapId);
+            reduceContext.getMapIdBytesMap().put(mapId, mapIdBytes);
+          }
+
           nextMap = sendMapOutput(reduceContext.getCtx().channel(),
-              mapId, reduceContext.getReduceRange(), info);
+              mapId, mapIdBytes, reduceContext.getReduceRange(), info);
           if (null == nextMap) {
             // TODO: Can we call sendFakeShuffleHeaderWithError() with DISK_ERROR_EXCEPTION instead???
             sendError(reduceContext.getCtx(), NOT_FOUND);
@@ -1038,20 +1053,22 @@ public class ShuffleHandler {
                                    Range reduceRange,
                                    HttpResponse response,
                                    boolean keepAliveParam,
-                                   Map<String, MapOutputInfo> mapOutputInfoMap)
+                                   Map<String, MapOutputInfo> mapOutputInfoMap,
+                                   Map<String, ByteBuffer> mapIdBytesMap)
         throws IOException {
 
       long contentLength = 0;
       // Content-Length only needs calculated for keep-alive
       if (connectionKeepAliveEnabled || keepAliveParam) {
-        contentLength = getContentLength(mapIds, reduceRange, mapOutputInfoMap);
+        contentLength = getContentLength(mapIds, reduceRange, mapOutputInfoMap, mapIdBytesMap);
       }
 
       // Now set the response headers.
       setResponseHeaders(response, keepAliveParam, contentLength);
     }
 
-    long getContentLength(List<String> mapIds, Range reduceRange, Map<String, MapOutputInfo> mapOutputInfoMap) throws IOException {
+    long getContentLength(List<String> mapIds, Range reduceRange, Map<String, MapOutputInfo> mapOutputInfoMap,
+        Map<String, ByteBuffer> mapIdBytesMap) throws IOException {
       long contentLength = 0;
       // Reduce count is written once per mapId
       int reduceCountVSize = 4;   // 4 = size of int
@@ -1062,6 +1079,7 @@ public class ShuffleHandler {
           mapOutputInfoMap.put(mapId, outputInfo);
         }
         ByteBuffer mapIdBytes = ShuffleHeader.encodeMapId(mapId);
+        mapIdBytesMap.put(mapId, mapIdBytes);
         contentLength += ShuffleHeader.mapIdWriteLength(mapIdBytes);
         for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
           TezIndexRecord indexRecord = outputInfo.getIndex(reduce);
@@ -1195,14 +1213,14 @@ public class ShuffleHandler {
     }
 
     private ChannelFuture sendMapOutput(
-        Channel ch, String mapId, Range reduceRange, MapOutputInfo outputInfo) throws IOException {
+        Channel ch, String mapId, ByteBuffer mapIdBytes, Range reduceRange, MapOutputInfo outputInfo)
+        throws IOException {
       TezIndexRecord firstIndex = null;
       TezIndexRecord lastIndex = null;
 
       DataOutputBuffer dob = new DataOutputBuffer();
       // Indicate how many records are in this composite block, followed by the shared map id.
       dob.writeInt(reduceRange.getLast() - reduceRange.getFirst() + 1);
-      ByteBuffer mapIdBytes = ShuffleHeader.encodeMapId(mapId);
       ShuffleHeader.writeMapId(dob, mapIdBytes);
       // DataOutputBuffer is reused below, so copy bytes before enqueuing async channel write.
       ChannelFuture writeFuture = ch.write(Unpooled.copiedBuffer(dob.getData(), 0, dob.getLength()));

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -17,7 +17,6 @@ package org.apache.tez.shufflehandler;
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.ReadaheadPool;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.util.DiskChecker;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
@@ -1062,15 +1061,13 @@ public class ShuffleHandler {
         if (mapOutputInfoMap.size() < mapOutputMetaInfoCacheSize) {
           mapOutputInfoMap.put(mapId, outputInfo);
         }
-        int lengthInitial = Text.encode(mapId).limit();
+        contentLength += ShuffleHeader.mapIdWriteLength(mapId);
         for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
           TezIndexRecord indexRecord = outputInfo.getIndex(reduce);
-          // contentLength += new ShuffleHeader(mapId, indexRecord.getPartLength(), indexRecord.getRawLength(), reduce, outputInfo.getTezOffsetRecord(reduce)).writeLength();
-          int length = lengthInitial;
-          length += 4 + 8 + 8 + 4;  // encoding of mapIdLength, compressedLength, uncompressedLength, forReduce
-          length += 5 * 4;          // encoding of TezOffsetRecord
-          contentLength += length;
-
+          TezOffsetRecord offsetRecord = outputInfo.getTezOffsetRecord(reduce);
+          ShuffleHeader header = new ShuffleHeader(
+              mapId, indexRecord.getPartLength(), indexRecord.getRawLength(), reduce, offsetRecord);
+          contentLength += header.compositePartitionWriteLength();
           contentLength += indexRecord.getPartLength();
         }
       }
@@ -1202,8 +1199,9 @@ public class ShuffleHandler {
       TezIndexRecord lastIndex = null;
 
       DataOutputBuffer dob = new DataOutputBuffer();
-      // Indicate how many record to be written
+      // Indicate how many records are in this composite block, followed by the shared map id.
       dob.writeInt(reduceRange.getLast() - reduceRange.getFirst() + 1);
+      ShuffleHeader.writeMapId(dob, mapId);
       // DataOutputBuffer is reused below, so copy bytes before enqueuing async channel write.
       ChannelFuture writeFuture = ch.write(Unpooled.copiedBuffer(dob.getData(), 0, dob.getLength()));
       for (int reduce = reduceRange.getFirst(); reduce <= reduceRange.getLast(); reduce++) {
@@ -1220,11 +1218,16 @@ public class ShuffleHandler {
         ShuffleHeader header = new ShuffleHeader(
             mapId, index.getPartLength(), index.getRawLength(), reduce, offsetRecord);
         dob.reset();
-        header.write(dob);
+        header.writeCompositePartition(dob);
         // Free the memory needed to store the spill and index records
         writeFuture = ch.write(Unpooled.copiedBuffer(dob.getData(), 0, dob.getLength()));
       }
       outputInfo.finish();
+
+      if (firstIndex == null) {
+        ch.flush();
+        return writeFuture;
+      }
 
       final long rangeOffset = firstIndex.getStartOffset();
       final long rangePartLength = lastIndex.getStartOffset() + lastIndex.getPartLength() - firstIndex.getStartOffset();
@@ -1287,9 +1290,9 @@ public class ShuffleHandler {
 
       ShuffleHeader header = new ShuffleHeader(message, -1, -1, -1, null);
       DataOutputBuffer out = new DataOutputBuffer();
-      // TODO: check if writing a fake partitionCount is necessary
-      out.writeInt(127);  // write 127 as a fake partitionCount
-      header.write(out);
+      out.writeInt(1);
+      ShuffleHeader.writeMapId(out, message);
+      header.writeCompositePartition(out);
 
       sendError(ctx, wrappedBuffer(out.getData(), 0, out.getLength()), fullResponse);
     }


### PR DESCRIPTION
### Motivation

- Reduce bytes transmitted for composite shuffle responses when many partitions are empty by switching to a block-oriented header that shares the `mapId` and uses a short form for empty partitions.
- The change targets `compositeFetch == true` only and does not attempt wire-format backwards compatibility.

### Description

- Add compact composite helpers to `ShuffleHeader`: `readMapId`, `writeMapId`, `mapIdWriteLength`, `readCompositeFields`, `writeCompositePartition`, and `compositePartitionWriteLength` to encode/decode the new block-oriented header and compact per-partition metadata.
- Update `ShuffleHandler` to compute `Content-Length` using the compact layout (`mapIdWriteLength` + `compositePartitionWriteLength`), to write the composite block preface (`partitionCount` + one shared `mapId`), to emit compact per-partition metadata via `writeCompositePartition`, and to short-circuit payload streaming when a composite block contains only empty partitions.
- Update `FetcherOrderedGrouped` and `FetcherUnordered` to read the composite block preface and shared `mapId`, to use `readCompositeFields` for each partition, and to skip empty partitions (early `compressedLength == 0` handling) so payload reads and source-lookup occur only for non-empty partitions.
- Update shuffle error path to emit a valid compact composite block framing for error responses and remove an unused `Text` import in `ShuffleHandler`.

### Testing

- Ran `git diff --check` to validate whitespace/format issues and it passed.
- Attempted to compile the runtime library with `mvn -pl tez-runtime-library -am -DskipTests compile`, which failed due to external plugin resolution errors when Maven attempted to fetch `com.github.os72:protoc-jar-maven-plugin:3.11.4` (HTTP 403) from remote repositories.
- Attempted offline and plugin-skip variants (`mvn -o -pl tez-runtime-library -am -DskipTests compile`, `mvn -pl tez-runtime-library -am -DskipTests -Dprotoc.skip=true compile`, and `mvn -pl tez-runtime-library -DskipTests compile`) and all failed due to the same plugin resolution issue or the plugin not being available in the local cache.

If you want, I can split the wire-format helpers into a smaller targeted change, add a version flag to negotiate formats, or provide a small unit test harness for the `ShuffleHeader` composite read/write helpers that does not require compiling the whole project in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6bd776c08328906b786bb1232a16)