### PR TITLE
Introduce TezRawDataBuffer and replace DataInputBuffer on hot raw-KV paths

### DIFF
--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTask.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTask.java
@@ -75,6 +75,7 @@ import org.apache.tez.runtime.api.AbstractLogicalIOProcessor;
 import org.apache.tez.runtime.api.LogicalOutput;
 import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.library.common.Constants;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
 public abstract class MRTask extends AbstractLogicalIOProcessor {
@@ -90,7 +91,7 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
   protected ProcessorContext processorContext;
   protected TaskAttemptID taskAttemptId;
   protected SecretKey jobTokenSecret;
-  
+
   LogicalOutput output;
 
   boolean isMap;
@@ -432,6 +433,8 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
     RawKeyValueIterator r =
         new RawKeyValueIterator() {
           private final Progress progress = new Progress();
+          private final DataInputBuffer keyBuffer = new DataInputBuffer();
+          private final DataInputBuffer valueBuffer = new DataInputBuffer();
           private boolean done = false;
 
           @Override
@@ -444,7 +447,8 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
 
           @Override
           public DataInputBuffer getValue() throws IOException {
-            return rIter.getValue();
+            resetDataInputBuffer(valueBuffer, rIter.getValue());
+            return valueBuffer;
           }
 
           @Override
@@ -455,12 +459,17 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
 
           @Override
           public DataInputBuffer getKey() throws IOException {
-            return rIter.getKey();
+            resetDataInputBuffer(keyBuffer, rIter.getKey());
+            return keyBuffer;
           }
 
           @Override
           public void close() throws IOException {
             rIter.close();
+          }
+
+          private void resetDataInputBuffer(DataInputBuffer target, TezRawDataBuffer source) {
+            target.reset(source.getData(), source.getPosition(), source.getRemaining());
           }
         };
     org.apache.hadoop.mapreduce.ReduceContext<INKEY, INVALUE, OUTKEY, OUTVALUE>
@@ -508,13 +517,13 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
     jobConf.setInt(JobContext.TASK_PARTITION,
         taskAttemptId.getTaskID().getId());
     jobConf.set(JobContext.ID, taskAttemptId.getJobID().toString());
-    
+
     jobConf.setBoolean(MRJobConfig.TASK_ISMAP, isMap);
-    
+
     Path outputPath = FileOutputFormat.getOutputPath(jobConf);
     if (outputPath != null) {
       if ((committer instanceof FileOutputCommitter)) {
-        FileOutputFormat.setWorkOutputPath(jobConf, 
+        FileOutputFormat.setWorkOutputPath(jobConf,
           ((FileOutputCommitter)committer).getTaskAttemptPath(taskAttemptContext));
       } else {
         FileOutputFormat.setWorkOutputPath(jobConf, outputPath);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.library.common.comparator.TezBytesComparator;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
@@ -32,10 +32,10 @@ import org.apache.tez.common.Preconditions;
 
 /**
  * Iterates values while keys match in sorted input.
- * 
+ *
  * This class is not thread safe. Accessing methods from multiple threads will
  * lead to corrupt data.
- * 
+ *
  */
 public class ValuesIterator {
 
@@ -47,13 +47,13 @@ public class ValuesIterator {
   private boolean currentRecordStable;
   private final TezCounter inputKeyCounter;
   private final TezCounter inputValueCounter;
-  
+
   private int keyCtr = 0;
   private boolean hasMoreValues; // For the current key.
   private boolean isFirstRecord = true;
 
   private boolean completedProcessing;
-  
+
   public ValuesIterator(TezRawKeyValueIterator in,
                         TezCounter inputKeyCounter,
                         TezCounter inputValueCounter) {
@@ -67,7 +67,7 @@ public class ValuesIterator {
   /**
    * Move to the next K-Vs pair
    * @return true if another pair exists, otherwise false.
-   * @throws IOException 
+   * @throws IOException
    */
   public boolean moveToNext() throws IOException {
     if (isFirstRecord) {
@@ -89,7 +89,7 @@ public class ValuesIterator {
   // Invariant:
   //   The backing byte[] array of BytesWritable is immutable, so the consumer may keep pointers to it.
   public BytesWritable getKey() {
-    return key; 
+    return key;
   }
 
   // Invariant:
@@ -102,7 +102,7 @@ public class ValuesIterator {
         return new Iterator<BytesWritable>() {
 
           private final int keyNumber = keyCtr;
-          
+
           @Override
           public boolean hasNext() {
             return hasMoreValues;
@@ -115,7 +115,7 @@ public class ValuesIterator {
             }
             Preconditions.checkState(keyNumber == keyCtr,
                 "Cannot use values iterator on the previous K-V pair after moveToNext has been invoked to move to the next K-V pair");
-            
+
             try {
               readNextValue();
               readNextKey();
@@ -138,7 +138,7 @@ public class ValuesIterator {
   /** Start processing next unique key. */
   private void nextKey() throws IOException {
     // read until we find a new key
-    while (hasMoreValues) { 
+    while (hasMoreValues) {
       readNextKey();
     }
 
@@ -149,15 +149,15 @@ public class ValuesIterator {
     hasMoreValues = more;
   }
 
-  /** 
+  /**
    * read the next key - which may be the same as the current key.
    */
   private void readNextKey() throws IOException {
     int nextResult = in.next();
     more = nextResult != TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
     currentRecordStable = nextResult == TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE;
-    if (more) {      
-      DataInputBuffer nextKeyBytes = in.getKey();
+    if (more) {
+      TezRawDataBuffer nextKeyBytes = in.getKey();
       if (!in.isSameKey()) {
         nextKey = copyToWritable(nextKey, nextKeyBytes, currentRecordStable);
         // hasMoreValues = is it first key or is key the same?
@@ -183,11 +183,11 @@ public class ValuesIterator {
    * @throws IOException
    */
   private void readNextValue() throws IOException {
-    DataInputBuffer nextValueBytes = in.getValue();
+    TezRawDataBuffer nextValueBytes = in.getValue();
     value = copyToWritable(value, nextValueBytes, currentRecordStable);
   }
 
-  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source, boolean stable) {
+  private BytesWritable copyToWritable(BytesWritable writable, TezRawDataBuffer source, boolean stable) {
     BytesWritable target = writable;
     if (target == null) {
       target = new BytesWritable();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -23,7 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
@@ -272,7 +272,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   @Override
-  public KeyState readRawKey(DataInputBuffer key) throws IOException {
+  public KeyState readRawKey(TezRawDataBuffer key) throws IOException {
     if (isRleEnabled) {
       return readRawKeyRle(key);
     } else {
@@ -280,7 +280,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
     }
   }
 
-  private KeyState readRawKeyNoRle(DataInputBuffer key) throws IOException {
+  private KeyState readRawKeyNoRle(TezRawDataBuffer key) throws IOException {
     if (!positionToNextRecordNoRle()) {
       return KeyState.NO_KEY;
     }
@@ -297,7 +297,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
     return KeyState.NEW_KEY;
   }
 
-  private KeyState readRawKeyRle(DataInputBuffer key) throws IOException {
+  private KeyState readRawKeyRle(TezRawDataBuffer key) throws IOException {
     if (!positionToNextRecordRle()) {
       return KeyState.NO_KEY;
     }
@@ -371,7 +371,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   @Override
-  public void nextRawValue(DataInputBuffer value) throws IOException {
+  public void nextRawValue(TezRawDataBuffer value) throws IOException {
     int pos = memDataIn.getPosition();
     byte[] data = memDataIn.getData();
     value.reset(data, pos, currentValueLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.zip.CRC32;
 
 import org.apache.hadoop.io.DataOutputBuffer;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
 import org.apache.tez.runtime.library.utils.BufferUtils;
@@ -33,7 +33,7 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   private final CRC32 checksum = new CRC32();
   private int pos;
 
-  private DataInputBuffer prevKey = null;
+  private TezRawDataBuffer prevKey = null;
   private final DataOutputBuffer previous = new DataOutputBuffer();
 
   // InMemoryWriter is used only in MergeManager.IntermediateMemoryToMemoryMerger with isRleEnabled = true.
@@ -54,15 +54,15 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       return isRleEnabled;
   }
 
-  public void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+  public void appendNoRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
     assert false;
   }
 
-  public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
+  public void appendNoRleTez(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
     assert false;
   }
 
-  public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+  public void appendRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
     assert isRleEnabled;
     int keyLength = key.getLength() - key.getPosition();
     int valueLength = value.getLength() - value.getPosition();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.hadoop.io.FileChunk;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.counters.TaskCounter;
@@ -69,7 +69,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @SuppressWarnings(value={"rawtypes"})
 public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
-  
+
   private static final Logger LOG = LoggerFactory.getLogger(MergeManager.class);
   private static final boolean isDebugEnabled = LOG.isDebugEnabled();
 
@@ -77,7 +77,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   private final FileSystem localFS;
   private final FileSystem rfs;
   private final LocalDirAllocator localDirAllocator;
-  
+
   private final TezTaskOutputFiles mapOutputFile;
 
   final Set<MapOutput> inMemoryMergedMapOutputs =
@@ -91,7 +91,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
   final Set<FileChunk> onDiskMapOutputs = new TreeSet<FileChunk>();
   final OnDiskMerger onDiskMerger;
-  
+
   private final long memoryLimit;
   final long postMergeMemLimit;
 
@@ -128,23 +128,23 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
   private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
-  private final int memToMemMergeOutputsThreshold; 
+  private final int memToMemMergeOutputsThreshold;
   private final long mergeThreshold;
-  
+
   private final ExceptionReporter exceptionReporter;
-  
+
   private final InputContext inputContext;
 
   private final TezCounter spilledRecordsCounter;
   private final TezCounter mergedMapOutputsCounter;
-  
+
   private final TezCounter numMemToDiskMerges;
   private final TezCounter numDiskToDiskMerges;
   private final TezCounter additionalSpillBytesWritten;
   private final TezCounter additionalSpillBytesRead;
-  
+
   private final CompressionCodec codec;
-  
+
   private final boolean ifileReadAhead;
   private final int ifileReadAheadLength;
 
@@ -167,7 +167,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
    */
   public MergeManager(Configuration conf,
                       FileSystem localFS,
-                      LocalDirAllocator localDirAllocator,  
+                      LocalDirAllocator localDirAllocator,
                       InputContext inputContext,
                       TezCounter spilledRecordsCounter,
                       TezCounter mergedMapOutputsCounter,
@@ -194,7 +194,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
     this.localFS = localFS;
     this.rfs = ((LocalFileSystem)localFS).getRaw();
-    
+
     this.numDiskToDiskMerges = inputContext.getCounters().findCounter(TaskCounter.MERGE_NUM_DISK_TO_DISK_MERGES);
     this.numMemToDiskMerges = inputContext.getCounters().findCounter(TaskCounter.MERGE_NUM_MEM_TO_DISK_MERGES);
     this.additionalSpillBytesWritten = inputContext.getCounters().findCounter(TaskCounter.SPILL_BYTES_DISK);
@@ -236,7 +236,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     } else {
       this.memoryLimit = memLimit;
     }
-    
+
     if (memoryAssigned < maxRedBuffer) {
       this.postMergeMemLimit = memoryAssigned;
     } else {
@@ -246,7 +246,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     this.ioSortFactor = conf.getInt(
         TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_FACTOR,
         TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_FACTOR_DEFAULT);
-    
+
     final float maxSingleShuffleMemoryLimitPercent = conf.getFloat(
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT,
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT_DEFAULT);
@@ -272,7 +272,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
                "postMergeMem=" + postMergeMemLimit + ", " +
                "memToMemMergeOutputsThreshold=" + memToMemMergeOutputsThreshold);
     }
-    
+
     if (this.maxSingleShuffleLimit >= this.mergeThreshold) {
       throw new RuntimeException("Invalid configuration: "
           + "maxSingleShuffleLimit should be less than mergeThreshold"
@@ -344,7 +344,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
       // Allow unit tests to fix Runtime memory
       long memLimit = (long)(maxAvailableTaskMemory * maxInMemCopyUse);
-      
+
       float maxRedPer = conf.getFloat(
           TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT,
           TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_BUFFER_PERCENT_DEFAULT);
@@ -418,7 +418,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       }
       return getDiskMapOutput(compressedLength, srcAttemptIdentifier, fetcher);
     }
-    
+
     // Stall shuffle if we are above the memory limit
 
     // It is possible that all threads could just be stalling and not make
@@ -534,7 +534,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   }
 
   @Override
-  public synchronized void closeInMemoryFile(MapOutput mapOutput) { 
+  public synchronized void closeInMemoryFile(MapOutput mapOutput) {
     inMemoryMapOutputs.add(mapOutput);
     trackAndLogCloseInMemoryFile(mapOutput);
 
@@ -576,7 +576,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       }
     }
   }
-  
+
   public synchronized void closeInMemoryMergedFile(MapOutput mapOutput) {
     inMemoryMergedMapOutputs.add(mapOutput);
     if (isDebugEnabled) {
@@ -703,7 +703,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   /**
    * Merges multiple in-memory segment to another in-memory segment
    */
-  private class IntermediateMemoryToMemoryMerger 
+  private class IntermediateMemoryToMemoryMerger
   extends MergeThread<MapOutput> {
 
     public IntermediateMemoryToMemoryMerger(MergeManager manager,
@@ -819,7 +819,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       //No OP
     }
   }
-  
+
   /**
    * Merges multiple in-memory segment to a disk segment
    */
@@ -867,7 +867,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       int noInMemorySegments = inMemorySegments.size();
 
       // TODO Maybe track serialized vs deserialized bytes.
-      
+
       // All disk writes done by this merge are overhead - due to the lack of
       // adequate memory to keep all segments in memory.
       outputPath = mapOutputFile.getInputFileForWrite(
@@ -903,7 +903,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         LOG.info("{} Merge of the {} files in-memory complete. Local file is {} of size {}",
             inputContext.getUniqueIdentifier(), noInMemorySegments, outputPath, outFileLen);
       } catch (IOException e) {
-        //make sure that we delete the ondisk file that we created 
+        //make sure that we delete the ondisk file that we created
         //earlier when we invoked cloneFileAttributes
         localFS.delete(outputPath, true);
         throw e;
@@ -1045,9 +1045,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       }
     }
   }
-  
+
   private long createInMemorySegments(List<MapOutput> inMemoryMapOutputs,
-                                      List<Segment> inMemorySegments, 
+                                      List<Segment> inMemorySegments,
                                       long leaveBytes) throws IOException {
     long totalSize = 0L;
     // We could use fullSize could come from the RamManager, but files can be
@@ -1115,13 +1115,13 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     }
 
     @Override
-    public IFile.Reader.KeyState readRawKey(DataInputBuffer key) throws IOException {
+    public IFile.Reader.KeyState readRawKey(TezRawDataBuffer key) throws IOException {
       lastNextResult = kvIter.next();
       if (lastNextResult == TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         return IFile.Reader.KeyState.NO_KEY;
       }
 
-      final DataInputBuffer kb = kvIter.getKey();
+      final TezRawDataBuffer kb = kvIter.getKey();
       final int kp = kb.getPosition();
       final int klen = kb.getLength() - kp;
       key.reset(kb.getData(), kp, klen);
@@ -1129,8 +1129,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     }
 
     @Override
-    public void nextRawValue(DataInputBuffer value) throws IOException {
-      final DataInputBuffer vb = kvIter.getValue();
+    public void nextRawValue(TezRawDataBuffer value) throws IOException {
+      final TezRawDataBuffer vb = kvIter.getValue();
       final int vp = vb.getPosition();
       final int vlen = vb.getLength() - vp;
       value.reset(vb.getData(), vp, vlen);
@@ -1169,13 +1169,13 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       inMemToDiskBytes = createInMemorySegments(inMemoryMapOutputs, memDiskSegments, this.postMergeMemLimit);
       final int numMemDiskSegments = memDiskSegments.size();
       if (numMemDiskSegments > 0 && ioSortFactor > onDiskMapOutputs.size()) {
-        
+
         // If we reach here, it implies that we have less than io.sort.factor
-        // disk segments and this will be incremented by 1 (result of the 
-        // memory segments merge). Since this total would still be 
+        // disk segments and this will be incremented by 1 (result of the
+        // memory segments merge). Since this total would still be
         // <= io.sort.factor, we will not do any more intermediate merges,
         // the merge of all these disk segments would be directly fed to the reduce method.
-        
+
         // must spill to disk, but can't retain in-mem for intermediate merge
         // Cannot use spill id in final merge as it would clobber with other files, hence using Integer.MAX_VALUE
         final Path outputPath = mapOutputFile.getInputFileForWrite(

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.tez.runtime.library.utils.CodecUtils;
 import org.apache.tez.util.FastByteComparisons;
@@ -55,7 +54,7 @@ import javax.annotation.Nullable;
  * <code>IFile</code> is the simple <key-len, value-len, key, value> format
  * for the intermediate map-outputs in Map-Reduce.
  *
- * There is a <code>Writer</code> to write out map-outputs in this format and 
+ * There is a <code>Writer</code> to write out map-outputs in this format and
  * a <code>Reader</code> to read files of this format.
  */
 public class IFile {
@@ -70,7 +69,7 @@ public class IFile {
   public static final byte FLAG_RLE_ENABLED = 0x02;
 
   // REPEAT_KEY is primarily an ordered-path optimization, and never used for unordered output.
-  public static final DataInputBuffer REPEAT_KEY = new DataInputBuffer();
+  public static final TezRawDataBuffer REPEAT_KEY = new TezRawDataBuffer();
   public static final byte[] HEADER = new byte[] { (byte) 'T', (byte) 'I', (byte) 'F', (byte) 0};
 
   private static final String INCOMPLETE_READ = "Requested to read %d got %d";
@@ -103,11 +102,11 @@ public class IFile {
     boolean isRleEnabled();
 
     // call when isRleEnabled is not statically known
-    void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException;
-    void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException;
+    void appendNoRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException;
+    void appendNoRleTez(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException;
 
     // if key != IFile.REPEAT_KEY, perform key comparison to check whether 'key' is a new key or not
-    void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException;
+    void appendRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException;
 
     void close() throws IOException;
   }
@@ -632,7 +631,7 @@ public class IFile {
       return isRleEnabled;
     }
 
-    public void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+    public void appendNoRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
       assert !isRleEnabled && !useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
@@ -649,7 +648,7 @@ public class IFile {
       ++numRecordsWritten;
     }
 
-    public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
+    public void appendNoRleTez(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
       assert !isRleEnabled && useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
@@ -686,7 +685,7 @@ public class IFile {
       ++numRecordsWritten;
     }
 
-    public void appendRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+    public void appendRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
       assert isRleEnabled && !useMaxKeyValLen;
       int keyLength = key.getLength() - key.getPosition();
       int valueLength = value.getLength() - value.getPosition();
@@ -939,15 +938,15 @@ public class IFile {
   }
 
   public interface KeyValueReaderDataInputBuffer extends KeyValueReaderBase {
-    Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
-    void nextRawValue(DataInputBuffer value) throws IOException;
+    Reader.KeyState readRawKey(TezRawDataBuffer key) throws IOException;
+    void nextRawValue(TezRawDataBuffer value) throws IOException;
 
     /**
      * Reports whether the most recently loaded current record returned through
-     * readRawKey(DataInputBuffer) and nextRawValue(DataInputBuffer)
+     * readRawKey(TezRawDataBuffer) and nextRawValue(TezRawDataBuffer)
      * has stable backing byte arrays.
      *
-     * Stable means the byte[] slices exposed through DataInputBuffer may be
+     * Stable means the byte[] slices exposed through TezRawDataBuffer may be
      * retained by the caller without being overwritten or reused by this reader.
      * The result must be safe for both the key and the value of the current
      * record, based on the invariant that current merge-based records are not
@@ -1016,7 +1015,7 @@ public class IFile {
     private int currentValueLength;
     private boolean eof = false;
     private int originalKeyLength;
-    private byte[] keyBytes = new byte[0];  // backing array for DataInputBuffer in readRawKey()
+    private byte[] keyBytes = new byte[0];  // backing array for TezRawDataBuffer in readRawKey()
 
     // for reporting errors
     private long bytesRead = 0;
@@ -1450,7 +1449,7 @@ public class IFile {
       return false;
     }
 
-    public KeyState readRawKey(DataInputBuffer key) throws IOException {
+    public KeyState readRawKey(TezRawDataBuffer key) throws IOException {
       if (isRleEnabled) {
         return readRawKeyRle(key);
       } else {
@@ -1458,7 +1457,7 @@ public class IFile {
       }
     }
 
-    private KeyState readRawKeyNoRle(DataInputBuffer key) throws IOException {
+    private KeyState readRawKeyNoRle(TezRawDataBuffer key) throws IOException {
       if (!positionToNextRecordNoRle()) {
         return KeyState.NO_KEY;
       }
@@ -1474,7 +1473,7 @@ public class IFile {
       return KeyState.NEW_KEY;
     }
 
-    private KeyState readRawKeyRle(DataInputBuffer key) throws IOException {
+    private KeyState readRawKeyRle(TezRawDataBuffer key) throws IOException {
       if (!positionToNextRecordRle()) {
         return KeyState.NO_KEY;
       }
@@ -1536,7 +1535,7 @@ public class IFile {
       return KeyState.NEW_KEY;
     }
 
-    public void nextRawValue(DataInputBuffer value) throws IOException {
+    public void nextRawValue(TezRawDataBuffer value) throws IOException {
       final byte[] valBytes;
       if ((value.getData().length < currentValueLength) || (value.getData() == keyBytes)) {
         valBytes = createLargerArray(currentValueLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounter;
@@ -73,7 +72,7 @@ import static org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord.ens
 
 @SuppressWarnings({"unchecked", "rawtypes"})
 public final class PipelinedSorter {
-  
+
   private static final Logger LOG = LoggerFactory.getLogger(PipelinedSorter.class);
   private static final boolean isDebugEnabled = LOG.isDebugEnabled();
 
@@ -555,7 +554,7 @@ public final class PipelinedSorter {
     int valend = -1;
     try {
       span.kvbuffer.put(key.getBytesRaw(), key.getOffset(), key.getLength());
-      valstart = span.kvbuffer.position();      
+      valstart = span.kvbuffer.position();
       span.kvbuffer.put(value.getBytesRaw(), value.getOffset(), value.getLength());
       valend = span.kvbuffer.position();
     } catch (BufferOverflowException overflow) {
@@ -1209,8 +1208,8 @@ public final class PipelinedSorter {
   }
 
 
-  private static final class InputByteBuffer extends DataInputBuffer {
-    private byte[] buffer = new byte[256]; 
+  private static final class InputByteBuffer extends TezRawDataBuffer {
+    private byte[] buffer = new byte[256];
     private ByteBuffer wrapped = ByteBuffer.wrap(buffer);
     private void resize(int length) {
       if (length > buffer.length || (buffer.length > 10 * (1+length))) {
@@ -1222,7 +1221,7 @@ public final class PipelinedSorter {
     }
 
     // shallow copy
-    public void reset(DataInputBuffer clone) {
+    public void reset(TezRawDataBuffer clone) {
       byte[] data = clone.getData();
       int start = clone.getPosition();
       int length = clone.getLength() - start;
@@ -1231,7 +1230,7 @@ public final class PipelinedSorter {
 
     // deep copy
     @SuppressWarnings("unused")
-    public void copy(DataInputBuffer clone) {
+    public void copy(TezRawDataBuffer clone) {
       byte[] data = clone.getData();
       int start = clone.getPosition();
       int length = clone.getLength() - start;
@@ -1500,7 +1499,7 @@ public final class PipelinedSorter {
           kvmetaArray, offsetForIntIndex(kvi + PARTITION));
       final int kvjp = FastByteComparisons.theUnsafe.getInt(
           kvmetaArray, offsetForIntIndex(kvj + PARTITION));
-      // sort by partition      
+      // sort by partition
       if (kvip != kvjp) {
         return kvip - kvjp;
       }
@@ -1563,7 +1562,7 @@ public final class PipelinedSorter {
       return remaining;
     }
 
-    private int compareInternal(final DataInputBuffer needle, final int needlePart, final int index) {
+    private int compareInternal(final TezRawDataBuffer needle, final int needlePart, final int index) {
       int cmp;
       final int partition = FastByteComparisons.theUnsafe.getInt(
           kvmetaArray, offsetForIntIndex(this.offsetFor(index) + PARTITION));
@@ -1584,11 +1583,11 @@ public final class PipelinedSorter {
       }
       return cmp;
     }
-    
+
     private long getEq() {
       return eq;
     }
-    
+
     @Override
     public String toString() {
         return String.format("Span[%d,%d]", kvmetaCapacity, kvbuffer.limit());
@@ -1619,13 +1618,13 @@ public final class PipelinedSorter {
       this.maxindex = span.length() - 1;
     }
 
-    public DataInputBuffer getKey()  {
+    public TezRawDataBuffer getKey()  {
       key.reset(kvbufferArray, kvbufferArrayOffset + keyStart, keyLength);
       return key;
     }
 
     public boolean next() {
-      // caveat: since we use this as a comparable in the merger 
+      // caveat: since we use this as a comparable in the merger
       if (kvindex == maxindex) return false;
       kvindex += 1;
       loadCurrentRecordMetadata();
@@ -1659,7 +1658,7 @@ public final class PipelinedSorter {
           other.kvbufferArray, other.kvbufferArrayOffset + other.keyStart + skip,
           other.keyLength - skip);
     }
-    
+
     @Override
     public String toString() {
       return String.format("SpanIterator<%d:%d> (span=%s)", kvindex, maxindex, span.toString());
@@ -1669,11 +1668,11 @@ public final class PipelinedSorter {
      * bisect returns the next insertion point for a given raw key, skipping keys
      * which are <= needle using a binary search instead of a linear comparison.
      * This is massively efficient when long strings of identical keys occur.
-     * @param needle 
+     * @param needle
      * @param needlePart
      * @return
      */
-    int bisect(DataInputBuffer needle, int needlePart) {
+    int bisect(TezRawDataBuffer needle, int needlePart) {
       int start = kvindex;
       int end = maxindex-1;
       int mid;
@@ -1686,8 +1685,8 @@ public final class PipelinedSorter {
       if (span.compareInternal(needle, needlePart, start) > 0) {
         return kvindex;
       }
-      
-      // bail out early if we haven't got a min run 
+
+      // bail out early if we haven't got a min run
       if (span.compareInternal(needle, needlePart, start+minrun) > 0) {
         return 0;
       }
@@ -1695,9 +1694,9 @@ public final class PipelinedSorter {
       if (span.compareInternal(needle, needlePart, end) < 0) {
         return end - kvindex;
       }
-      
+
       boolean found = false;
-      
+
       // Bound the search work: the span can be large, but this bisection is an
       // optimization only, and minrun already defines the minimum profitable run.
       for (int i = 0; start < end && i < minrun; i++) {
@@ -1707,7 +1706,7 @@ public final class PipelinedSorter {
           start = mid;
           found = true;
         } else if (cmp < 0) {
-          start = mid; 
+          start = mid;
           found = true;
         }
         if (cmp > 0) {
@@ -2011,7 +2010,7 @@ public final class PipelinedSorter {
     private SpanIterator horse;
     private long total = 0;
     private long eq = 0;
-    
+
     public SpanMerger() {
       // SpanIterators are comparable
       partIter = new PartitionFilter(this);
@@ -2087,7 +2086,7 @@ public final class PipelinedSorter {
       horse = current;
       return current;
     }
-    
+
     public boolean needsRLE() {
       return (eq > 0.1 * total);
     }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TezCounter;
@@ -55,7 +54,7 @@ public class TezMerger {
   private static final Logger LOG = LoggerFactory.getLogger(TezMerger.class);
 
   // Local directories
-  private static LocalDirAllocator lDirAlloc = 
+  private static LocalDirAllocator lDirAlloc =
     new LocalDirAllocator(TezRuntimeFrameworkConfigs.LOCAL_DIRS);
 
   public static
@@ -83,7 +82,7 @@ public class TezMerger {
     if (isRleEnabled) {
       while (records.next() != TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         // Even if records.isSameKey() is false, the two keys may be the same.
-        DataInputBuffer key = records.isSameKey() ? IFile.REPEAT_KEY : records.getKey();
+        TezRawDataBuffer key = records.isSameKey() ? IFile.REPEAT_KEY : records.getKey();
         writer.appendRle(key, records.getValue());
         if (((recordCtr++) % recordsBeforeProgress) == 0) { checkProgress(); }
       }
@@ -152,7 +151,7 @@ public class TezMerger {
 
     KeyValueBuffer getKey() { return key; }
 
-    DataInputBuffer getValue(DataInputBuffer value) throws IOException {
+    TezRawDataBuffer getValue(TezRawDataBuffer value) throws IOException {
       nextRawValue(value);
       return value;
     }
@@ -161,19 +160,19 @@ public class TezMerger {
       return reader.getLength();
     }
 
-    KeyState readRawKey(DataInputBuffer nextKey) throws IOException {
+    KeyState readRawKey(TezRawDataBuffer nextKey) throws IOException {
       KeyState keyState = reader.readRawKey(nextKey);
       key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
       return keyState;
     }
 
-    boolean nextRawKey(DataInputBuffer nextKey) throws IOException {
+    boolean nextRawKey(TezRawDataBuffer nextKey) throws IOException {
       boolean hasNext = reader.readRawKey(nextKey) != KeyState.NO_KEY;
       key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
       return hasNext;
     }
 
-    void nextRawValue(DataInputBuffer value) throws IOException {
+    void nextRawValue(TezRawDataBuffer value) throws IOException {
       reader.nextRawValue(value);
     }
 
@@ -300,14 +299,14 @@ public class TezMerger {
 
     // Invariant: Segment.close() is called for all Segment objects
     List<Segment> segments = new ArrayList<Segment>();
-    
-    final DataInputBuffer key = new DataInputBuffer();
-    final DataInputBuffer value = new DataInputBuffer();
-    final DataInputBuffer nextKey = new DataInputBuffer();
-    final DataInputBuffer diskIFileValue = new DataInputBuffer();
-    
+
+    final TezRawDataBuffer key = new TezRawDataBuffer();
+    final TezRawDataBuffer value = new TezRawDataBuffer();
+    final TezRawDataBuffer nextKey = new TezRawDataBuffer();
+    final TezRawDataBuffer diskIFileValue = new TezRawDataBuffer();
+
     Segment minSegment;
-    Comparator<Segment> segmentComparator =   
+    Comparator<Segment> segmentComparator =
       new Comparator<Segment>() {
       public int compare(Segment o1, Segment o2) {
         if (o1.getLength() == o2.getLength()) {
@@ -343,11 +342,11 @@ public class TezMerger {
       }
     }
 
-    public DataInputBuffer getKey() throws IOException {
+    public TezRawDataBuffer getKey() throws IOException {
       return key;
     }
 
-    public DataInputBuffer getValue() throws IOException {
+    public TezRawDataBuffer getValue() throws IOException {
       return value;
     }
 
@@ -607,7 +606,7 @@ public class TezMerger {
       int numSegments = segments.size();
       int origFactor = factor;
       int passNo = 1;
-      
+
       // create the MergeStreams from the sorted map created in the constructor
       // and dump the final output to a file
       byte[] writeBuffer = IFile.allocateWriteBuffer();
@@ -625,7 +624,7 @@ public class TezMerger {
         while (true) {
           // extract the smallest 'factor' number of segments
           // Call cleanup on the empty segments (no key/value data)
-          List<Segment> mStream = 
+          List<Segment> mStream =
             getSegmentDescriptors(numSegmentsToConsider);
           for (Segment segment : mStream) {
             // Initialize the segment at the last possible moment;
@@ -633,7 +632,7 @@ public class TezMerger {
 
             segment.init(readsCounter, bytesReadCounter);
             boolean hasNext = segment.nextRawKey(nextKey);
-            
+
             if (hasNext) {
               segmentsToMerge.add(segment);
               segmentsConsidered++;
@@ -644,7 +643,7 @@ public class TezMerger {
             }
           }
           // if we have the desired number of segments or looked at all available segments, we break
-          if (segmentsConsidered == factor || 
+          if (segmentsConsidered == factor ||
               segments.size() == 0) {
             break;
           }
@@ -652,14 +651,14 @@ public class TezMerger {
           // Get the correct # of segments in case some of them were empty.
           numSegmentsToConsider = factor - segmentsConsidered;
         }
-        
+
         // feed the streams to the loser tree
         loserTree.initialize(segmentsToMerge.size());
         for (Segment segment : segmentsToMerge) {
           loserTree.put(segment);
         }
         loserTree.build();
-        
+
         // if we have lesser number of segments remaining, then just return the iterator,
         // else do another single level merge
         if (numSegments <= factor) { // Will always kick in if only in-mem segments are provided.
@@ -677,9 +676,9 @@ public class TezMerger {
                 " intermediate segments out of a total of " +
                 (segments.size() + segmentsToMerge.size()));
           }
-          
+
           // we want to spread the creation of temp files on multiple disks if available under the space constraints
-          long approxOutputSize = 0; 
+          long approxOutputSize = 0;
           for (Segment s : segmentsToMerge) {
             approxOutputSize += s.getLength() + (long)ChecksumFileSystem.getApproxChkSumLength(s.getLength());
           }
@@ -710,7 +709,7 @@ public class TezMerger {
 
           writeFile(this, writer, recordsBeforeProgress);
           writer.close();
-          
+
           // we finished one single level merge; now clean up the loser tree
           this.close();
 
@@ -742,7 +741,7 @@ public class TezMerger {
         factor = origFactor;
       } while(true);
     }
-    
+
     /**
      * Determine the number of segments to merge in a given pass. Assuming more
      * than factor segments, the first pass should attempt to bring the total
@@ -751,14 +750,14 @@ public class TezMerger {
      */
     private static int getPassFactor(int factor, int passNo, int numSegments) {
       // passNo > 1 in the OR list - is that correct ?
-      if (passNo > 1 || numSegments <= factor || factor == 1) 
+      if (passNo > 1 || numSegments <= factor || factor == 1)
         return factor;
       int mod = (numSegments - 1) % (factor - 1);
       if (mod == 0)
         return factor;
       return mod + 1;
     }
-    
+
     /** Return (& remove) the requested number of segment descriptors from the
      * sorted map.
      */
@@ -775,7 +774,7 @@ public class TezMerger {
       subList.clear();
       return subListCopy;
     }
-    
+
     @Override
     public boolean isSameKey() {
       return (hasNext != null) && (hasNext == KeyState.SAME_KEY);
@@ -803,12 +802,12 @@ public class TezMerger {
 
   private static class EmptyIterator implements TezRawKeyValueIterator {
     @Override
-    public DataInputBuffer getKey() throws IOException {
+    public TezRawDataBuffer getKey() throws IOException {
       throw new RuntimeException("No keys on an empty iterator");
     }
 
     @Override
-    public DataInputBuffer getValue() throws IOException {
+    public TezRawDataBuffer getValue() throws IOException {
       throw new RuntimeException("No values on an empty iterator");
     }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawDataBuffer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawDataBuffer.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.sort.impl;
+
+/**
+ * Minimal byte-array slice holder used for raw intermediate keys and values.
+ *
+ * <p>The ordered shuffle/merge paths only need a buffer to describe the
+ * current key/value bytes. Hadoop's {@code DataInputBuffer} also carries
+ * {@code InputStream}/{@code DataInput} machinery which is unused on these
+ * hot paths. This class intentionally exposes the small subset of methods that
+ * those callers use, while preserving {@code DataInputBuffer}'s offset/length
+ * convention: {@link #getPosition()} is the slice start and
+ * {@link #getLength()} is the exclusive end offset in the backing array.</p>
+ */
+public class TezRawDataBuffer {
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  private byte[] data = EMPTY_BYTES;
+  private int position;
+  private int length;
+
+  public TezRawDataBuffer() {
+  }
+
+  public TezRawDataBuffer(byte[] data, int length) {
+    reset(data, length);
+  }
+
+  public TezRawDataBuffer(byte[] data, int position, int length) {
+    reset(data, position, length);
+  }
+
+  public void reset(byte[] input, int length) {
+    reset(input, 0, length);
+  }
+
+  public void reset(byte[] input, int position, int length) {
+    this.data = input;
+    this.position = position;
+    this.length = position + length;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  public int getPosition() {
+    return position;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public int getRemaining() {
+    return length - position;
+  }
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -19,11 +19,10 @@ package org.apache.tez.runtime.library.common.sort.impl;
 
 import java.io.IOException;
 
-import org.apache.hadoop.io.DataInputBuffer;
 
 /**
  * <code>TezRawKeyValueIterator</code> is an iterator used to iterate over
- * the raw keys and values during sort/merge of intermediate data. 
+ * the raw keys and values during sort/merge of intermediate data.
  */
 public interface TezRawKeyValueIterator {
 
@@ -39,23 +38,23 @@ public interface TezRawKeyValueIterator {
   // This provenance invariant does not by itself imply that the returned backing arrays are stable/immutable.
   // Segment/source-specific stability must be reported separately.
 
-  /** 
+  /**
    * Gets the current raw key.
-   * 
-   * @return Gets the current raw key as a DataInputBuffer
+   *
+   * @return Gets the current raw key as a TezRawDataBuffer
    * @throws IOException
    */
-  DataInputBuffer getKey() throws IOException;
-  
-  /** 
+  TezRawDataBuffer getKey() throws IOException;
+
+  /**
    * Gets the current raw value.
-   * 
-   * @return Gets the current raw value as a DataInputBuffer 
+   *
+   * @return Gets the current raw value as a TezRawDataBuffer
    * @throws IOException
    */
-  DataInputBuffer getValue() throws IOException;
-  
-  /** 
+  TezRawDataBuffer getValue() throws IOException;
+
+  /**
    * Sets up the current key and value (for getKey and getValue).
    *
    * The returned stability code describes backing-array stability for both the
@@ -84,13 +83,13 @@ public interface TezRawKeyValueIterator {
    */
   boolean hasNext() throws IOException;
 
-  /** 
+  /**
    * Closes the iterator so that the underlying streams can be closed.
-   * 
+   *
    * @throws IOException
    */
   void close() throws IOException;
-  
+
   /**
    * Whether the current key is same as the previous key
    *

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -56,7 +56,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.CompressionCodec;
@@ -825,8 +825,8 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
               spillNumber, spillPathDetails.outputFilePath.toString(), canUseBuffers);
         }
 
-        DataInputBuffer key = new DataInputBuffer();
-        DataInputBuffer val = new DataInputBuffer();
+        TezRawDataBuffer key = new TezRawDataBuffer();
+        TezRawDataBuffer val = new TezRawDataBuffer();
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
         for (int i = 0; i < numPartitions; i++) {
@@ -899,7 +899,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
   }
 
   private long writePartition(int pos, WrappedBuffer wrappedBuffer, WriterDataInputBuffer writer,
-      DataInputBuffer keyBuffer, DataInputBuffer valBuffer) throws IOException {
+      TezRawDataBuffer keyBuffer, TezRawDataBuffer valBuffer) throws IOException {
     long numRecords = 0;
     while (pos != WrappedBuffer.PARTITION_ABSENT_POSITION) {
       int metaIndex = pos / INT_SIZE;
@@ -1338,11 +1338,11 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     final Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
         (compositeFetch && !isFinalMergeRleEnabled) ? new HashMap<>() : null;
 
-    DataInputBuffer keyBuffer = new DataInputBuffer();
-    DataInputBuffer valBuffer = new DataInputBuffer();
+    TezRawDataBuffer keyBuffer = new TezRawDataBuffer();
+    TezRawDataBuffer valBuffer = new TezRawDataBuffer();
 
-    DataInputBuffer keyBufferIFile = new DataInputBuffer();
-    DataInputBuffer valBufferIFile = new DataInputBuffer();
+    TezRawDataBuffer keyBufferIFile = new TezRawDataBuffer();
+    TezRawDataBuffer valBufferIFile = new TezRawDataBuffer();
 
     MultiByteArrayOutputStream byteArrayOutput = null;
     if (useFreeMemoryWriterOutput) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -875,8 +875,6 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
             }
           }
         }
-        key.close();
-        val.close();
       } finally {
         if (compressorExternal != null) {
           outputContext.returnCompressor(codec.getCompressorType(), compressorExternal);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
@@ -20,7 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
@@ -37,12 +37,12 @@ public class OrderedGroupedInputLegacy extends OrderedGroupedKVInput {
       if (getNumPhysicalInputs() == 0) {
         return new TezRawKeyValueIterator() {
           @Override
-          public DataInputBuffer getKey() throws IOException {
+          public TezRawDataBuffer getKey() throws IOException {
             throw new RuntimeException("No data available in Input");
           }
 
           @Override
-          public DataInputBuffer getValue() throws IOException {
+          public TezRawDataBuffer getValue() throws IOException {
             throw new RuntimeException("No data available in Input");
           }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/BufferUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/BufferUtils.java
@@ -20,13 +20,13 @@ package org.apache.tez.runtime.library.utils;
 
 import java.io.IOException;
 
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.tez.util.FastByteComparisons;
 
 public class BufferUtils {
 
-  public static int compare(DataInputBuffer buf1, DataInputBuffer buf2) {
+  public static int compare(TezRawDataBuffer buf1, TezRawDataBuffer buf2) {
     byte[] b1 = buf1.getData();
     byte[] b2 = buf2.getData();
     int s1 = buf1.getPosition();
@@ -56,7 +56,7 @@ public class BufferUtils {
     return FastByteComparisons.compareEqual(b1, s1, l1, b2, s2, l2);
   }
 
-  public static int compare(DataInputBuffer buf1, DataOutputBuffer buf2) {
+  public static int compare(TezRawDataBuffer buf1, DataOutputBuffer buf2) {
     byte[] b1 = buf1.getData();
     byte[] b2 = buf2.getData();
     int s1 = buf1.getPosition();
@@ -66,11 +66,11 @@ public class BufferUtils {
     return FastByteComparisons.compareTo(b1, s1, (l1 - s1), b2, s2, l2);
   }
 
-  public static int compare(DataOutputBuffer buf1, DataInputBuffer buf2) {
+  public static int compare(DataOutputBuffer buf1, TezRawDataBuffer buf2) {
     return compare(buf2, buf1);
   }
 
-  public static boolean compareEqual(DataOutputBuffer buf2, DataInputBuffer buf1) {
+  public static boolean compareEqual(DataOutputBuffer buf2, TezRawDataBuffer buf1) {
     byte[] b1 = buf1.getData();
     byte[] b2 = buf2.getData();
     int s1 = buf1.getPosition();
@@ -80,7 +80,7 @@ public class BufferUtils {
     return FastByteComparisons.compareEqual(b1, s1, (l1 - s1), b2, s2, l2);
   }
 
-  public static void copy(DataInputBuffer src, DataOutputBuffer dst) throws IOException {
+  public static void copy(TezRawDataBuffer src, DataOutputBuffer dst) throws IOException {
     byte[] b1 = src.getData();
     int s1 = src.getPosition();
     int l1 = src.getLength();


### PR DESCRIPTION
### Motivation

- Reduce overhead and footprint of using Hadoop's `DataInputBuffer` on hot merge/shuffle/sort codepaths by replacing it with a minimal byte-slice holder. 
- Expose only the lightweight slice API callers need (backing array, start, length) to avoid unused `DataInput`/`InputStream` machinery and improve performance on tight loops.
- Keep compatibility at the MapReduce bridge by adapting to `DataInputBuffer` only at the external boundary.

### Description

- Add `TezRawDataBuffer` as a compact byte-slice holder with `getData()`, `getPosition()`, `getLength()`, `getRemaining()`, and `reset(...)` helpers (file: `tez-runtime-library/.../TezRawDataBuffer.java`).
- Replace usages of `DataInputBuffer` on internal raw-KV paths with `TezRawDataBuffer` and update the iterator and IFile contracts to use it: `TezRawKeyValueIterator`, `IFile` reader/writer interfaces and implementations now accept/populate `TezRawDataBuffer` slices.
- Refactor hot components (merge/sort/shuffle/writer/reader paths) to use `TezRawDataBuffer`: `TezMerger`, `PipelinedSorter`, `MergeManager`, `InMemoryReader`/`InMemoryWriter`, `InMemoryWriter`, `ValuesIterator`, `UnorderedPartitionedKVWriter`, and related utilities (notable files changed include those under `tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/`, `.../shuffle/orderedgrouped/`, `.../writers/`, `.../input/`, and `tez-mapreduce/src/.../MRTask.java`).
- Preserve `DataInputBuffer` at the MR bridge only: `MRTask` now adapts `TezRawDataBuffer` into reusable `DataInputBuffer` instances by resetting adapter buffers for the reduce `RawKeyValueIterator`.
- Update `BufferUtils` helpers to operate with `TezRawDataBuffer` where appropriate and keep semantics identical (offset/length conventions unchanged).

### Testing

- Ran `git diff --check` and fixed trailing whitespace issues; the diff check passed.
- Verified there are no remaining `org.apache.hadoop.io.DataInputBuffer` imports in the runtime-library code with `rg` checks; the runtime-library now uses `TezRawDataBuffer` on internal paths.
- Attempted compilation with `mvn -pl tez-runtime-library,tez-mapreduce -DskipTests compile`, but the build could not complete in this environment because Maven failed to resolve `com.github.os72:protoc-jar-maven-plugin:3.11.4` (HTTP 403 from remote repository); the refactor is syntactically compiled locally where possible, but a full project compile was blocked by external dependency resolution. 
- Other local validations (searches and source-level checks) were performed to ensure API consistency and bridging at the MR boundary.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23117cba588328bb080e4d8324ea31)