### PR TITLE
Reduce key copy overhead in TezMerger by using KeyValueBuffer and volatile-key handling

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -20,11 +20,9 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 import java.io.IOException;
 import java.util.zip.CRC32;
 
-import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
-import org.apache.tez.runtime.library.utils.BufferUtils;
 import org.apache.tez.util.FastByteComparisons;
 
 public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
@@ -33,8 +31,11 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   private final CRC32 checksum = new CRC32();
   private int pos;
 
-  private DataInputBuffer prevKey = null;
-  private final DataOutputBuffer previous = new DataOutputBuffer();
+  private byte[] previousKeyData = new byte[0];
+  private int previousKeyOffset = 0;
+  private int previousKeyLength = 0;
+  private byte[] previousKeyCopy = new byte[0];
+  private boolean previousWasRepeat = false;
 
   // InMemoryWriter is used only in MergeManager.IntermediateMemoryToMemoryMerger with isRleEnabled = true.
   private final boolean isRleEnabled = true;
@@ -63,30 +64,37 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   }
 
   public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+    appendRle(key, value, false);
+  }
+
+  @Override
+  public void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException {
     assert isRleEnabled;
-    int keyLength = key.getLength() - key.getPosition();
+    int keyPosition = key.getPosition();
+    int keyLength = key.getLength() - keyPosition;
     int valueLength = value.getLength() - value.getPosition();
 
     boolean sameKey = key == IFile.REPEAT_KEY;
     if (!sameKey) {
-      sameKey = (keyLength != 0) && BufferUtils.compareEqual(previous, key);
+      sameKey = (keyLength != 0) && FastByteComparisons.compareEqual(
+          previousKeyData, previousKeyOffset, previousKeyLength, key.getData(), keyPosition, keyLength);
     }
 
     if (!sameKey) {
       // Normal key-value pair
       // Write V_END_MARKER if needed (if previous was a REPEAT_KEY)
-      if (prevKey == IFile.REPEAT_KEY) {
+      if (previousWasRepeat) {
         writeInt(IFile.V_END_MARKER);
       }
 
       long combined = ((long) valueLength << 32) | (keyLength & 0xFFFFFFFFL);
       writeLong(combined);
-      writeBytes(key.getData(), key.getPosition(), keyLength);
+      writeBytes(key.getData(), keyPosition, keyLength);
       writeBytes(value.getData(), value.getPosition(), valueLength);
-      BufferUtils.copy(key, previous);
+      populatePreviousKey(key.getData(), keyPosition, keyLength, keyStable);
     } else {
       // Repeated key
-      if (prevKey != IFile.REPEAT_KEY) {
+      if (!previousWasRepeat) {
         // First repeated key, write RLE marker
         writeInt(IFile.RLE_MARKER);
       }
@@ -96,7 +104,23 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       writeBytes(value.getData(), value.getPosition(), valueLength);
     }
 
-    prevKey = sameKey ? IFile.REPEAT_KEY : key;
+    previousWasRepeat = sameKey;
+  }
+
+  private void populatePreviousKey(byte[] keyData, int keyOffset, int keyLength, boolean keyStable) {
+    if (keyStable) {
+      previousKeyData = keyData;
+      previousKeyOffset = keyOffset;
+      previousKeyLength = keyLength;
+    } else {
+      if (previousKeyCopy.length < keyLength) {
+        previousKeyCopy = new byte[keyLength];
+      }
+      System.arraycopy(keyData, keyOffset, previousKeyCopy, 0, keyLength);
+      previousKeyData = previousKeyCopy;
+      previousKeyOffset = 0;
+      previousKeyLength = keyLength;
+    }
   }
 
   public void close() throws IOException {
@@ -112,7 +136,7 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
   private void closeRle() throws IOException {
     // Write V_END_MARKER if needed
-    if (prevKey == IFile.REPEAT_KEY) {
+    if (previousWasRepeat) {
       writeInt(IFile.V_END_MARKER);
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -109,6 +109,10 @@ public class IFile {
     // if key != IFile.REPEAT_KEY, perform key comparison to check whether 'key' is a new key or not
     void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException;
 
+    default void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException {
+      appendRle(key, value);
+    }
+
     void close() throws IOException;
   }
 
@@ -590,7 +594,10 @@ public class IFile {
 
   public static class WriterDataInputBuffer extends Writer implements WriterAppendDataInputBuffer {
 
-    private final DataOutputBuffer previous = new DataOutputBuffer();
+    private byte[] previousKeyData = new byte[0];
+    private int previousKeyOffset = 0;
+    private int previousKeyLength = 0;
+    private byte[] previousKeyCopy = new byte[0];
     private boolean previousSameKey = false;
 
     private long rleWritten = 0;      //number of RLE markers written
@@ -687,6 +694,11 @@ public class IFile {
     }
 
     public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+      appendRle(key, value, false);
+    }
+
+    @Override
+    public void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException {
       assert isRleEnabled && !useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
@@ -698,24 +710,45 @@ public class IFile {
       }
 
       appendRle(key.getData(), key.getPosition(), keyLength,
-          value.getData(), value.getPosition(), valueLength);
+          value.getData(), value.getPosition(), valueLength, keyStable);
     }
 
     public void appendRle(byte[] keyData, int keyOffset, int keyLength,
                           byte[] valueData, int valueOffset, int valueLength) throws IOException {
+      appendRle(keyData, keyOffset, keyLength, valueData, valueOffset, valueLength, false);
+    }
+
+    private void appendRle(byte[] keyData, int keyOffset, int keyLength,
+                           byte[] valueData, int valueOffset, int valueLength, boolean keyStable)
+        throws IOException {
       assert isRleEnabled && !useMaxKeyValLen;
       boolean sameKey = keyLength != 0 && FastByteComparisons.compareEqual(
-          previous.getData(), 0, previous.getLength(), keyData, keyOffset, keyLength);
+          previousKeyData, previousKeyOffset, previousKeyLength, keyData, keyOffset, keyLength);
       if (sameKey) {
         appendRepeatValue(valueData, valueOffset, valueLength);
       } else {
         writeValueMarker();
         super.writeKVPair(keyData, keyOffset, keyLength, valueData, valueOffset, valueLength);
-        previous.reset();
-        previous.write(keyData, keyOffset, keyLength);
+        populatePreviousKey(keyData, keyOffset, keyLength, keyStable);
         previousSameKey = false;
       }
       ++numRecordsWritten;
+    }
+
+    private void populatePreviousKey(byte[] keyData, int keyOffset, int keyLength, boolean keyStable) {
+      if (keyStable) {
+        previousKeyData = keyData;
+        previousKeyOffset = keyOffset;
+        previousKeyLength = keyLength;
+      } else {
+        if (previousKeyCopy.length < keyLength) {
+          previousKeyCopy = new byte[keyLength];
+        }
+        System.arraycopy(keyData, keyOffset, previousKeyCopy, 0, keyLength);
+        previousKeyData = previousKeyCopy;
+        previousKeyOffset = 0;
+        previousKeyLength = keyLength;
+      }
     }
 
     private void appendRepeatValue(byte[] valueData, int valueOffset, int valueLength) throws IOException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -109,9 +109,7 @@ public class IFile {
     // if key != IFile.REPEAT_KEY, perform key comparison to check whether 'key' is a new key or not
     void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException;
 
-    default void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException {
-      appendRle(key, value);
-    }
+    void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException;
 
     void close() throws IOException;
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -81,10 +81,12 @@ public class TezMerger {
 
     long recordCtr = 0;
     if (isRleEnabled) {
-      while (records.next() != TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
+      int nextResult;
+      while ((nextResult = records.next()) != TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         // Even if records.isSameKey() is false, the two keys may be the same.
         DataInputBuffer key = records.isSameKey() ? IFile.REPEAT_KEY : records.getKey();
-        writer.appendRle(key, records.getValue());
+        writer.appendRle(key, records.getValue(),
+            nextResult == TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE);
         if (((recordCtr++) % recordsBeforeProgress) == 0) { checkProgress(); }
       }
     } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.DataInputBuffer;
-import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TezCounter;
@@ -46,7 +45,6 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
-import org.apache.tez.runtime.library.utils.BufferUtils;
 
 /**
  * Merger is an utility class used by the Map and Reduce tasks for merging
@@ -321,7 +319,8 @@ public class TezMerger {
     };
 
     KeyState hasNext;
-    DataOutputBuffer prevKey = new DataOutputBuffer();
+    KeyValueBuffer prevKey = new KeyValueBuffer(Segment.EMPTY_BYTES, 0, 0);
+    byte[] prevKeyCopy = Segment.EMPTY_BYTES;
 
     public MergeQueue(Configuration conf, FileSystem fs,
         List<Segment> segments,
@@ -352,9 +351,20 @@ public class TezMerger {
       return value;
     }
 
-    private void populatePreviousKey() throws IOException {
-      key.reset();
-      BufferUtils.copy(key, prevKey);
+    private void populatePreviousKey(Segment currentSegment) {
+      KeyValueBuffer currentKey = currentSegment.getKey();
+      byte[] keyData = currentKey.getData();
+      int keyPosition = currentKey.getPosition();
+      int keyLength = currentKey.getLength();
+      if (currentSegment.isCurrentRecordStable()) {
+        prevKey.reset(keyData, keyPosition, keyLength);
+      } else {
+        if (prevKeyCopy.length < keyLength) {
+          prevKeyCopy = new byte[keyLength];
+        }
+        System.arraycopy(keyData, keyPosition, prevKeyCopy, 0, keyLength);
+        prevKey.reset(prevKeyCopy, 0, keyLength);
+      }
     }
 
     private void adjustPriorityQueue(Segment reader) throws IOException{
@@ -366,17 +376,18 @@ public class TezMerger {
            * during this process, we need to compare keys for RLE across segment boundaries.
            * prevKey can't be empty at that time (e.g custom comparators)
            */
-          populatePreviousKey();
+          populatePreviousKey(reader);
         } else {
           // indicates a key has been read already
           if (hasNext != KeyState.SAME_KEY) {
             /**
              * Store previous key before reading next for later key comparisons.
-             * If all keys in a segment are unique, it would always hit this code path and key copies
-             * are wasteful in such condition, as these comparisons are mainly done for RLE.
+             * If all keys in a segment are unique, it would always hit this code path. For
+             * volatile records this still requires a fallback key copy, which is wasteful in
+             * such condition, as these comparisons are mainly done for RLE.
              * TODO: When better stats are available, this condition can be avoided.
              */
-            populatePreviousKey();
+            populatePreviousKey(reader);
           }
         }
       }
@@ -441,14 +452,10 @@ public class TezMerger {
           : TezRawKeyValueIterator.NEXT_KEY_VALUE_VOLATILE;
     }
 
-    boolean compare(KeyValueBuffer nextKey, DataOutputBuffer buf2) {
-      byte[] b1 = nextKey.getData();
-      byte[] b2 = buf2.getData();
-      int s1 = nextKey.getPosition();
-      int s2 = 0;
-      int l1 = nextKey.getLength();
-      int l2 = buf2.getLength();
-      return FastByteComparisons.compareEqual(b1, s1, l1, b2, s2, l2);
+    boolean compare(KeyValueBuffer key1, KeyValueBuffer key2) {
+      return FastByteComparisons.compareEqual(
+          key1.getData(), key1.getPosition(), key1.getLength(),
+          key2.getData(), key2.getPosition(), key2.getLength());
     }
 
     /*


### PR DESCRIPTION
### Motivation

- Reduce unnecessary key byte copying during merge operations and handle volatile vs stable record buffers more efficiently to improve performance and memory usage.

### Description

- Replace the previous `DataOutputBuffer prevKey` with `KeyValueBuffer prevKey` and add a `byte[] prevKeyCopy` to only copy bytes when the record buffer is volatile.
- Change `populatePreviousKey()` to `populatePreviousKey(Segment)` and use the segment's `KeyValueBuffer` to reset `prevKey` directly for stable records and fallback to `prevKeyCopy` for unstable records.
- Update usages to call `populatePreviousKey(reader)` and adjust `compare(...)` to accept two `KeyValueBuffer` instances and compare via `FastByteComparisons.compareEqual(...)`.
- Remove the `DataOutputBuffer` and `BufferUtils` usages/imports and update related comments to reflect copy-avoidance behavior.

### Testing

- Ran the project's unit tests with `mvn -DskipTests=false test` and the module tests for the runtime library with `mvn -pl tez-runtime-library test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22f20831d48328b954f07dbe1edaa8)