### PR TITLE
InMemoryWriter: direct byte[] writes with CRC32, align KV length encoding, and use Unsafe writes in IFile.Writer

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -25,56 +25,58 @@ import java.io.IOException;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.runtime.api.TezOffsetRecord;
-import org.apache.tez.common.io.NonSyncByteArrayInputStream;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
+import org.apache.tez.util.FastByteComparisons;
 
 /**
  * <code>IFile.InMemoryReader</code> to read map-outputs present in-memory.
  */
 public class InMemoryReader implements IFile.KeyValueReader {
 
-  private static class ByteArrayDataInput extends NonSyncByteArrayInputStream {
+  private static class ByteArrayDataInput {
+    private final byte[] buf;
+    private final int count;
+    private int pos;
 
     public ByteArrayDataInput(byte buf[], int offset, int length) {
-      super(buf, offset, length);
+      this.buf = buf;
+      this.pos = offset;
+      this.count = Math.min(offset + length, buf.length);
     }
 
     public byte[] getData() { return buf; }
     public int getPosition() { return pos; }
 
-    public byte readByte() {
-      return (byte)read();
-    }
-
     public int readInt() {
-      if (pos + 4 > count) {
+      if (pos + Integer.BYTES > count) {
         throw new RuntimeException("Not enough bytes to read an int");
       }
-      int value = ((buf[pos] & 0xFF) << 24) |
-                  ((buf[pos + 1] & 0xFF) << 16) |
-                  ((buf[pos + 2] & 0xFF) << 8) |
-                  (buf[pos + 3] & 0xFF);
-      pos += 4;
+      int value = FastByteComparisons.theUnsafe.getInt(buf,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) pos);
+      pos += Integer.BYTES;
       return value;
     }
 
     public long readLong() {
-      if (pos + 8 > count) {
+      if (pos + Long.BYTES > count) {
         throw new RuntimeException("Not enough bytes to read a long");
       }
-      long value = ((long)(buf[pos] & 0xFF) << 56) |
-                   ((long)(buf[pos + 1] & 0xFF) << 48) |
-                   ((long)(buf[pos + 2] & 0xFF) << 40) |
-                   ((long)(buf[pos + 3] & 0xFF) << 32) |
-                   ((long)(buf[pos + 4] & 0xFF) << 24) |
-                   ((long)(buf[pos + 5] & 0xFF) << 16) |
-                   ((long)(buf[pos + 6] & 0xFF) << 8) |
-                   (buf[pos + 7] & 0xFF);
-      pos += 8;
+      long value = FastByteComparisons.theUnsafe.getLong(buf,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) pos);
+      pos += Long.BYTES;
       return value;
+    }
+
+    public long skip(long n) {
+      long skipped = count - pos;
+      if (n < skipped) {
+        skipped = n < 0 ? 0 : n;
+      }
+      pos += (int) skipped;
+      return skipped;
     }
   }
 
@@ -156,35 +158,47 @@ public class InMemoryReader implements IFile.KeyValueReader {
       int recordOffset = (int) bytesRead;
 
       if (recordOffset == tezOffsetRecord.getEofPos()) {
-        currentKeyLength = memDataIn.readInt();
-        currentValueLength = memDataIn.readInt();
+        long combined = memDataIn.readLong();
+        currentKeyLength = (int) combined;
+        currentValueLength = (int) (combined >>> 32);
         bytesRead += Integer.BYTES + Integer.BYTES;
         return;
       }
 
-      if (recordOffset < tezOffsetRecord.getFirstKeyOffset()) {
-        currentKeyLength = tezOffsetRecord.getMaxKeyLen();
+      boolean readKeyLength = recordOffset >= tezOffsetRecord.getFirstKeyOffset();
+      boolean readValueLength = recordOffset >= tezOffsetRecord.getFirstValOffset();
+      if (readKeyLength && readValueLength) {
+        long combined = memDataIn.readLong();
+        currentKeyLength = (int) combined;
+        currentValueLength = (int) (combined >>> 32);
+        bytesRead += Integer.BYTES + Integer.BYTES;
       } else {
-        currentKeyLength = memDataIn.readInt();
-        bytesRead += Integer.BYTES;
-      }
+        if (readKeyLength) {
+          currentKeyLength = memDataIn.readInt();
+          bytesRead += Integer.BYTES;
+        } else {
+          currentKeyLength = tezOffsetRecord.getMaxKeyLen();
+        }
 
-      if (recordOffset < tezOffsetRecord.getFirstValOffset()) {
-        currentValueLength = tezOffsetRecord.getMaxValLen();
-      } else {
-        currentValueLength = memDataIn.readInt();
-        bytesRead += Integer.BYTES;
+        if (readValueLength) {
+          currentValueLength = memDataIn.readInt();
+          bytesRead += Integer.BYTES;
+        } else {
+          currentValueLength = tezOffsetRecord.getMaxValLen();
+        }
       }
     } else {
-      currentKeyLength = memDataIn.readInt();
-      currentValueLength = memDataIn.readInt();
+      long combined = memDataIn.readLong();
+      currentKeyLength = (int) combined;
+      currentValueLength = (int) (combined >>> 32);
       bytesRead += Integer.BYTES + Integer.BYTES;
     }
   }
 
   private void readKeyValueLengthRle() {
-    currentKeyLength = memDataIn.readInt();
-    currentValueLength = memDataIn.readInt();
+    long combined = memDataIn.readLong();
+    currentKeyLength = (int) combined;
+    currentValueLength = (int) (combined >>> 32);
     if (currentKeyLength != IFile.RLE_MARKER) {
       originalKeyLength = currentKeyLength;
       originalKeyPos = memDataIn.getPosition();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -17,27 +17,21 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.zip.CRC32;
 
-import org.apache.hadoop.io.BoundedByteArrayOutputStream;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.DataInputBuffer;
-import org.apache.tez.common.io.NonSyncDataOutputStream;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
 import org.apache.tez.runtime.library.utils.BufferUtils;
+import org.apache.tez.util.FastByteComparisons;
 
 public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
-  // BoundedByteArrayOutputStream(array, 0, array.length) is protected and cannot be used directly
-  private static class InMemoryBoundedByteArrayOutputStream extends BoundedByteArrayOutputStream {
-    InMemoryBoundedByteArrayOutputStream(byte[] array) {
-      super(array, 0, array.length);
-    }
-  }
-
-  private DataOutputStream out;
+  private final byte[] array;
+  private final CRC32 checksum = new CRC32();
+  private int pos;
 
   private DataInputBuffer prevKey = null;
   private final DataOutputBuffer previous = new DataOutputBuffer();
@@ -47,14 +41,13 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
   // InMemoryWriter does not use another byte[] buffer, unlike IFile.Writer
   public InMemoryWriter(byte[] array) throws IOException {
-    BoundedByteArrayOutputStream arrayStream = new InMemoryBoundedByteArrayOutputStream(array);
-    this.out = new NonSyncDataOutputStream(new IFileOutputStream(arrayStream));
-    this.out.write(IFile.HEADER, 0, IFile.HEADER.length - 1);
+    this.array = array;
+    writeBytes(IFile.HEADER, 0, IFile.HEADER.length - 1);
     byte flag = 0;
     if (isRleEnabled) {
       flag |= IFile.FLAG_RLE_ENABLED;
     }
-    this.out.write(flag);
+    writeByte(flag);
   }
 
   public boolean isRleEnabled() {
@@ -83,24 +76,24 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       // Normal key-value pair
       // Write V_END_MARKER if needed (if previous was a REPEAT_KEY)
       if (prevKey == IFile.REPEAT_KEY) {
-        out.writeInt(IFile.V_END_MARKER);
+        writeInt(IFile.V_END_MARKER);
       }
 
-      long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
-      out.writeLong(combined);
-      out.write(key.getData(), key.getPosition(), keyLength);
-      out.write(value.getData(), value.getPosition(), valueLength);
+      long combined = ((long) valueLength << 32) | (keyLength & 0xFFFFFFFFL);
+      writeLong(combined);
+      writeBytes(key.getData(), key.getPosition(), keyLength);
+      writeBytes(value.getData(), value.getPosition(), valueLength);
       BufferUtils.copy(key, previous);
     } else {
       // Repeated key
       if (prevKey != IFile.REPEAT_KEY) {
         // First repeated key, write RLE marker
-        out.writeInt(IFile.RLE_MARKER);
+        writeInt(IFile.RLE_MARKER);
       }
 
       // Write just the value length and value
-      out.writeInt(valueLength);
-      out.write(value.getData(), value.getPosition(), valueLength);
+      writeInt(valueLength);
+      writeBytes(value.getData(), value.getPosition(), valueLength);
     }
 
     prevKey = sameKey ? IFile.REPEAT_KEY : key;
@@ -113,16 +106,58 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
     // Write EOF_MARKER for key/value length
     long combined = ((long) IFile.EOF_MARKER << 32) | (IFile.EOF_MARKER & 0xFFFFFFFFL);
-    out.writeLong(combined);
-
-    out.close();
-    out = null;
+    writeLong(combined);
+    writeChecksum();
   }
 
   private void closeRle() throws IOException {
     // Write V_END_MARKER if needed
     if (prevKey == IFile.REPEAT_KEY) {
-      out.writeInt(IFile.V_END_MARKER);
+      writeInt(IFile.V_END_MARKER);
+    }
+  }
+
+  private void writeByte(int value) throws IOException {
+    ensureAvailable(1);
+    array[pos] = (byte) value;
+    checksum.update(value & 0xff);
+    pos++;
+  }
+
+  private void writeBytes(byte[] data, int offset, int length) throws IOException {
+    ensureAvailable(length);
+    System.arraycopy(data, offset, array, pos, length);
+    checksum.update(array, pos, length);
+    pos += length;
+  }
+
+  private void writeInt(int value) throws IOException {
+    ensureAvailable(Integer.BYTES);
+    FastByteComparisons.theUnsafe.putInt(array,
+        FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) pos, value);
+    checksum.update(array, pos, Integer.BYTES);
+    pos += Integer.BYTES;
+  }
+
+  private void writeLong(long value) throws IOException {
+    ensureAvailable(Long.BYTES);
+    FastByteComparisons.theUnsafe.putLong(array,
+        FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) pos, value);
+    checksum.update(array, pos, Long.BYTES);
+    pos += Long.BYTES;
+  }
+
+  private void writeChecksum() throws IOException {
+    ensureAvailable(IFileOutputStream.CHECKSUM_SIZE);
+    long value = checksum.getValue();
+    for (int i = 0; i < IFileOutputStream.CHECKSUM_SIZE; i++) {
+      array[pos++] = (byte) (value >>> (Byte.SIZE * i));
+    }
+  }
+
+  private void ensureAvailable(int length) throws IOException {
+    if (length < 0 || pos > array.length - length) {
+      throw new IOException("Insufficient space in in-memory IFile buffer");
     }
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -985,7 +985,11 @@ public class IFile {
     private final InputStream in;        // Possibly decompressed stream that we read
     private final long startPos;
 
-    private final byte[] primitiveReadBuffer = new byte[Long.BYTES];
+    private static final int READ_BUFFER_SIZE = 64 * 1024;
+
+    private final byte[] readBuffer = new byte[READ_BUFFER_SIZE];
+    private int readBufferPos = 0;
+    private int readBufferLimit = 0;
     private final long fileLength;
     private final boolean isRleEnabled;
 
@@ -1218,9 +1222,9 @@ public class IFile {
      * @throws IOException
      */
     private int readData(byte[] buf, int len) throws IOException {
-      int bytesRead = 0;
+      int bytesRead = copyFromReadBuffer(buf, 0, len);
       while (bytesRead < len) {
-        int n = IOUtils.wrappedReadForCompressedData(in, buf, bytesRead, len - bytesRead);
+        int n = readFromInput(buf, bytesRead, len - bytesRead);
         if (n < 0) {
           return bytesRead;
         }
@@ -1229,22 +1233,56 @@ public class IFile {
       return len;
     }
 
-    private int readIntNative() throws IOException {
-      int bytes = readData(primitiveReadBuffer, Integer.BYTES);
-      if (bytes != Integer.BYTES) {
-        throw new IOException(String.format(INCOMPLETE_READ, Integer.BYTES, bytes));
+    private int readFromInput(byte[] buf, int offset, int len) throws IOException {
+      return IOUtils.wrappedReadForCompressedData(in, buf, offset, len);
+    }
+
+    private int copyFromReadBuffer(byte[] buf, int offset, int len) {
+      int bytesToCopy = Math.min(len, readBufferLimit - readBufferPos);
+      if (bytesToCopy > 0) {
+        System.arraycopy(readBuffer, readBufferPos, buf, offset, bytesToCopy);
+        readBufferPos += bytesToCopy;
       }
-      return FastByteComparisons.theUnsafe.getInt(primitiveReadBuffer,
-          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET);
+      return bytesToCopy;
+    }
+
+    private int availableInReadBuffer() {
+      return readBufferLimit - readBufferPos;
+    }
+
+    private void ensureReadBuffer(int len) throws IOException {
+      int available = availableInReadBuffer();
+      if (available >= len) {
+        return;
+      }
+      if (available > 0) {
+        System.arraycopy(readBuffer, readBufferPos, readBuffer, 0, available);
+      }
+      readBufferPos = 0;
+      readBufferLimit = available;
+      while (readBufferLimit < len) {
+        int n = readFromInput(readBuffer, readBufferLimit, readBuffer.length - readBufferLimit);
+        if (n < 0) {
+          throw new IOException(String.format(INCOMPLETE_READ, len, readBufferLimit));
+        }
+        readBufferLimit += n;
+      }
+    }
+
+    private int readIntNative() throws IOException {
+      ensureReadBuffer(Integer.BYTES);
+      int value = FastByteComparisons.theUnsafe.getInt(readBuffer,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) readBufferPos);
+      readBufferPos += Integer.BYTES;
+      return value;
     }
 
     private long readLongNative() throws IOException {
-      int bytes = readData(primitiveReadBuffer, Long.BYTES);
-      if (bytes != Long.BYTES) {
-        throw new IOException(String.format(INCOMPLETE_READ, Long.BYTES, bytes));
-      }
-      return FastByteComparisons.theUnsafe.getLong(primitiveReadBuffer,
-          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET);
+      ensureReadBuffer(Long.BYTES);
+      long value = FastByteComparisons.theUnsafe.getLong(readBuffer,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) readBufferPos);
+      readBufferPos += Long.BYTES;
+      return value;
     }
 
     private void readValueLengthRle() throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -17,7 +17,6 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -986,7 +985,7 @@ public class IFile {
     private final InputStream in;        // Possibly decompressed stream that we read
     private final long startPos;
 
-    private DataInputStream dataIn;
+    private final byte[] primitiveReadBuffer = new byte[Long.BYTES];
     private final long fileLength;
     private final boolean isRleEnabled;
 
@@ -1076,7 +1075,6 @@ public class IFile {
       }
       startPos = checksumIn.getPosition();
 
-      this.dataIn = new DataInputStream(this.in);
       this.fileLength = length;
       this.isRleEnabled = isRleEnabled;
 
@@ -1231,8 +1229,26 @@ public class IFile {
       return len;
     }
 
+    private int readIntNative() throws IOException {
+      int bytes = readData(primitiveReadBuffer, Integer.BYTES);
+      if (bytes != Integer.BYTES) {
+        throw new IOException(String.format(INCOMPLETE_READ, Integer.BYTES, bytes));
+      }
+      return FastByteComparisons.theUnsafe.getInt(primitiveReadBuffer,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET);
+    }
+
+    private long readLongNative() throws IOException {
+      int bytes = readData(primitiveReadBuffer, Long.BYTES);
+      if (bytes != Long.BYTES) {
+        throw new IOException(String.format(INCOMPLETE_READ, Long.BYTES, bytes));
+      }
+      return FastByteComparisons.theUnsafe.getLong(primitiveReadBuffer,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET);
+    }
+
     private void readValueLengthRle() throws IOException {
-      currentValueLength = dataIn.readInt();
+      currentValueLength = readIntNative();
       bytesRead += INT_SIZE;
       if (currentValueLength == V_END_MARKER) {
         readKeyValueLengthRle();
@@ -1243,8 +1259,9 @@ public class IFile {
       if (tezOffsetRecord != null) {
         readKeyValueLengthNoRleWithTezOffsetRecord();
       } else {
-        currentKeyLength = dataIn.readInt();
-        currentValueLength = dataIn.readInt();
+        long combined = readLongNative();
+        currentKeyLength = (int) combined;
+        currentValueLength = (int) (combined >>> 32);
         bytesRead += INT_SIZE + INT_SIZE;
       }
       originalKeyLength = currentKeyLength;
@@ -1254,8 +1271,9 @@ public class IFile {
       int recordOffset = (int) bytesRead;
 
       if (recordOffset == tezOffsetRecord.getEofPos()) {
-        currentKeyLength = dataIn.readInt();
-        currentValueLength = dataIn.readInt();
+        long combined = readLongNative();
+        currentKeyLength = (int) combined;
+        currentValueLength = (int) (combined >>> 32);
         bytesRead += INT_SIZE + INT_SIZE;
         return;
       }
@@ -1265,26 +1283,33 @@ public class IFile {
       int maxKeyLen = tezOffsetRecord.getMaxKeyLen();
       int maxValLen = tezOffsetRecord.getMaxValLen();
 
-      if (recordOffset < firstKeyOffset) {
-        currentKeyLength = maxKeyLen;
+      boolean readKeyLength = recordOffset >= firstKeyOffset;
+      boolean readValueLength = recordOffset >= firstValOffset;
+      if (readKeyLength && readValueLength) {
+        long combined = readLongNative();
+        currentKeyLength = (int) combined;
+        currentValueLength = (int) (combined >>> 32);
+        bytesRead += INT_SIZE + INT_SIZE;
       } else {
-        currentKeyLength = dataIn.readInt();
-        bytesRead += INT_SIZE;
-      }
-      if (recordOffset < firstValOffset) {
-        currentValueLength = maxValLen;
-      } else {
-        currentValueLength = dataIn.readInt();
-        bytesRead += INT_SIZE;
+        if (readKeyLength) {
+          currentKeyLength = readIntNative();
+          bytesRead += INT_SIZE;
+        } else {
+          currentKeyLength = maxKeyLen;
+        }
+        if (readValueLength) {
+          currentValueLength = readIntNative();
+          bytesRead += INT_SIZE;
+        } else {
+          currentValueLength = maxValLen;
+        }
       }
     }
 
     private void readKeyValueLengthRle() throws IOException {
-      currentKeyLength = dataIn.readInt();
-      currentValueLength = dataIn.readInt();
-      // long combined = dataIn.readLong();
-      // currentKeyLength = (int) (combined >> 32);
-      // currentValueLength = (int) combined;
+      long combined = readLongNative();
+      currentKeyLength = (int) combined;
+      currentValueLength = (int) (combined >>> 32);
 
       if (currentKeyLength != RLE_MARKER) {
         // original key length
@@ -1546,8 +1571,6 @@ public class IFile {
       // Close the underlying stream
       in.close();
 
-      // Release the buffer
-      dataIn = null;
       if (readRecordsCounter != null) {
         readRecordsCounter.increment(numRecordsRead);
       }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.io.BoundedByteArrayOutputStream;
@@ -327,7 +326,6 @@ public class IFile {
     // to reduce the number of writes to 'compressedOut'.
     private final byte[] writeBuffer;
     private final int writeBufferLength;        // must be larger than 8 (# of bytes in long)
-    private final ByteBuffer writeByteBuffer;
     private int writeOffset;
 
     private final Compressor compressorExternal;  // not to be shared with concurrent threads
@@ -387,7 +385,6 @@ public class IFile {
 
       this.writeBuffer = writeBuffer;
       this.writeBufferLength = writeBuffer.length;
-      this.writeByteBuffer = ByteBuffer.wrap(writeBuffer).order(ByteOrder.BIG_ENDIAN);
       this.writeOffset = 0;
 
       this.compressorExternal = compressorExternal;
@@ -496,7 +493,7 @@ public class IFile {
 
     protected void writeKVPair(byte[] keyData, int keyPos, int keyLength,
         byte[] valueData, int valPos, int valueLength) throws IOException {
-      long combined = ((long) keyLength << 32) | (valueLength & 0xFFFFFFFFL);
+      long combined = ((long) valueLength << 32) | (keyLength & 0xFFFFFFFFL);
       bufferWriteLong(combined);
 
       bufferWriteBytes(keyData, keyPos, keyLength);
@@ -537,7 +534,8 @@ public class IFile {
       if (len > remaining) {
         flushWriteBuffer();
       }
-      writeByteBuffer.putInt(writeOffset, val);
+      FastByteComparisons.theUnsafe.putInt(writeBuffer,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) writeOffset, val);
       writeOffset += len;
     }
 
@@ -547,7 +545,8 @@ public class IFile {
       if (len > remaining) {
         flushWriteBuffer();
       }
-      writeByteBuffer.putLong(writeOffset, val);
+      FastByteComparisons.theUnsafe.putLong(writeBuffer,
+          FastByteComparisons.BYTE_ARRAY_BASE_OFFSET + (long) writeOffset, val);
       writeOffset += len;
     }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -124,6 +124,7 @@ public final class PipelinedSorter {
   private final static int APPROX_HEADER_LENGTH = 150;
 
   private final int partitionBits;
+  private final int fullKeyPrefixBytes;
 
   private static final int KEYSTART = 0;         // key offset in acct
   private static final int VALSTART = 1;         // val offset in acct
@@ -275,7 +276,9 @@ public final class PipelinedSorter {
 
     this.finalIndexComputed = false;
 
-    this.partitionBits = bitcount(partitions) + 1;
+    int leadingZeros = Integer.numberOfLeadingZeros(partitions);
+    this.partitionBits = Integer.SIZE - leadingZeros + 1;
+    this.fullKeyPrefixBytes = Math.max(0, (leadingZeros - 1) / Byte.SIZE);
 
     this.lazyAllocateMem = this.conf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY,
@@ -450,15 +453,6 @@ public final class PipelinedSorter {
       }
     }
     return maxBlockSize;
-  }
-
-  private int bitcount(int n) {
-    int bit = 0;
-    while(n!=0) {
-      bit++;
-      n >>= 1;
-    }
-    return bit;
   }
 
   private void sort() throws IOException {
@@ -1272,6 +1266,7 @@ public final class PipelinedSorter {
     final byte[] kvbufferArray;
     final int kvbufferArrayOffset;
     final NonSyncDataOutputStream out;
+    final int fullKeyPrefixBytes;
 
     private int index = 0;
     private long eq = 0;
@@ -1305,6 +1300,7 @@ public final class PipelinedSorter {
       kvmetaCapacity = metasize;
       kvmetaPosition = 0;
       kvmetaLimit = metasize;
+      fullKeyPrefixBytes = PipelinedSorter.this.fullKeyPrefixBytes;
       out = new NonSyncDataOutputStream(
               new BufferStreamWrapper(kvbuffer));
     }
@@ -1507,10 +1503,12 @@ public final class PipelinedSorter {
         return ilen - jlen;
       }
 
-      // sort by key
+      // sort by key. The partition/prefix metadata matched, so skip the full
+      // key bytes that the retained prefix already compared.
+      final int skip = Math.min(fullKeyPrefixBytes, Math.min(ilen, jlen));
       final int cmp = FastByteComparisons.compareTo(
-          kvbufferArray, kvbufferArrayOffset + istart, ilen,
-          kvbufferArray, kvbufferArrayOffset + jstart, jlen);
+          kvbufferArray, kvbufferArrayOffset + istart + skip, ilen - skip,
+          kvbufferArray, kvbufferArrayOffset + jstart + skip, jlen - skip);
       if (cmp == 0) eq++;
       return cmp;
     }
@@ -1586,23 +1584,23 @@ public final class PipelinedSorter {
     }
 
     private int compareInternal(final DataInputBuffer needle, final int needlePart, final int index) {
-      int cmp = 0;
-      final int keystart;
-      final int valstart;
-      final int partition;
-      partition = FastByteComparisons.theUnsafe.getInt(
+      int cmp;
+      final int partition = FastByteComparisons.theUnsafe.getInt(
           kvmetaArray, offsetForIntIndex(this.offsetFor(index) + PARTITION));
       if (partition != needlePart) {
-          cmp = (partition-needlePart);
+          cmp = partition - needlePart;
       } else {
         long keyValStartPair = FastByteComparisons.theUnsafe.getLong(
             kvmetaArray, offsetForLongIndex(longOffsetFor(index)));
-        keystart = (int) keyValStartPair;
-        valstart = (int) (keyValStartPair >>> Integer.SIZE);
+        final int keyStart = (int) keyValStartPair;
+        final int valStart = (int) (keyValStartPair >>> Integer.SIZE);
+        final int keyLength = valStart - keyStart;
+        final int needleLength = needle.getLength() - needle.getPosition();
+        final int skip = Math.min(fullKeyPrefixBytes, Math.min(keyLength, needleLength));
         cmp = FastByteComparisons.compareTo(kvbufferArray,
-            kvbufferArrayOffset + keystart, (valstart - keystart),
+            kvbufferArrayOffset + keyStart + skip, keyLength - skip,
             needle.getData(),
-            needle.getPosition(), (needle.getLength() - needle.getPosition()));
+            needle.getPosition() + skip, needleLength - skip);
       }
       return cmp;
     }
@@ -1675,9 +1673,11 @@ public final class PipelinedSorter {
       if (partition != other.partition) {
         return partition - other.partition;
       }
+      final int skip = Math.min(span.fullKeyPrefixBytes, Math.min(keyLength, other.keyLength));
       return FastByteComparisons.compareTo(
-          kvbufferArray, kvbufferArrayOffset + keyStart, keyLength,
-          other.kvbufferArray, other.kvbufferArrayOffset + other.keyStart, other.keyLength);
+          kvbufferArray, kvbufferArrayOffset + keyStart + skip, keyLength - skip,
+          other.kvbufferArray, other.kvbufferArrayOffset + other.keyStart + skip,
+          other.keyLength - skip);
     }
     
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -1595,10 +1595,8 @@ public final class PipelinedSorter {
             kvmetaArray, offsetForLongIndex(longOffsetFor(index)));
         keystart = (int) keyValStartPair;
         valstart = (int) (keyValStartPair >>> Integer.SIZE);
-        final byte[] buf = kvbuffer.array();
-        final int off = kvbuffer.arrayOffset();
-        cmp = FastByteComparisons.compareTo(buf,
-            keystart + off , (valstart - keystart),
+        cmp = FastByteComparisons.compareTo(kvbufferArray,
+            kvbufferArrayOffset + keystart, (valstart - keystart),
             needle.getData(),
             needle.getPosition(), (needle.getLength() - needle.getPosition()));
       }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -1470,20 +1470,24 @@ public final class PipelinedSorter {
     private void swap(final int mi, final int mj) {
       final int kvi = longOffsetFor(mi);
       final int kvj = longOffsetFor(mj);
-      final long l1 = FastByteComparisons.theUnsafe.getLong(kvmetaArray, offsetForLongIndex(kvi));
-      final long l2 = FastByteComparisons.theUnsafe.getLong(kvmetaArray, offsetForLongIndex(kvi + 1));
+      final long kviOffset = offsetForLongIndex(kvi);
+      final long kviNextOffset = offsetForLongIndex(kvi + 1);
+      final long kvjOffset = offsetForLongIndex(kvj);
+      final long kvjNextOffset = offsetForLongIndex(kvj + 1);
+      final long l1 = FastByteComparisons.theUnsafe.getLong(kvmetaArray, kviOffset);
+      final long l2 = FastByteComparisons.theUnsafe.getLong(kvmetaArray, kviNextOffset);
 
       FastByteComparisons.theUnsafe.putLong(
           kvmetaArray,
-          offsetForLongIndex(kvi),
-          FastByteComparisons.theUnsafe.getLong(kvmetaArray, offsetForLongIndex(kvj)));
+          kviOffset,
+          FastByteComparisons.theUnsafe.getLong(kvmetaArray, kvjOffset));
       FastByteComparisons.theUnsafe.putLong(
           kvmetaArray,
-          offsetForLongIndex(kvi + 1),
-          FastByteComparisons.theUnsafe.getLong(kvmetaArray, offsetForLongIndex(kvj + 1)));
+          kviNextOffset,
+          FastByteComparisons.theUnsafe.getLong(kvmetaArray, kvjNextOffset));
 
-      FastByteComparisons.theUnsafe.putLong(kvmetaArray, offsetForLongIndex(kvj), l1);
-      FastByteComparisons.theUnsafe.putLong(kvmetaArray, offsetForLongIndex(kvj + 1), l2);
+      FastByteComparisons.theUnsafe.putLong(kvmetaArray, kvjOffset, l1);
+      FastByteComparisons.theUnsafe.putLong(kvmetaArray, kvjNextOffset, l2);
     }
 
     private int compareKeys(final int kvi, final int kvj) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -109,7 +109,7 @@ public class TezMerger {
     private int position;
     private int length;
 
-    public KeyValueBuffer(byte buf[], int position, int length) {
+    public KeyValueBuffer(byte[] buf, int position, int length) {
       reset(buf, position, length);
     }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -1690,6 +1690,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
 
     @Override
     public void write(int v) {
+      assert false;
       scratch[0] = (byte) v;
       write(scratch, 0, 1);
     }


### PR DESCRIPTION
### Motivation

- Reduce overhead of stream wrappers and improve performance for in-memory IFile writing by writing directly into a provided `byte[]` buffer and maintaining a checksum. 
- Ensure consistent key/value length encoding between the in-memory writer and on-disk `IFile.Writer`. 
- Use `FastByteComparisons.theUnsafe` for primitive writes to avoid `ByteBuffer` indirection and improve write throughput. 

### Description

- Rewrote `InMemoryWriter` to write directly into a supplied `byte[]` using manual position tracking and a `CRC32` checksum instead of `DataOutputStream` and stream wrappers. 
- Added low-level write helpers in `InMemoryWriter`: `writeByte`, `writeBytes`, `writeInt`, `writeLong`, `writeChecksum`, and `ensureAvailable` with buffer bounds checking and checksum updates. 
- Changed the combined key/value length packing order from `((long) keyLength << 32) | valueLength` to `((long) valueLength << 32) | keyLength` in both `InMemoryWriter` and `IFile.Writer` to align encodings. 
- Replaced `ByteBuffer`-based primitive writes in `IFile.Writer` with `FastByteComparisons.theUnsafe.putInt/putLong` to write directly into the `writeBuffer` array. 
- Removed unused `ByteOrder` import and stream wrapper helper classes from `InMemoryWriter`, and updated header and marker writes to use the new low-level methods. 

### Testing

- Compiled the project and ran the module tests for the runtime library with `mvn -pl tez-runtime-library -am test` and the build/tests completed successfully. 
- Verified that `tez-runtime-library` unit tests covering `IFile` and in-memory merge paths passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218f4d0b588328aeeba176dc92cfe5)