### PR TITLE
Optimize SpanIterator key comparison with 8-byte prefix and absolute key offsets

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -1640,6 +1640,8 @@ public final class PipelinedSorter {
     private int keyLength;
     private int valueStart;
     private int valueLength;
+    private int keyAbsoluteStart;
+    private long keyPrefix8;
 
     private static final int minrun = (1 << 4);
 
@@ -1680,6 +1682,20 @@ public final class PipelinedSorter {
           span.kvmetaArray, span.offsetForIntIndex(kvindexOffset + VALLEN));
       partition = FastByteComparisons.theUnsafe.getInt(
           span.kvmetaArray, span.offsetForIntIndex(kvindexOffset + PARTITION));
+      keyAbsoluteStart = kvbufferArrayOffset + keyStart;
+      keyPrefix8 = loadKeyPrefix8();
+    }
+
+    private long loadKeyPrefix8() {
+      if (keyLength >= Long.BYTES) {
+        return Long.reverseBytes(FastByteComparisons.theUnsafe.getLong(
+            kvbufferArray, FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + keyAbsoluteStart));
+      }
+      long prefix = 0;
+      for (int i = 0; i < keyLength; i++) {
+        prefix = (prefix << Byte.SIZE) | (kvbufferArray[keyAbsoluteStart + i] & 0xFFL);
+      }
+      return prefix << ((Long.BYTES - keyLength) * Byte.SIZE);
     }
 
     @Override
@@ -1717,9 +1733,18 @@ public final class PipelinedSorter {
       if (partition != other.partition) {
         return partition - other.partition;
       }
+      if (keyPrefix8 != other.keyPrefix8) {
+        return Long.compareUnsigned(keyPrefix8, other.keyPrefix8);
+      }
+      if (keyLength >= Long.BYTES && other.keyLength >= Long.BYTES) {
+        return FastByteComparisons.compareTo(
+            kvbufferArray, keyAbsoluteStart + Long.BYTES, keyLength - Long.BYTES,
+            other.kvbufferArray, other.keyAbsoluteStart + Long.BYTES,
+            other.keyLength - Long.BYTES);
+      }
       return FastByteComparisons.compareTo(
-          kvbufferArray, kvbufferArrayOffset + keyStart, keyLength,
-          other.kvbufferArray, other.kvbufferArrayOffset + other.keyStart, other.keyLength);
+          kvbufferArray, keyAbsoluteStart, keyLength,
+          other.kvbufferArray, other.keyAbsoluteStart, other.keyLength);
     }
     
     @Override


### PR DESCRIPTION
### Motivation
- Reduce CPU cost of key comparisons during merging and bisect operations by short-circuiting on a fixed-size key prefix. 
- Avoid repeated offset arithmetic into the backing byte array to make comparisons faster and more cache-friendly.

### Description
- Added `keyAbsoluteStart` and `keyPrefix8` fields and populated them in `loadCurrentRecordMetadata()` to cache the absolute byte-array start and an 8-byte prefix for each key. 
- Implemented `loadKeyPrefix8()` which reads an 8-byte prefix using `FastByteComparisons.theUnsafe.getLong(...)` with `FastByteComparisons.BYTE_ARRAY_BASE_OFFSET` and `Long.reverseBytes(...)`, and constructs a left-shifted prefix for keys shorter than 8 bytes. 
- Updated `compareTo(SpanIterator)` to first compare `partition`, then compare unsigned `keyPrefix8`, and only fall back to full-key comparisons for equal prefixes; when both keys are at least 8 bytes the full comparison skips the prefix bytes. 
- Replaced usages of `kvbufferArrayOffset + keyStart` with the precomputed `keyAbsoluteStart` in comparisons to avoid repeated addition.

### Testing
- Built the project and ran the unit test suite via `mvn -DskipTests=false test`, which completed successfully. 
- Ran the `tez-runtime-library` module tests and integration checks, and they passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6737e44083288585db911c9a2f70)