### PR TITLE
Safe zero-copy fast path for ValuesIterator; TezRawKeyValueIterator.next returns stability codes

### DIFF
--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTask.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTask.java
@@ -436,7 +436,8 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
 
           @Override
           public boolean next() throws IOException {
-            boolean hasMore = rIter.next();
+            int nextResult = rIter.next();
+            boolean hasMore = nextResult != TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
             done = !hasMore;
             return hasMore;
           }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -44,6 +44,7 @@ public class ValuesIterator {
   private BytesWritable nextKey;
   private BytesWritable value;          // current value
   private boolean more;                 // more in file
+  private boolean currentRecordStable;
   private final TezCounter inputKeyCounter;
   private final TezCounter inputValueCounter;
   
@@ -152,11 +153,13 @@ public class ValuesIterator {
    * read the next key - which may be the same as the current key.
    */
   private void readNextKey() throws IOException {
-    more = in.next();
+    int nextResult = in.next();
+    more = nextResult != TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
+    currentRecordStable = nextResult == TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE;
     if (more) {      
       DataInputBuffer nextKeyBytes = in.getKey();
       if (!in.isSameKey()) {
-        nextKey = copyToWritable(nextKey, nextKeyBytes);
+        nextKey = copyToWritable(nextKey, nextKeyBytes, currentRecordStable);
         // hasMoreValues = is it first key or is key the same?
         hasMoreValues = (key == null) || (TezBytesComparator.compare(key, nextKey) == 0);
         if (key == null || !hasMoreValues) {
@@ -181,10 +184,10 @@ public class ValuesIterator {
    */
   private void readNextValue() throws IOException {
     DataInputBuffer nextValueBytes = in.getValue();
-    value = copyToWritable(value, nextValueBytes);
+    value = copyToWritable(value, nextValueBytes, currentRecordStable);
   }
 
-  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source) {
+  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source, boolean stable) {
     BytesWritable target = writable;
     if (target == null) {
       target = new BytesWritable();
@@ -192,8 +195,12 @@ public class ValuesIterator {
 
     int pos = source.getPosition();
     int length = source.getLength() - pos;
-    byte[] bytes = target.reinitialize(length);
-    System.arraycopy(source.getData(), pos, bytes, 0, length);
+    if (stable) {
+      target.setDirect(source.getData(), pos, length);
+    } else {
+      byte[] bytes = target.reinitialize(length);
+      System.arraycopy(source.getData(), pos, bytes, 0, length);
+    }
 
     return target;
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -267,6 +267,11 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   @Override
+  public boolean isCurrentRecordStable() {
+    return true;
+  }
+
+  @Override
   public KeyState readRawKey(DataInputBuffer key) throws IOException {
     if (isRleEnabled) {
       return readRawKeyRle(key);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -1107,6 +1107,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
     private final TezRawKeyValueIterator kvIter;
     private final long size;
+    private int lastNextResult = TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
 
     public RawKVIteratorReader(TezRawKeyValueIterator kvIter, long size) {
       this.kvIter = kvIter;
@@ -1115,14 +1116,16 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
     @Override
     public IFile.Reader.KeyState readRawKey(DataInputBuffer key) throws IOException {
-      if (kvIter.next()) {
-        final DataInputBuffer kb = kvIter.getKey();
-        final int kp = kb.getPosition();
-        final int klen = kb.getLength() - kp;
-        key.reset(kb.getData(), kp, klen);
-        return kvIter.isSameKey() ? IFile.Reader.KeyState.SAME_KEY : IFile.Reader.KeyState.NEW_KEY;
+      lastNextResult = kvIter.next();
+      if (lastNextResult == TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
+        return IFile.Reader.KeyState.NO_KEY;
       }
-      return IFile.Reader.KeyState.NO_KEY;
+
+      final DataInputBuffer kb = kvIter.getKey();
+      final int kp = kb.getPosition();
+      final int klen = kb.getLength() - kp;
+      key.reset(kb.getData(), kp, klen);
+      return kvIter.isSameKey() ? IFile.Reader.KeyState.SAME_KEY : IFile.Reader.KeyState.NEW_KEY;
     }
 
     @Override
@@ -1131,6 +1134,11 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       final int vp = vb.getPosition();
       final int vlen = vb.getLength() - vp;
       value.reset(vb.getData(), vp, vlen);
+    }
+
+    @Override
+    public boolean isCurrentRecordStable() {
+      return lastNextResult == TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE;
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -941,6 +941,23 @@ public class IFile {
   public interface KeyValueReaderDataInputBuffer extends KeyValueReaderBase {
     Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
     void nextRawValue(DataInputBuffer value) throws IOException;
+
+    /**
+     * Reports whether the most recently loaded current record returned through
+     * {@link #readRawKey(DataInputBuffer)} and {@link #nextRawValue(DataInputBuffer)}
+     * has stable backing byte arrays.
+     * <p>
+     * Stable means the byte[] slices exposed through DataInputBuffer may be
+     * retained by the caller without being overwritten or reused by this reader.
+     * The result must be safe for both the key and the value of the current
+     * record, based on the invariant that current merge-based records are not
+     * assembled from different segments. If a reader cannot prove backing-array
+     * stability, it must return false.
+     *
+     * @return true if both key and value backing arrays for the current record
+     *         are stable; false otherwise.
+     */
+    boolean isCurrentRecordStable();
   }
 
   public interface KeyValueReaderBytesWritable extends KeyValueReaderBase {
@@ -1425,6 +1442,12 @@ public class IFile {
         newLength = currentLength << 1;
       }
       return new byte[newLength];
+    }
+
+
+    @Override
+    public boolean isCurrentRecordStable() {
+      return false;
     }
 
     public KeyState readRawKey(DataInputBuffer key) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -83,14 +83,14 @@ public class TezMerger {
 
     long recordCtr = 0;
     if (isRleEnabled) {
-      while (records.next()) {
+      while (records.next() != TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         // Even if records.isSameKey() is false, the two keys may be the same.
         DataInputBuffer key = records.isSameKey() ? IFile.REPEAT_KEY : records.getKey();
         writer.appendRle(key, records.getValue());
         if (((recordCtr++) % recordsBeforeProgress) == 0) { checkProgress(); }
       }
     } else {
-      while (records.next()) {
+      while (records.next() != TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         writer.appendNoRle(records.getKey(), records.getValue());
         if (((recordCtr++) % recordsBeforeProgress) == 0) { checkProgress(); }
       }
@@ -177,6 +177,10 @@ public class TezMerger {
 
     void nextRawValue(DataInputBuffer value) throws IOException {
       reader.nextRawValue(value);
+    }
+
+    boolean isCurrentRecordStable() {
+      return reader.isCurrentRecordStable();
     }
 
     void closeReader() throws IOException {
@@ -409,9 +413,9 @@ public class TezMerger {
       }
     }
 
-    public boolean next() throws IOException {
+    public int next() throws IOException {
       if (!hasNext()) {
-        return false;
+        return TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
       }
 
       minSegment = loserTree.top();
@@ -432,7 +436,9 @@ public class TezMerger {
         minSegment.getValue(value);
       }
 
-      return true;
+      return minSegment.isCurrentRecordStable()
+          ? TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE
+          : TezRawKeyValueIterator.NEXT_KEY_VALUE_VOLATILE;
     }
 
     boolean compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
@@ -800,8 +806,8 @@ public class TezMerger {
     }
 
     @Override
-    public boolean next() throws IOException {
-      return false;
+    public int next() throws IOException {
+      return TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
     }
 
     @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -27,6 +27,10 @@ import org.apache.hadoop.io.DataInputBuffer;
  */
 public interface TezRawKeyValueIterator {
 
+  int NO_MORE_KEY_VALUE = 0;
+  int NEXT_KEY_VALUE_VOLATILE = 1;
+  int NEXT_KEY_VALUE_STABLE = 2;
+
   // Invariant for current merge-based implementations:
   //   For any record loaded with next(),
   //    - getKey() and getValue() describe data from the same current record source/segment.
@@ -53,12 +57,26 @@ public interface TezRawKeyValueIterator {
   
   /** 
    * Sets up the current key and value (for getKey and getValue).
-   * 
-   * @return <code>true</code> if there exists a key/value, 
-   *         <code>false</code> otherwise. 
+   * <p>
+   * The returned stability code describes backing-array stability for both the
+   * key and the value of the current record. A stable result means the byte[]
+   * slices returned through {@link #getKey()} and {@link #getValue()} may be
+   * retained by callers without being overwritten or reused by this iterator. A
+   * volatile result means the current record exists, but the backing arrays must
+   * not be retained without copying.
+   * <p>
+   * For current merge-based implementations, for any record loaded with this
+   * method, {@link #getKey()} and {@link #getValue()} describe data from the
+   * same current record source/segment. A record is not assembled from a key
+   * from one segment and a value from another segment.
+   *
+   * @return {@link #NO_MORE_KEY_VALUE} if no key/value remains,
+   *         {@link #NEXT_KEY_VALUE_VOLATILE} if a key/value exists but its
+   *         backing arrays are not stable, or {@link #NEXT_KEY_VALUE_STABLE} if
+   *         a key/value exists and both key and value backing arrays are stable.
    * @throws IOException
    */
-  boolean next() throws IOException;
+  int next() throws IOException;
 
   /**
    * Returns true if any items are left in the iterator.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
@@ -47,8 +47,8 @@ public class OrderedGroupedInputLegacy extends OrderedGroupedKVInput {
           }
 
           @Override
-          public boolean next() throws IOException {
-            return false;
+          public int next() throws IOException {
+            return TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
           }
 
           @Override


### PR DESCRIPTION
### Motivation
- Avoid unnecessary byte[] allocations/copies in `ValuesIterator.copyToWritable()` by using a safe zero-copy fast path when the raw record backing arrays are provably stable. 
- Expose a stability/availability signal from raw iterators so callers can distinguish volatile (must-copy) vs stable (can reference backing array) records. 
- Preserve the existing merge provenance invariant that a record's key and value originate from the same segment when reporting stability. 

### Description
- Change `TezRawKeyValueIterator.next()` from `boolean` to `int` and add constants `NO_MORE_KEY_VALUE`, `NEXT_KEY_VALUE_VOLATILE`, and `NEXT_KEY_VALUE_STABLE`, plus Javadoc describing semantics and the merge-source invariant. 
- Add `isCurrentRecordStable()` to `IFile.KeyValueReaderDataInputBuffer` and implement it as `true` in `InMemoryReader`, `false` in disk `IFile.Reader`, and in `MergeManager.RawKVIteratorReader` based on the last `next()` result from the wrapped `TezRawKeyValueIterator`. 
- Thread stability through `TezMerger` segments and the merge queue: `Segment.isCurrentRecordStable()` delegates to its reader, `MergeQueue.next()` returns the new `next()` codes, and `TezMerger.writeFile()` consumes records until `NO_MORE_KEY_VALUE`. The `EmptyIterator` and zero-input anonymous iterators were updated to return `NO_MORE_KEY_VALUE`. 
- Implement a safe fast path in `ValuesIterator` by tracking the current record stability (`currentRecordStable`) and updating `copyToWritable()` to use `BytesWritable.setDirect()` when `stable==true` and to fall back to `reinitialize()` + `System.arraycopy()` when volatile. 
- Update call sites/adapters that used the old boolean `next()` such as the MapReduce `RawKeyValueIterator` adapter in `MRTask`, `MergeManager.RawKVIteratorReader`, `OrderedGroupedInputLegacy`, and relevant merger/iterator code to handle the new int return values. 

### Testing
- Ran `git diff --check` to validate workspace changes and whitespace issues, which reported no problems. (success) 
- Attempted to compile `tez-runtime-library` with `mvn -pl tez-runtime-library -am -DskipTests compile`, and variants including `-Dprotocjar.skip=true` and offline mode, but the build was blocked by external Maven plugin resolution failures (missing `protoc-jar-maven-plugin` / offline plugin artifacts), so full compile verification could not complete in this environment. (blocked)
- Performed repository-level static/grep inspections to ensure the `next()` call sites and reader/segment implementations were updated consistently. (informal static checks, success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22dcd72bc08328925f4e94204481a8)