### PR TITLE
Precompute shuffle codec settings and thread through CodecUtils.getCodec

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/FetcherConfigCommon.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/FetcherConfigCommon.java
@@ -3,6 +3,7 @@ package org.apache.tez.runtime.api;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.security.JobTokenSecretManager;
 import org.apache.tez.http.HttpConnectionParams;
 
@@ -10,6 +11,8 @@ import org.apache.tez.http.HttpConnectionParams;
 public class FetcherConfigCommon {
 
   public final Configuration codecConf;
+  public final Class<? extends CompressionCodec> codecClass;
+  public final int bufferSize;
   public final JobTokenSecretManager jobTokenSecretMgr;
   public final HttpConnectionParams httpConnectionParams;
 
@@ -24,6 +27,8 @@ public class FetcherConfigCommon {
 
   public FetcherConfigCommon(
       Configuration codecConf,
+      Class<? extends CompressionCodec> codecClass,
+      int bufferSize,
       JobTokenSecretManager jobTokenSecretMgr,
       HttpConnectionParams httpConnectionParams,
       RawLocalFileSystem localFs,
@@ -35,6 +40,8 @@ public class FetcherConfigCommon {
       boolean compositeFetch,
       boolean connectionFailAllInput) {
     this.codecConf = codecConf;
+    this.codecClass = codecClass;
+    this.bufferSize = bufferSize;
     this.jobTokenSecretMgr = jobTokenSecretMgr;
     this.httpConnectionParams = httpConnectionParams;
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
@@ -25,6 +25,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.compress.CompressionCodec;
 
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.FetcherConfig;
@@ -85,6 +86,22 @@ public class ShuffleServer implements FetcherCallback {
       return new Configuration(((ShuffleServer)instance).fetcherConfigCommon.codecConf);
     } else {
       return new Configuration(conf);
+    }
+  }
+
+  public static Class<? extends CompressionCodec> getCodecClass(Object instance) {
+    if (instance != null) {
+      return ((ShuffleServer)instance).fetcherConfigCommon.codecClass;
+    } else {
+      return null;
+    }
+  }
+
+  public static int getCodecBufferSize(Object instance) {
+    if (instance != null) {
+      return ((ShuffleServer)instance).fetcherConfigCommon.bufferSize;
+    } else {
+      return -1;
     }
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/impl/FetcherUnordered.java
@@ -139,7 +139,8 @@ public class FetcherUnordered extends Fetcher<FetchedInput> {
       if (codec == null) {
         // clone codecConf because Decompressor uses locks on the Configuration object
         Configuration codecConf = new Configuration(fetcherConfigCommon.codecConf);
-        CompressionCodec newCodec = CodecUtils.getCodec(codecConf);
+        CompressionCodec newCodec = CodecUtils.getCodec(
+            codecConf, fetcherConfigCommon.codecClass, fetcherConfigCommon.bufferSize);
         codec = newCodec;
         codecHolder.set(newCodec);
       }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -159,7 +159,8 @@ public class FetcherOrderedGrouped extends Fetcher<MapOutput> {
         if (codec == null) {
           // clone codecConf because Decompressor uses locks on the Configuration object
           Configuration codecConf = new Configuration(fetcherConfigCommon.codecConf);
-          CompressionCodec newCodec = CodecUtils.getCodec(codecConf);
+          CompressionCodec newCodec = CodecUtils.getCodec(
+              codecConf, fetcherConfigCommon.codecClass, fetcherConfigCommon.bufferSize);
           codec = newCodec;
           codecHolder.set(newCodec);
         }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/Shuffle.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/Shuffle.java
@@ -96,8 +96,12 @@ public class Shuffle implements ExceptionReporter {
     this.inputContext = inputContext;
     this.srcNameTrimmed = TezUtilsInternal.cleanVertexName(inputContext.getSourceVertexName());
 
-    Configuration codecConf = ShuffleServer.getCodecConf(inputContext.peekShuffleServer(), conf);
-    CompressionCodec codec = CodecUtils.getCodec(codecConf);
+    Object shuffleServer = inputContext.peekShuffleServer();
+    Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+    CompressionCodec codec = CodecUtils.getCodec(
+        codecConf,
+        ShuffleServer.getCodecClass(shuffleServer),
+        ShuffleServer.getCodecBufferSize(shuffleServer));
 
     boolean ifileReadAhead = conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -229,8 +229,12 @@ public final class PipelinedSorter {
           + ", reportPartitionStats=" + reportPartitionStats);
     }
 
-    Configuration codecConf = ShuffleServer.getCodecConf(outputContext.peekShuffleServer(), conf);
-    this.codec = CodecUtils.getCodec(codecConf);
+    Object shuffleServer = outputContext.peekShuffleServer();
+    Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+    this.codec = CodecUtils.getCodec(
+        codecConf,
+        ShuffleServer.getCodecClass(shuffleServer),
+        ShuffleServer.getCodecBufferSize(shuffleServer));
 
     this.ifileReadAhead = this.conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -266,8 +266,12 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     shuffleDataViaEventSize = outputContext.getCounters().findCounter(TaskCounter.SHUFFLE_DATA_BYTES_VIA_EVENT);
 
     try {
-      Configuration codecConf = ShuffleServer.getCodecConf(outputContext.peekShuffleServer(), conf);
-      this.codec = CodecUtils.getCodec(codecConf);
+      Object shuffleServer = outputContext.peekShuffleServer();
+      Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+      this.codec = CodecUtils.getCodec(
+          codecConf,
+          ShuffleServer.getCodecClass(shuffleServer),
+          ShuffleServer.getCodecBufferSize(shuffleServer));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
@@ -114,8 +114,12 @@ public class UnorderedKVInput extends AbstractLogicalInput implements LogicalInp
       ////// Initial configuration
       memoryUpdateCallbackHandler.validateUpdateReceived();
 
-      Configuration codecConf = ShuffleServer.getCodecConf(getContext().peekShuffleServer(), conf);
-      CompressionCodec codec = CodecUtils.getCodec(codecConf);
+      Object shuffleServer = getContext().peekShuffleServer();
+      Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+      CompressionCodec codec = CodecUtils.getCodec(
+          codecConf,
+          ShuffleServer.getCodecClass(shuffleServer),
+          ShuffleServer.getCodecBufferSize(shuffleServer));
 
       boolean ifileReadAhead = conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
           TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/CodecUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/CodecUtils.java
@@ -66,7 +66,22 @@ public final class CodecUtils {
   // conf is specific to each RuntimeTask
   public static FetcherConfigCommon constructFetcherConfigCommon(
       Configuration conf, TaskContext taskContext) throws IOException {
-    Configuration codecConf = CodecUtils.reduceConfForCodec(conf);
+    boolean enabled = ConfigUtils.shouldCompressIntermediateOutput(conf);
+    Configuration codecConf = CodecUtils.reduceConfForCodec(conf, enabled);
+    Class<? extends CompressionCodec> codecClass = null;
+    int bufferSize = -1;
+    if (enabled) {
+      codecClass = ConfigUtils.getIntermediateOutputCompressorClass(codecConf, DefaultCodec.class);
+      if (codecClass == SnappyCodec.class) {
+        bufferSize = codecConf.getInt(
+            CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY,
+            CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_DEFAULT);
+      } else if (codecClass == ZStandardCodec.class) {
+        bufferSize = codecConf.getInt(
+            CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY,
+            CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT);
+      }
+    }
 
     String auxiliaryService = ShuffleUtils.getTezShuffleHandlerServiceId(conf);
     SecretKey shuffleSecret = ShuffleUtils.getJobTokenSecretFromTokenBytes(
@@ -95,6 +110,8 @@ public final class CodecUtils {
 
     return new FetcherConfigCommon(
         codecConf,
+        codecClass,
+        bufferSize,
         jobTokenSecretMgr,
         httpConnectionParams,
         localFs,
@@ -138,10 +155,9 @@ public final class CodecUtils {
         maxSpeculativeFetchAttempts);
   }
 
-  private static Configuration reduceConfForCodec(Configuration conf) {
+  private static Configuration reduceConfForCodec(Configuration conf, boolean enabled) {
     Configuration newConf = new Configuration(false);
 
-    boolean enabled = ConfigUtils.shouldCompressIntermediateOutput(conf);
     newConf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, enabled);
 
     String compressionCodec = conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC);
@@ -158,58 +174,45 @@ public final class CodecUtils {
     return newConf;
   }
 
-  // This is the only place where we call codecConf.getInt() to set the buffer size in CompressionCodec.
-  // In the current implementation, codecConf is created as: new Configuration(fetcherConfigCommon.codecConf).
-  // This implies that the buffer size is set only when ShuffleServer starts, and
-  // the buffer size for individual queries is NOT honored.
-  // TODO: pass bufferSize as an argument
-  public static CompressionCodec getCodec(Configuration codecConf) throws IOException {
-    if (ConfigUtils.shouldCompressIntermediateOutput(codecConf)) {
-      Class<? extends CompressionCodec> codecClass =
-          ConfigUtils.getIntermediateOutputCompressorClass(codecConf, DefaultCodec.class);
-      CompressionCodec codec = ReflectionUtils.newInstance(codecClass, codecConf);
+  public static CompressionCodec getCodec(Configuration codecConf,
+      Class<? extends CompressionCodec> codecClass, int bufferSize) throws IOException {
+    if (codecClass == null) {
+      return null;
+    }
 
-      if (codec != null) {
-        Class<? extends Compressor> compressorType = null;
-        Throwable cause = null;
-        try {
-          compressorType = codec.getCompressorType();
-        } catch (RuntimeException e) {
-          cause = e;
-        }
+    CompressionCodec codec = ReflectionUtils.newInstance(codecClass, codecConf);
 
-        if (compressorType == null) {
-          String errMsg = String.format(
-              "Unable to get CompressorType for codec (%s). This is most likely due to missing native libraries for the codec.",
-              codecConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC));
-          throw new IOException(errMsg, cause);
-        }
+    if (codec != null) {
+      Class<? extends Compressor> compressorType = null;
+      Throwable cause = null;
+      try {
+        compressorType = codec.getCompressorType();
+      } catch (RuntimeException e) {
+        cause = e;
+      }
 
-        String bufferSizeProp = getBufferSizeProperty(codec);
-        if (bufferSizeProp != null) {
-          if (bufferSizeProp.equals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY)) {
-            int bufferSize = codecConf.getInt(
-                CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY,
-                CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_DEFAULT);
-            SnappyCodec snappyCodec = (SnappyCodec)codec;
-            synchronized (snappyCodec.getConf()) {
-              snappyCodec.setBufferSize(bufferSize);
-            }
-          } else if (bufferSizeProp.equals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY)) {
-            int bufferSize = codecConf.getInt(
-                CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY,
-                CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT);
-            ZStandardCodec zstdCodec = (ZStandardCodec)codec;
-            synchronized (zstdCodec.getConf()) {
-              zstdCodec.setBufferSize(bufferSize);
-            }
+      if (compressorType == null) {
+        String errMsg = String.format(
+            "Unable to get CompressorType for codec (%s). This is most likely due to missing native libraries for the codec.",
+            codecConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC));
+        throw new IOException(errMsg, cause);
+      }
+
+      if (bufferSize != -1) {
+        if (codecClass == SnappyCodec.class) {
+          SnappyCodec snappyCodec = (SnappyCodec)codec;
+          synchronized (snappyCodec.getConf()) {
+            snappyCodec.setBufferSize(bufferSize);
+          }
+        } else if (codecClass == ZStandardCodec.class) {
+          ZStandardCodec zstdCodec = (ZStandardCodec)codec;
+          synchronized (zstdCodec.getConf()) {
+            zstdCodec.setBufferSize(bufferSize);
           }
         }
       }
-      return codec;
-    } else {
-      return null;
     }
+    return codec;
   }
 
   public static Compressor getCompressor(CompressionCodec codec) {


### PR DESCRIPTION
### Motivation
- `CodecUtils.getCodec()` previously read compression settings and buffer-size values from a `Configuration` at runtime, which made per-query buffer size honors unreliable and required repeated config lookups. 
- The change precomputes codec selection and Snappy/ZStandard buffer sizes when constructing fetcher configuration so fetchers can reuse those values and avoid re-reading config during codec instantiation. 

### Description
- Added `Class<? extends CompressionCodec> codecClass` and `int bufferSize` fields to `FetcherConfigCommon` and its constructor to carry precomputed codec settings. 
- `CodecUtils.constructFetcherConfigCommon()` now computes `codecClass` and `bufferSize` (using `CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY` and `CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY` for Snappy/ZStandard) and stores them in the returned `FetcherConfigCommon`; `codecClass` is `null` when compression is disabled and `bufferSize` is `-1` when not applicable. 
- `CodecUtils.getCodec()` signature was changed to `getCodec(Configuration codecConf, Class<? extends CompressionCodec> codecClass, int bufferSize)` and it no longer calls `ConfigUtils.shouldCompressIntermediateOutput()`, `ConfigUtils.getIntermediateOutputCompressorClass()`, or `codecConf.getInt()` internally; it returns `null` when `codecClass` is `null` and applies the provided `bufferSize` only for `SnappyCodec` and `ZStandardCodec`. 
- Exposed `ShuffleServer.getCodecClass()` and `ShuffleServer.getCodecBufferSize()` helpers and updated call sites (shuffle, fetchers, sorter, writers, inputs) to pass the codec class and buffer size from the `ShuffleServer` when available, otherwise passing `null`/`-1`. 

### Testing
- Ran `git diff --check` to validate whitespace/patch correctness and it reported no issues. 
- Attempted `mvn -pl tez-runtime-library -am -DskipTests compile`, but the full build in this environment was blocked by external Maven plugin resolution (HTTP 403 for `com.github.os72:protoc-jar-maven-plugin:3.11.4`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9894894c8328b9e2febf48b0b8b3)