### PR TITLE
Use intermediate-output compression config to select codec and buffer sizes for shuffle

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleServer.java
@@ -25,7 +25,11 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.DefaultCodec;
+import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.io.compress.ZStandardCodec;
 
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.FetcherConfig;
@@ -33,6 +37,7 @@ import org.apache.tez.runtime.api.FetcherConfigCommon;
 import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.ConfigUtils;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.impl.FetcherUnordered;
 import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleManager;
@@ -89,20 +94,34 @@ public class ShuffleServer implements FetcherCallback {
     }
   }
 
-  public static Class<? extends CompressionCodec> getCodecClass(Object instance) {
+  public static Class<? extends CompressionCodec> getCodecClass(
+      Object instance, Configuration codecConf) {
     if (instance != null) {
       return ((ShuffleServer)instance).fetcherConfigCommon.codecClass;
-    } else {
-      return null;
     }
+
+    if (ConfigUtils.shouldCompressIntermediateOutput(codecConf)) {
+      return ConfigUtils.getIntermediateOutputCompressorClass(codecConf, DefaultCodec.class);
+    }
+    return null;
   }
 
-  public static int getCodecBufferSize(Object instance) {
+  public static int getCodecBufferSize(
+      Object instance, Configuration codecConf, Class<? extends CompressionCodec> codecClass) {
     if (instance != null) {
       return ((ShuffleServer)instance).fetcherConfigCommon.bufferSize;
-    } else {
-      return -1;
     }
+
+    if (codecClass == SnappyCodec.class) {
+      return codecConf.getInt(
+          CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY,
+          CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_DEFAULT);
+    } else if (codecClass == ZStandardCodec.class) {
+      return codecConf.getInt(
+          CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY,
+          CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT);
+    }
+    return -1;
   }
 
   public static class PathPartition {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/Shuffle.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/Shuffle.java
@@ -98,10 +98,12 @@ public class Shuffle implements ExceptionReporter {
 
     Object shuffleServer = inputContext.peekShuffleServer();
     Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+    Class<? extends CompressionCodec> codecClass =
+        ShuffleServer.getCodecClass(shuffleServer, codecConf);
     CompressionCodec codec = CodecUtils.getCodec(
         codecConf,
-        ShuffleServer.getCodecClass(shuffleServer),
-        ShuffleServer.getCodecBufferSize(shuffleServer));
+        codecClass,
+        ShuffleServer.getCodecBufferSize(shuffleServer, codecConf, codecClass));
 
     boolean ifileReadAhead = conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -231,10 +231,12 @@ public final class PipelinedSorter {
 
     Object shuffleServer = outputContext.peekShuffleServer();
     Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+    Class<? extends CompressionCodec> codecClass =
+        ShuffleServer.getCodecClass(shuffleServer, codecConf);
     this.codec = CodecUtils.getCodec(
         codecConf,
-        ShuffleServer.getCodecClass(shuffleServer),
-        ShuffleServer.getCodecBufferSize(shuffleServer));
+        codecClass,
+        ShuffleServer.getCodecBufferSize(shuffleServer, codecConf, codecClass));
 
     this.ifileReadAhead = this.conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -268,10 +268,12 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     try {
       Object shuffleServer = outputContext.peekShuffleServer();
       Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+      Class<? extends CompressionCodec> codecClass =
+          ShuffleServer.getCodecClass(shuffleServer, codecConf);
       this.codec = CodecUtils.getCodec(
           codecConf,
-          ShuffleServer.getCodecClass(shuffleServer),
-          ShuffleServer.getCodecBufferSize(shuffleServer));
+          codecClass,
+          ShuffleServer.getCodecBufferSize(shuffleServer, codecConf, codecClass));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
@@ -116,10 +116,12 @@ public class UnorderedKVInput extends AbstractLogicalInput implements LogicalInp
 
       Object shuffleServer = getContext().peekShuffleServer();
       Configuration codecConf = ShuffleServer.getCodecConf(shuffleServer, conf);
+      Class<? extends CompressionCodec> codecClass =
+          ShuffleServer.getCodecClass(shuffleServer, codecConf);
       CompressionCodec codec = CodecUtils.getCodec(
           codecConf,
-          ShuffleServer.getCodecClass(shuffleServer),
-          ShuffleServer.getCodecBufferSize(shuffleServer));
+          codecClass,
+          ShuffleServer.getCodecBufferSize(shuffleServer, codecConf, codecClass));
 
       boolean ifileReadAhead = conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
           TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT);


### PR DESCRIPTION
### Motivation
- Allow codec selection and buffer-size determination for shuffle/serialization even when no `ShuffleServer` instance is available by consulting intermediate output compression configuration.
- Ensure correct buffer sizes are used for Snappy and ZStandard decompression during shuffle to avoid incorrect defaults.

### Description
- Changed `ShuffleServer.getCodecClass` to accept `Configuration codecConf` and return the configured intermediate-output compressor via `ConfigUtils.getIntermediateOutputCompressorClass(codecConf, DefaultCodec.class)` when the `ShuffleServer` instance is null.
- Changed `ShuffleServer.getCodecBufferSize` to accept `Configuration codecConf` and `Class<? extends CompressionCodec> codecClass` and to return codec-specific buffer sizes for `SnappyCodec` and `ZStandardCodec` using `CommonConfigurationKeys`, returning `-1` otherwise.
- Updated callers in `Shuffle`, `PipelinedSorter`, `UnorderedPartitionedKVWriter`, and `UnorderedKVInput` to obtain `codecConf`, call `ShuffleServer.getCodecClass(shuffleServer, codecConf)`, and pass `codecConf` and `codecClass` into `ShuffleServer.getCodecBufferSize(...)` and `CodecUtils.getCodec(...)`.
- Added imports for `CommonConfigurationKeys`, `DefaultCodec`, `SnappyCodec`, `ZStandardCodec`, and `ConfigUtils` in `ShuffleServer`.

### Testing
- Ran the unit test suite for the `tez-runtime-library` module; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9e77e03c83288db4ba0ba606cf67)