### PR TITLE
Log shuffle wait durations

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/ShuffleManager.java
@@ -47,6 +47,8 @@ import com.google.common.collect.Lists;
 // (multiple src-indices), modifications will be required.
 public class ShuffleManager extends ShuffleClient<FetchedInput> {
 
+  private static final long SHUFFLE_WAIT_LOG_THRESHOLD_NANOS = 20L;
+
   private final FetchedInputAllocator inputManager;
 
   private final TezCounter approximateInputRecords;
@@ -436,7 +438,19 @@ public class ShuffleManager extends ShuffleClient<FetchedInput> {
 
     // block until next input or End of Input message
     // the only place where completedInputs.take() is called
-    FetchedInput fetchedInput = completedInputs.take();
+    long shuffleWaitStartTime = System.nanoTime();
+    FetchedInput fetchedInput;
+    try {
+      fetchedInput = completedInputs.take();
+    } finally {
+      long shuffleWaitFinishTime = System.nanoTime();
+      if (shuffleWaitFinishTime - shuffleWaitStartTime >= SHUFFLE_WAIT_LOG_THRESHOLD_NANOS) {
+        LOG.info("SHUFFLE_WAIT {} {}", inputContext.getUniqueIdentifier(),
+            shuffleWaitStartTime);
+        LOG.info("SHUFFLE_FINISH {} {}", inputContext.getUniqueIdentifier(),
+            shuffleWaitFinishTime);
+      }
+    }
 
     if (fetchedInput instanceof MemoryFetchedInput) {
       totalSizeOfMemoryCompletedInputs.addAndGet(-fetchedInput.getSize());

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/Shuffle.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/Shuffle.java
@@ -62,6 +62,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 public class Shuffle implements ExceptionReporter {
 
   private static final Logger LOG = LoggerFactory.getLogger(Shuffle.class);
+  private static final long SHUFFLE_WAIT_LOG_THRESHOLD_NANOS = 20L;
 
   private final InputContext inputContext;
 
@@ -203,8 +204,19 @@ public class Shuffle implements ExceptionReporter {
     Preconditions.checkState(runShuffleFuture != null,
         "waitForInput can only be called after run");
     TezRawKeyValueIterator kvIter = null;
+    long shuffleWaitStartTime = System.nanoTime();
     try {
-      kvIter = runShuffleFuture.get();
+      try {
+        kvIter = runShuffleFuture.get();
+      } finally {
+        long shuffleWaitFinishTime = System.nanoTime();
+        if (shuffleWaitFinishTime - shuffleWaitStartTime >= SHUFFLE_WAIT_LOG_THRESHOLD_NANOS) {
+          LOG.info("SHUFFLE_WAIT {} {}", inputContext.getUniqueIdentifier(),
+              shuffleWaitStartTime);
+          LOG.info("SHUFFLE_FINISH {} {}", inputContext.getUniqueIdentifier(),
+              shuffleWaitFinishTime);
+        }
+      }
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       // Processor interrupted while waiting for errors, will see an InterruptedException.


### PR DESCRIPTION
### Motivation

- Provide runtime visibility into places where readers block waiting for shuffle input so waits can be measured and correlated with TaskAttemptIDs. 
- Suppress trivial noise by only recording paired start/finish nano-times when the elapsed wait is at least 20 ns.

### Description

- Add a constant `SHUFFLE_WAIT_LOG_THRESHOLD_NANOS = 20L` and instrument unordered shuffle waits around `completedInputs.take()` in `ShuffleManager.getNextInput()`. 
- Instrument ordered-grouped shuffle waits around `runShuffleFuture.get()` in `Shuffle.waitForInput()` to record start/finish nano-times. 
- Emit paired `SHUFFLE_WAIT <taskAttemptId> <nanoTime>` and `SHUFFLE_FINISH <taskAttemptId> <nanoTime>` log lines only after the wait completes and only when the elapsed time meets the 20 ns threshold. 
- Remove the previous markdown inventory `tez-runtime-library/SHUFFLE_READER_WAIT_POINTS.md` which was replaced by the runtime logging instrumentation.

### Testing

- Ran `git diff --check`, which completed successfully. 
- Ran `mvn -pl tez-runtime-library -DskipTests compile`, which failed due to environment dependency resolution (`com.github.os72:protoc-jar-maven-plugin:3.11.4` could not be retrieved; remote returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd84912a148328b157640d895ab072)