### PR TITLE
Replace raw KV DataInputBuffer usage with TezRawDataBuffer

### DIFF
--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTask.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/processor/MRTask.java
@@ -75,6 +75,7 @@ import org.apache.tez.runtime.api.AbstractLogicalIOProcessor;
 import org.apache.tez.runtime.api.LogicalOutput;
 import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.library.common.Constants;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
 public abstract class MRTask extends AbstractLogicalIOProcessor {
@@ -432,6 +433,8 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
     RawKeyValueIterator r =
         new RawKeyValueIterator() {
           private final Progress progress = new Progress();
+          private final DataInputBuffer keyBuffer = new DataInputBuffer();
+          private final DataInputBuffer valueBuffer = new DataInputBuffer();
           private boolean done = false;
 
           @Override
@@ -444,7 +447,9 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
 
           @Override
           public DataInputBuffer getValue() throws IOException {
-            return rIter.getValue();
+            TezRawDataBuffer value = rIter.getValue();
+            valueBuffer.reset(value.getData(), value.getPosition(), value.getRemaining());
+            return valueBuffer;
           }
 
           @Override
@@ -455,7 +460,9 @@ public abstract class MRTask extends AbstractLogicalIOProcessor {
 
           @Override
           public DataInputBuffer getKey() throws IOException {
-            return rIter.getKey();
+            TezRawDataBuffer key = rIter.getKey();
+            keyBuffer.reset(key.getData(), key.getPosition(), key.getRemaining());
+            return keyBuffer;
           }
 
           @Override

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezEvent.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezEvent.java
@@ -23,7 +23,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.Writable;
 import org.apache.tez.common.ProtoConverters;
 import org.apache.tez.common.TezConverterUtils;
@@ -258,17 +257,9 @@ public class TezEvent implements Writable {
       ((TaskStatusUpdateEvent)event).readFields(in);
     } else {
       int eventBytesLen = in.readInt();
-      byte[] eventBytes;
-      CodedInputStream input;
-      int startOffset = 0;
-      if (in instanceof DataInputBuffer) {
-        eventBytes = ((DataInputBuffer)in).getData();
-        startOffset = ((DataInputBuffer) in).getPosition();
-      } else {
-        eventBytes = new byte[eventBytesLen];
-        in.readFully(eventBytes);
-      }
-      input = CodedInputStream.newInstance(eventBytes, startOffset, eventBytesLen);
+      byte[] eventBytes = new byte[eventBytesLen];
+      in.readFully(eventBytes);
+      CodedInputStream input = CodedInputStream.newInstance(eventBytes);
       switch (eventType) {
       case CUSTOM_PROCESSOR_EVENT:
         CustomProcessorEventProto cpProto =
@@ -330,13 +321,6 @@ public class TezEvent implements Writable {
         // RootInputUpdatePayload event not wrapped in a TezEvent.
         throw new TezUncheckedException("Unexpected TezEvent"
            + ", type=" + eventType);
-      }
-      if (in instanceof DataInputBuffer) {
-        // Skip so that position is updated
-        int skipped = in.skipBytes(eventBytesLen);
-        if (skipped != eventBytesLen) {
-          throw new TezUncheckedException("Expected to skip " + eventBytesLen + " bytes. Actually skipped = " + skipped);
-        }
       }
     }
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ValuesIterator.java
@@ -23,7 +23,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.library.common.comparator.TezBytesComparator;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
@@ -157,7 +157,7 @@ public class ValuesIterator {
     more = nextResult != TezRawKeyValueIterator.NO_MORE_KEY_VALUE;
     currentRecordStable = nextResult == TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE;
     if (more) {      
-      DataInputBuffer nextKeyBytes = in.getKey();
+      TezRawDataBuffer nextKeyBytes = in.getKey();
       if (!in.isSameKey()) {
         nextKey = copyToWritable(nextKey, nextKeyBytes, currentRecordStable);
         // hasMoreValues = is it first key or is key the same?
@@ -183,18 +183,18 @@ public class ValuesIterator {
    * @throws IOException
    */
   private void readNextValue() throws IOException {
-    DataInputBuffer nextValueBytes = in.getValue();
+    TezRawDataBuffer nextValueBytes = in.getValue();
     value = copyToWritable(value, nextValueBytes, currentRecordStable);
   }
 
-  private BytesWritable copyToWritable(BytesWritable writable, DataInputBuffer source, boolean stable) {
+  private BytesWritable copyToWritable(BytesWritable writable, TezRawDataBuffer source, boolean stable) {
     BytesWritable target = writable;
     if (target == null) {
       target = new BytesWritable();
     }
 
     int pos = source.getPosition();
-    int length = source.getLength() - pos;
+    int length = source.getRemaining();
     if (stable) {
       target.setDirect(source.getData(), pos, length);
     } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -23,7 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
@@ -272,7 +272,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   @Override
-  public KeyState readRawKey(DataInputBuffer key) throws IOException {
+  public KeyState readRawKey(TezRawDataBuffer key) throws IOException {
     if (isRleEnabled) {
       return readRawKeyRle(key);
     } else {
@@ -280,7 +280,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
     }
   }
 
-  private KeyState readRawKeyNoRle(DataInputBuffer key) throws IOException {
+  private KeyState readRawKeyNoRle(TezRawDataBuffer key) throws IOException {
     if (!positionToNextRecordNoRle()) {
       return KeyState.NO_KEY;
     }
@@ -297,7 +297,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
     return KeyState.NEW_KEY;
   }
 
-  private KeyState readRawKeyRle(DataInputBuffer key) throws IOException {
+  private KeyState readRawKeyRle(TezRawDataBuffer key) throws IOException {
     if (!positionToNextRecordRle()) {
       return KeyState.NO_KEY;
     }
@@ -371,7 +371,7 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   @Override
-  public void nextRawValue(DataInputBuffer value) throws IOException {
+  public void nextRawValue(TezRawDataBuffer value) throws IOException {
     int pos = memDataIn.getPosition();
     byte[] data = memDataIn.getData();
     value.reset(data, pos, currentValueLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -20,12 +20,12 @@ package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 import java.io.IOException;
 import java.util.zip.CRC32;
 
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
 import org.apache.tez.util.FastByteComparisons;
 
-public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
+public class InMemoryWriter implements IFile.WriterAppendRawDataBuffer {
 
   private final byte[] array;
   private final CRC32 checksum = new CRC32();
@@ -55,20 +55,20 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
       return isRleEnabled;
   }
 
-  public void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+  public void appendNoRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
     assert false;
   }
 
-  public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
+  public void appendNoRleTez(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
     assert false;
   }
 
   @Override
-  public void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException {
+  public void appendRle(TezRawDataBuffer key, TezRawDataBuffer value, boolean keyStable) throws IOException {
     assert isRleEnabled;
     int keyPosition = key.getPosition();
-    int keyLength = key.getLength() - keyPosition;
-    int valueLength = value.getLength() - value.getPosition();
+    int keyLength = key.getRemaining();
+    int valueLength = value.getRemaining();
 
     boolean sameKey = key == IFile.REPEAT_KEY;
     if (!sameKey) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -25,7 +25,7 @@ import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileOutputStream;
 import org.apache.tez.util.FastByteComparisons;
 
-public class InMemoryWriter implements IFile.WriterAppendRawDataBuffer {
+public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
 
   private final byte[] array;
   private final CRC32 checksum = new CRC32();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.hadoop.io.FileChunk;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.counters.TaskCounter;
@@ -39,7 +39,7 @@ import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleClient;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.InputStreamSegment;
@@ -782,7 +782,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
       int noInMemorySegments = inMemorySegments.size();
 
-      IFile.WriterAppendDataInputBuffer writer = new InMemoryWriter(mergedMapOutputs.getMemory());
+      IFile.WriterAppendRawDataBuffer writer = new InMemoryWriter(mergedMapOutputs.getMemory());
 
       if (isDebugEnabled) {
         LOG.debug("{}: Initiating Memory-to-Memory merge with {} segments of total-size: {}",
@@ -874,10 +874,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
           srcTaskIdentifier.getInputIdentifier(), srcTaskIdentifier.getSpillEventId(),
           mergeOutputSize).suffix(Constants.MERGED_OUTPUT_PREFIX);
 
-      WriterDataInputBuffer writer = null;
+      WriterRawDataBuffer writer = null;
       long outFileLen = 0;
       try {
-        writer = new WriterDataInputBuffer(rfs, outputPath, codec, null, null,
+        writer = new WriterRawDataBuffer(rfs, outputPath, codec, null, null,
             true, writeBuffer, inputContext);
 
         TezRawKeyValueIterator rIter = null;
@@ -1005,7 +1005,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       outputPath = localDirAllocator.getLocalPathForWrite(outputPathString, approxOutputSize, conf);
       outputPath = outputPath.suffix(Constants.MERGED_OUTPUT_PREFIX + mergeFileSequenceId.getAndIncrement());
 
-      WriterDataInputBuffer writer = new WriterDataInputBuffer(rfs, outputPath, codec, null, null,
+      WriterRawDataBuffer writer = new WriterRawDataBuffer(rfs, outputPath, codec, null, null,
           true, writeBuffer, inputContext);
       tmpDir = new Path(inputContext.getUniqueIdentifier());
       try {
@@ -1070,7 +1070,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   }
 
   private Segment createMapOutputSegment(MapOutput mapOutput) throws IOException {
-    IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mapOutput);
+    IFile.KeyValueReaderRawDataBuffer reader = createMapOutputReader(mapOutput);
     TezCounter mapOutputsCounter = mapOutput.isPrimaryMapOutput() ? mergedMapOutputsCounter : null;
     if (mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE) {
       return new InputStreamSegment(reader, mapOutputsCounter);
@@ -1078,7 +1078,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     return new Segment(reader, mapOutputsCounter);
   }
 
-  private IFile.KeyValueReaderDataInputBuffer createMapOutputReader(MapOutput mapOutput) throws IOException {
+  private IFile.KeyValueReaderRawDataBuffer createMapOutputReader(MapOutput mapOutput) throws IOException {
     assert mapOutput.getType() == ShuffleClient.Type.MEMORY || mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE;
     if (mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE) {
       java.io.InputStream inputStream = mapOutput.getInputStream();
@@ -1103,7 +1103,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         (int) mapOutput.getUsedMemoryForMergeManager(), null);
   }
 
-  static class RawKVIteratorReader implements IFile.KeyValueReaderDataInputBuffer {
+  static class RawKVIteratorReader implements IFile.KeyValueReaderRawDataBuffer {
 
     private final TezRawKeyValueIterator kvIter;
     private final long size;
@@ -1115,24 +1115,24 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     }
 
     @Override
-    public IFile.Reader.KeyState readRawKey(DataInputBuffer key) throws IOException {
+    public IFile.Reader.KeyState readRawKey(TezRawDataBuffer key) throws IOException {
       lastNextResult = kvIter.next();
       if (lastNextResult == TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         return IFile.Reader.KeyState.NO_KEY;
       }
 
-      final DataInputBuffer kb = kvIter.getKey();
+      final TezRawDataBuffer kb = kvIter.getKey();
       final int kp = kb.getPosition();
-      final int klen = kb.getLength() - kp;
+      final int klen = kb.getRemaining();
       key.reset(kb.getData(), kp, klen);
       return kvIter.isSameKey() ? IFile.Reader.KeyState.SAME_KEY : IFile.Reader.KeyState.NEW_KEY;
     }
 
     @Override
-    public void nextRawValue(DataInputBuffer value) throws IOException {
-      final DataInputBuffer vb = kvIter.getValue();
+    public void nextRawValue(TezRawDataBuffer value) throws IOException {
+      final TezRawDataBuffer vb = kvIter.getValue();
       final int vp = vb.getPosition();
-      final int vlen = vb.getLength() - vp;
+      final int vlen = vb.getRemaining();
       value.reset(vb.getData(), vp, vlen);
     }
 
@@ -1185,7 +1185,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             false, spilledRecordsCounter, null,
             additionalSpillBytesRead, true, inputContext);
         final byte[] writeBuffer = IFile.allocateWriteBuffer();
-        final WriterDataInputBuffer writer = new WriterDataInputBuffer(fs, outputPath, codec, null, null,
+        final WriterRawDataBuffer writer = new WriterRawDataBuffer(fs, outputPath, codec, null, null,
             true, writeBuffer, inputContext);
         try {
           TezMerger.writeFile(rIter, writer,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -39,7 +39,7 @@ import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleClient;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.InputStreamSegment;
@@ -782,7 +782,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
       int noInMemorySegments = inMemorySegments.size();
 
-      IFile.WriterAppendRawDataBuffer writer = new InMemoryWriter(mergedMapOutputs.getMemory());
+      IFile.WriterAppendDataInputBuffer writer = new InMemoryWriter(mergedMapOutputs.getMemory());
 
       if (isDebugEnabled) {
         LOG.debug("{}: Initiating Memory-to-Memory merge with {} segments of total-size: {}",
@@ -874,10 +874,10 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
           srcTaskIdentifier.getInputIdentifier(), srcTaskIdentifier.getSpillEventId(),
           mergeOutputSize).suffix(Constants.MERGED_OUTPUT_PREFIX);
 
-      WriterRawDataBuffer writer = null;
+      WriterDataInputBuffer writer = null;
       long outFileLen = 0;
       try {
-        writer = new WriterRawDataBuffer(rfs, outputPath, codec, null, null,
+        writer = new WriterDataInputBuffer(rfs, outputPath, codec, null, null,
             true, writeBuffer, inputContext);
 
         TezRawKeyValueIterator rIter = null;
@@ -1005,7 +1005,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       outputPath = localDirAllocator.getLocalPathForWrite(outputPathString, approxOutputSize, conf);
       outputPath = outputPath.suffix(Constants.MERGED_OUTPUT_PREFIX + mergeFileSequenceId.getAndIncrement());
 
-      WriterRawDataBuffer writer = new WriterRawDataBuffer(rfs, outputPath, codec, null, null,
+      WriterDataInputBuffer writer = new WriterDataInputBuffer(rfs, outputPath, codec, null, null,
           true, writeBuffer, inputContext);
       tmpDir = new Path(inputContext.getUniqueIdentifier());
       try {
@@ -1070,7 +1070,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
   }
 
   private Segment createMapOutputSegment(MapOutput mapOutput) throws IOException {
-    IFile.KeyValueReaderRawDataBuffer reader = createMapOutputReader(mapOutput);
+    IFile.KeyValueReaderDataInputBuffer reader = createMapOutputReader(mapOutput);
     TezCounter mapOutputsCounter = mapOutput.isPrimaryMapOutput() ? mergedMapOutputsCounter : null;
     if (mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE) {
       return new InputStreamSegment(reader, mapOutputsCounter);
@@ -1078,7 +1078,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     return new Segment(reader, mapOutputsCounter);
   }
 
-  private IFile.KeyValueReaderRawDataBuffer createMapOutputReader(MapOutput mapOutput) throws IOException {
+  private IFile.KeyValueReaderDataInputBuffer createMapOutputReader(MapOutput mapOutput) throws IOException {
     assert mapOutput.getType() == ShuffleClient.Type.MEMORY || mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE;
     if (mapOutput.getType() == ShuffleClient.Type.LOCAL_BYTE_CACHE) {
       java.io.InputStream inputStream = mapOutput.getInputStream();
@@ -1103,7 +1103,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
         (int) mapOutput.getUsedMemoryForMergeManager(), null);
   }
 
-  static class RawKVIteratorReader implements IFile.KeyValueReaderRawDataBuffer {
+  static class RawKVIteratorReader implements IFile.KeyValueReaderDataInputBuffer {
 
     private final TezRawKeyValueIterator kvIter;
     private final long size;
@@ -1185,7 +1185,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
             false, spilledRecordsCounter, null,
             additionalSpillBytesRead, true, inputContext);
         final byte[] writeBuffer = IFile.allocateWriteBuffer();
-        final WriterRawDataBuffer writer = new WriterRawDataBuffer(fs, outputPath, codec, null, null,
+        final WriterDataInputBuffer writer = new WriterDataInputBuffer(fs, outputPath, codec, null, null,
             true, writeBuffer, inputContext);
         try {
           TezMerger.writeFile(rIter, writer,

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.tez.runtime.library.utils.CodecUtils;
 import org.apache.tez.util.FastByteComparisons;
@@ -70,7 +69,7 @@ public class IFile {
   public static final byte FLAG_RLE_ENABLED = 0x02;
 
   // REPEAT_KEY is primarily an ordered-path optimization, and never used for unordered output.
-  public static final DataInputBuffer REPEAT_KEY = new DataInputBuffer();
+  public static final TezRawDataBuffer REPEAT_KEY = new TezRawDataBuffer();
   public static final byte[] HEADER = new byte[] { (byte) 'T', (byte) 'I', (byte) 'F', (byte) 0};
 
   private static final String INCOMPLETE_READ = "Requested to read %d got %d";
@@ -99,14 +98,14 @@ public class IFile {
     return 2 * INT_SIZE;
   }
 
-  public interface WriterAppendDataInputBuffer {
+  public interface WriterAppendRawDataBuffer {
     boolean isRleEnabled();
 
     // call when isRleEnabled is not statically known
-    void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException;
-    void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException;
+    void appendNoRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException;
+    void appendNoRleTez(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException;
 
-    void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException;
+    void appendRle(TezRawDataBuffer key, TezRawDataBuffer value, boolean keyStable) throws IOException;
 
     void close() throws IOException;
   }
@@ -583,7 +582,7 @@ public class IFile {
     }
   }
 
-  public static class WriterDataInputBuffer extends Writer implements WriterAppendDataInputBuffer {
+  public static class WriterRawDataBuffer extends Writer implements WriterAppendRawDataBuffer {
 
     private byte[] previousKeyData = new byte[0];
     private int previousKeyOffset = 0;
@@ -597,7 +596,7 @@ public class IFile {
     private static final int RLE_MARKER_SIZE = INT_SIZE;
     private static final int V_END_MARKER_SIZE = INT_SIZE;
 
-    public WriterDataInputBuffer(FileSystem fs, Path file,
+    public WriterRawDataBuffer(FileSystem fs, Path file,
                                  CompressionCodec codec,
                                  TezCounter writesCounter,
                                  TezCounter serializedBytesCounter,
@@ -610,7 +609,7 @@ public class IFile {
       this.ownOutputStream = true;
     }
 
-    public WriterDataInputBuffer(FSDataOutputStream outputStream,
+    public WriterRawDataBuffer(FSDataOutputStream outputStream,
                                  CompressionCodec codec,
                                  TezCounter writesCounter,
                                  TezCounter serializedBytesCounter,
@@ -630,10 +629,10 @@ public class IFile {
       return isRleEnabled;
     }
 
-    public void appendNoRle(DataInputBuffer key, DataInputBuffer value) throws IOException {
+    public void appendNoRle(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
       assert !isRleEnabled && !useMaxKeyValLen;
-      int keyLength = key.getLength() - key.getPosition();
-      int valueLength = value.getLength() - value.getPosition();
+      int keyLength = key.getRemaining();
+      int valueLength = value.getRemaining();
 
       super.writeKVPair(key.getData(), key.getPosition(), keyLength,
           value.getData(), value.getPosition(), valueLength);
@@ -647,10 +646,10 @@ public class IFile {
       ++numRecordsWritten;
     }
 
-    public void appendNoRleTez(DataInputBuffer key, DataInputBuffer value) throws IOException {
+    public void appendNoRleTez(TezRawDataBuffer key, TezRawDataBuffer value) throws IOException {
       assert !isRleEnabled && useMaxKeyValLen;
-      int keyLength = key.getLength() - key.getPosition();
-      int valueLength = value.getLength() - value.getPosition();
+      int keyLength = key.getRemaining();
+      int valueLength = value.getRemaining();
 
       if (maxKeyLen < 0 || maxValLen < 0) {
         maxKeyLen = keyLength;
@@ -684,10 +683,10 @@ public class IFile {
       ++numRecordsWritten;
     }
 
-    public void appendRle(DataInputBuffer key, DataInputBuffer value, boolean keyStable) throws IOException {
+    public void appendRle(TezRawDataBuffer key, TezRawDataBuffer value, boolean keyStable) throws IOException {
       assert isRleEnabled && !useMaxKeyValLen;
-      int keyLength = key.getLength() - key.getPosition();
-      int valueLength = value.getLength() - value.getPosition();
+      int keyLength = key.getRemaining();
+      int valueLength = value.getRemaining();
 
       if (key == REPEAT_KEY) {
         appendRepeatValue(value.getData(), value.getPosition(), valueLength);
@@ -872,16 +871,16 @@ public class IFile {
     void close() throws IOException;
   }
 
-  public interface KeyValueReaderDataInputBuffer extends KeyValueReaderBase {
-    Reader.KeyState readRawKey(DataInputBuffer key) throws IOException;
-    void nextRawValue(DataInputBuffer value) throws IOException;
+  public interface KeyValueReaderRawDataBuffer extends KeyValueReaderBase {
+    Reader.KeyState readRawKey(TezRawDataBuffer key) throws IOException;
+    void nextRawValue(TezRawDataBuffer value) throws IOException;
 
     /**
      * Reports whether the most recently loaded current record returned through
-     * readRawKey(DataInputBuffer) and nextRawValue(DataInputBuffer)
+     * readRawKey(TezRawDataBuffer) and nextRawValue(TezRawDataBuffer)
      * has stable backing byte arrays.
      *
-     * Stable means the byte[] slices exposed through DataInputBuffer may be
+     * Stable means the byte[] slices exposed through TezRawDataBuffer may be
      * retained by the caller without being overwritten or reused by this reader.
      * The result must be safe for both the key and the value of the current
      * record, based on the invariant that current merge-based records are not
@@ -908,7 +907,7 @@ public class IFile {
     long consumeAll(KeyValueReaderEdge.ThrowingBiConsumer<BytesWritable, BytesWritable> consumer) throws Exception;
   }
 
-  public interface KeyValueReader extends KeyValueReaderDataInputBuffer, KeyValueReaderBytesWritable {
+  public interface KeyValueReader extends KeyValueReaderRawDataBuffer, KeyValueReaderBytesWritable {
   }
 
   /**
@@ -950,7 +949,7 @@ public class IFile {
     private int currentValueLength;
     private boolean eof = false;
     private int originalKeyLength;
-    private byte[] keyBytes = new byte[0];  // backing array for DataInputBuffer in readRawKey()
+    private byte[] keyBytes = new byte[0];  // backing array for TezRawDataBuffer in readRawKey()
 
     // for reporting errors
     private long bytesRead = 0;
@@ -1384,7 +1383,7 @@ public class IFile {
       return false;
     }
 
-    public KeyState readRawKey(DataInputBuffer key) throws IOException {
+    public KeyState readRawKey(TezRawDataBuffer key) throws IOException {
       if (isRleEnabled) {
         return readRawKeyRle(key);
       } else {
@@ -1392,7 +1391,7 @@ public class IFile {
       }
     }
 
-    private KeyState readRawKeyNoRle(DataInputBuffer key) throws IOException {
+    private KeyState readRawKeyNoRle(TezRawDataBuffer key) throws IOException {
       if (!positionToNextRecordNoRle()) {
         return KeyState.NO_KEY;
       }
@@ -1408,7 +1407,7 @@ public class IFile {
       return KeyState.NEW_KEY;
     }
 
-    private KeyState readRawKeyRle(DataInputBuffer key) throws IOException {
+    private KeyState readRawKeyRle(TezRawDataBuffer key) throws IOException {
       if (!positionToNextRecordRle()) {
         return KeyState.NO_KEY;
       }
@@ -1470,7 +1469,7 @@ public class IFile {
       return KeyState.NEW_KEY;
     }
 
-    public void nextRawValue(DataInputBuffer value) throws IOException {
+    public void nextRawValue(TezRawDataBuffer value) throws IOException {
       final byte[] valBytes;
       if ((value.getData().length < currentValueLength) || (value.getData() == keyBytes)) {
         valBytes = createLargerArray(currentValueLength);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -98,7 +98,7 @@ public class IFile {
     return 2 * INT_SIZE;
   }
 
-  public interface WriterAppendRawDataBuffer {
+  public interface WriterAppendDataInputBuffer {
     boolean isRleEnabled();
 
     // call when isRleEnabled is not statically known
@@ -582,7 +582,7 @@ public class IFile {
     }
   }
 
-  public static class WriterRawDataBuffer extends Writer implements WriterAppendRawDataBuffer {
+  public static class WriterDataInputBuffer extends Writer implements WriterAppendDataInputBuffer {
 
     private byte[] previousKeyData = new byte[0];
     private int previousKeyOffset = 0;
@@ -596,7 +596,7 @@ public class IFile {
     private static final int RLE_MARKER_SIZE = INT_SIZE;
     private static final int V_END_MARKER_SIZE = INT_SIZE;
 
-    public WriterRawDataBuffer(FileSystem fs, Path file,
+    public WriterDataInputBuffer(FileSystem fs, Path file,
                                  CompressionCodec codec,
                                  TezCounter writesCounter,
                                  TezCounter serializedBytesCounter,
@@ -609,7 +609,7 @@ public class IFile {
       this.ownOutputStream = true;
     }
 
-    public WriterRawDataBuffer(FSDataOutputStream outputStream,
+    public WriterDataInputBuffer(FSDataOutputStream outputStream,
                                  CompressionCodec codec,
                                  TezCounter writesCounter,
                                  TezCounter serializedBytesCounter,
@@ -871,7 +871,7 @@ public class IFile {
     void close() throws IOException;
   }
 
-  public interface KeyValueReaderRawDataBuffer extends KeyValueReaderBase {
+  public interface KeyValueReaderDataInputBuffer extends KeyValueReaderBase {
     Reader.KeyState readRawKey(TezRawDataBuffer key) throws IOException;
     void nextRawValue(TezRawDataBuffer value) throws IOException;
 
@@ -907,7 +907,7 @@ public class IFile {
     long consumeAll(KeyValueReaderEdge.ThrowingBiConsumer<BytesWritable, BytesWritable> consumer) throws Exception;
   }
 
-  public interface KeyValueReader extends KeyValueReaderRawDataBuffer, KeyValueReaderBytesWritable {
+  public interface KeyValueReader extends KeyValueReaderDataInputBuffer, KeyValueReaderBytesWritable {
   }
 
   /**

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -62,7 +62,7 @@ import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleServer;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterBytesWritable;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.Segment;
 import org.apache.tez.runtime.library.common.TezRuntimeUtils;
@@ -747,13 +747,13 @@ public final class PipelinedSorter {
         PartitionFilter kvIter = merger.filter(i);
         // write merged output to disk
         long segmentStart = fsOutput.getPos();
-        WriterRawDataBuffer writer = null;
+        WriterDataInputBuffer writer = null;
         boolean hasNext = kvIter.hasNext();
         if (hasNext || !sendEmptyPartitionDetails) {
           if (codec != null && compressorExternal == null) {
             compressorExternal = outputContext.getCompressor(codec);
           }
-          writer = new WriterRawDataBuffer(
+          writer = new WriterDataInputBuffer(
               fsOutput,
               codec, spilledRecordsCounter, null, false, isRleEnabled,
               -1, -1,
@@ -845,7 +845,7 @@ public final class PipelinedSorter {
     InputStream input = byteArrayOutput.createInputStreamFrom(
         indexRecord.getStartOffset(), indexRecord.getPartLength());
 
-    IFile.KeyValueReaderRawDataBuffer reader = new IFile.Reader(input, indexRecord.getPartLength(),
+    IFile.KeyValueReaderDataInputBuffer reader = new IFile.Reader(input, indexRecord.getPartLength(),
         codec, null, null, ifileReadAhead, ifileReadAheadLength, outputContext, null);
     // This spill output (byteArrayOutput) can be consumed for multiple partitions during the final merge.
     // Keep it alive across partition segments and clean once all partitions are merged in cleanSpillOutputBuffers().
@@ -1047,9 +1047,9 @@ public final class PipelinedSorter {
           long segmentStart = finalOut.getPos();
           long rawLength = 0;
           long partLength = 0;
-          WriterRawDataBuffer writer = null;
+          WriterDataInputBuffer writer = null;
           if (shouldWrite) {
-            writer = new WriterRawDataBuffer(
+            writer = new WriterDataInputBuffer(
                 finalOut,
                 codec, spilledRecordsCounter, null, false, isFinalMergeRleEnabled,
                 -1, -1,
@@ -1751,7 +1751,7 @@ public final class PipelinedSorter {
       this.iter = iter;
     }
 
-    public void appendCurrentTo(WriterRawDataBuffer writer) throws IOException {
+    public void appendCurrentTo(WriterDataInputBuffer writer) throws IOException {
       iter.appendCurrentTo(writer);
     }
 
@@ -2146,7 +2146,7 @@ public final class PipelinedSorter {
       currentValueLength = current.valueLength;
     }
 
-    private void appendCurrentTo(WriterRawDataBuffer writer) throws IOException {
+    private void appendCurrentTo(WriterDataInputBuffer writer) throws IOException {
       if (writer.isRleEnabled()) {
         writer.appendRle(currentKeyData, currentKeyOffset, currentKeyLength,
             currentValueData, currentValueOffset, currentValueLength, true);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounter;
@@ -63,7 +62,7 @@ import org.apache.tez.runtime.library.common.serializer.SerializationContext;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleServer;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterBytesWritable;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.DiskSegment;
 import org.apache.tez.runtime.library.common.sort.impl.TezMerger.Segment;
 import org.apache.tez.runtime.library.common.TezRuntimeUtils;
@@ -748,13 +747,13 @@ public final class PipelinedSorter {
         PartitionFilter kvIter = merger.filter(i);
         // write merged output to disk
         long segmentStart = fsOutput.getPos();
-        WriterDataInputBuffer writer = null;
+        WriterRawDataBuffer writer = null;
         boolean hasNext = kvIter.hasNext();
         if (hasNext || !sendEmptyPartitionDetails) {
           if (codec != null && compressorExternal == null) {
             compressorExternal = outputContext.getCompressor(codec);
           }
-          writer = new WriterDataInputBuffer(
+          writer = new WriterRawDataBuffer(
               fsOutput,
               codec, spilledRecordsCounter, null, false, isRleEnabled,
               -1, -1,
@@ -846,7 +845,7 @@ public final class PipelinedSorter {
     InputStream input = byteArrayOutput.createInputStreamFrom(
         indexRecord.getStartOffset(), indexRecord.getPartLength());
 
-    IFile.KeyValueReaderDataInputBuffer reader = new IFile.Reader(input, indexRecord.getPartLength(),
+    IFile.KeyValueReaderRawDataBuffer reader = new IFile.Reader(input, indexRecord.getPartLength(),
         codec, null, null, ifileReadAhead, ifileReadAheadLength, outputContext, null);
     // This spill output (byteArrayOutput) can be consumed for multiple partitions during the final merge.
     // Keep it alive across partition segments and clean once all partitions are merged in cleanSpillOutputBuffers().
@@ -1048,9 +1047,9 @@ public final class PipelinedSorter {
           long segmentStart = finalOut.getPos();
           long rawLength = 0;
           long partLength = 0;
-          WriterDataInputBuffer writer = null;
+          WriterRawDataBuffer writer = null;
           if (shouldWrite) {
-            writer = new WriterDataInputBuffer(
+            writer = new WriterRawDataBuffer(
                 finalOut,
                 codec, spilledRecordsCounter, null, false, isFinalMergeRleEnabled,
                 -1, -1,
@@ -1215,7 +1214,7 @@ public final class PipelinedSorter {
   }
 
 
-  private static final class InputByteBuffer extends DataInputBuffer {
+  private static final class InputByteBuffer extends TezRawDataBuffer {
     private byte[] buffer = new byte[256]; 
     private ByteBuffer wrapped = ByteBuffer.wrap(buffer);
     private void resize(int length) {
@@ -1228,19 +1227,19 @@ public final class PipelinedSorter {
     }
 
     // shallow copy
-    public void reset(DataInputBuffer clone) {
+    public void reset(TezRawDataBuffer clone) {
       byte[] data = clone.getData();
       int start = clone.getPosition();
-      int length = clone.getLength() - start;
+      int length = clone.getRemaining();
       super.reset(data, start, length);
     }
 
     // deep copy
     @SuppressWarnings("unused")
-    public void copy(DataInputBuffer clone) {
+    public void copy(TezRawDataBuffer clone) {
       byte[] data = clone.getData();
       int start = clone.getPosition();
-      int length = clone.getLength() - start;
+      int length = clone.getRemaining();
       resize(length);
       System.arraycopy(data, start, buffer, 0, length);
       super.reset(buffer, 0, length);
@@ -1569,7 +1568,7 @@ public final class PipelinedSorter {
       return remaining;
     }
 
-    private int compareInternal(final DataInputBuffer needle, final int needlePart, final int index) {
+    private int compareInternal(final TezRawDataBuffer needle, final int needlePart, final int index) {
       int cmp;
       final int partition = FastByteComparisons.theUnsafe.getInt(
           kvmetaArray, offsetForIntIndex(this.offsetFor(index) + PARTITION));
@@ -1581,7 +1580,7 @@ public final class PipelinedSorter {
         final int keyStart = (int) keyValStartPair;
         final int valStart = (int) (keyValStartPair >>> Integer.SIZE);
         final int keyLength = valStart - keyStart;
-        final int needleLength = needle.getLength() - needle.getPosition();
+        final int needleLength = needle.getRemaining();
         final int skip = Math.min(fullKeyPrefixBytes, Math.min(keyLength, needleLength));
         cmp = FastByteComparisons.compareTo(kvbufferArray,
             kvbufferArrayOffset + keyStart + skip, keyLength - skip,
@@ -1625,7 +1624,7 @@ public final class PipelinedSorter {
       this.maxindex = span.length() - 1;
     }
 
-    public DataInputBuffer getKey()  {
+    public TezRawDataBuffer getKey()  {
       key.reset(kvbufferArray, kvbufferArrayOffset + keyStart, keyLength);
       return key;
     }
@@ -1679,7 +1678,7 @@ public final class PipelinedSorter {
      * @param needlePart
      * @return
      */
-    int bisect(DataInputBuffer needle, int needlePart) {
+    int bisect(TezRawDataBuffer needle, int needlePart) {
       int start = kvindex;
       int end = maxindex-1;
       int mid;
@@ -1752,7 +1751,7 @@ public final class PipelinedSorter {
       this.iter = iter;
     }
 
-    public void appendCurrentTo(WriterDataInputBuffer writer) throws IOException {
+    public void appendCurrentTo(WriterRawDataBuffer writer) throws IOException {
       iter.appendCurrentTo(writer);
     }
 
@@ -2147,7 +2146,7 @@ public final class PipelinedSorter {
       currentValueLength = current.valueLength;
     }
 
-    private void appendCurrentTo(WriterDataInputBuffer writer) throws IOException {
+    private void appendCurrentTo(WriterRawDataBuffer writer) throws IOException {
       if (writer.isRleEnabled()) {
         writer.appendRle(currentKeyData, currentKeyOffset, currentKeyLength,
             currentValueData, currentValueOffset, currentValueLength, true);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -43,7 +43,7 @@ import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
 
 /**
  * Merger is an utility class used by the Map and Reduce tasks for merging
@@ -73,7 +73,7 @@ public class TezMerger {
       mergeFactor, inMemSegments, tmpDir, readsCounter, writesCounter, bytesReadCounter, taskContext);
   }
 
-  public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppendRawDataBuffer writer,
+  public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppendDataInputBuffer writer,
       long recordsBeforeProgress)
       throws IOException, InterruptedException {
     boolean isRleEnabled = writer.isRleEnabled();
@@ -132,11 +132,11 @@ public class TezMerger {
 
   public static class Segment {
     static final byte[] EMPTY_BYTES = new byte[0];
-    IFile.KeyValueReaderRawDataBuffer reader;
+    IFile.KeyValueReaderDataInputBuffer reader;
     final KeyValueBuffer key = new KeyValueBuffer(EMPTY_BYTES, 0, 0);
     TezCounter mapOutputsCounter;
 
-    public Segment(IFile.KeyValueReaderRawDataBuffer reader, TezCounter mapOutputsCounter) {
+    public Segment(IFile.KeyValueReaderDataInputBuffer reader, TezCounter mapOutputsCounter) {
       this.reader = reader;
       this.mapOutputsCounter = mapOutputsCounter;
     }
@@ -255,7 +255,7 @@ public class TezMerger {
   }
 
   public static final class InputStreamSegment extends Segment {
-    public InputStreamSegment(IFile.KeyValueReaderRawDataBuffer reader, TezCounter mapOutputsCounter) {
+    public InputStreamSegment(IFile.KeyValueReaderDataInputBuffer reader, TezCounter mapOutputsCounter) {
       super(reader, mapOutputsCounter);
     }
 
@@ -269,7 +269,7 @@ public class TezMerger {
     private final MultiByteArrayOutputStream byteArrayOutput;
     private final boolean cleanupOnClose;
 
-    IntermediateMemorySegment(IFile.KeyValueReaderRawDataBuffer reader,
+    IntermediateMemorySegment(IFile.KeyValueReaderDataInputBuffer reader,
                               MultiByteArrayOutputStream byteArrayOutput, boolean cleanupOnClose) {
       super(reader, null);
       this.byteArrayOutput = byteArrayOutput;
@@ -698,14 +698,14 @@ public class TezMerger {
               && MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold);
 
           MultiByteArrayOutputStream byteArrayOutput = null;
-          IFile.WriterAppendRawDataBuffer writer;
+          IFile.WriterAppendDataInputBuffer writer;
           if (writeIntermediateToMemory) {
             byteArrayOutput = new MultiByteArrayOutputStream(fs, outputFile);
             FSDataOutputStream outputStream = new FSDataOutputStream(byteArrayOutput, null);
-            writer = new WriterRawDataBuffer(outputStream, codec, writesCounter, null,
+            writer = new WriterDataInputBuffer(outputStream, codec, writesCounter, null,
                 false, checkForSameKeys, -1, -1, writeBuffer, null, taskContext);
           } else {
-            writer = new WriterRawDataBuffer(fs, outputFile, codec, writesCounter, null,
+            writer = new WriterDataInputBuffer(fs, outputFile, codec, writesCounter, null,
                 checkForSameKeys, writeBuffer, taskContext);
           }
 
@@ -721,7 +721,7 @@ public class TezMerger {
             tempSegment = new DiskSegment(fs, outputFile, 0, fs.getFileStatus(outputFile).getLen(), codec,
                 ifileReadAhead, ifileReadAheadLength, false, null, taskContext);
           } else {
-            IFile.KeyValueReaderRawDataBuffer reader = new Reader(
+            IFile.KeyValueReaderDataInputBuffer reader = new Reader(
                 byteArrayOutput.createInputStreamFrom(0, byteArrayOutput.getTotalBytes()),
                 byteArrayOutput.getTotalBytes(),
                 codec, null, null, ifileReadAhead, ifileReadAheadLength, taskContext);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.DataInputBuffer;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TezCounter;
@@ -44,7 +43,7 @@ import org.apache.tez.runtime.api.MultiByteArrayOutputStream;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader.KeyState;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
 
 /**
  * Merger is an utility class used by the Map and Reduce tasks for merging
@@ -74,7 +73,7 @@ public class TezMerger {
       mergeFactor, inMemSegments, tmpDir, readsCounter, writesCounter, bytesReadCounter, taskContext);
   }
 
-  public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppendDataInputBuffer writer,
+  public static void writeFile(TezRawKeyValueIterator records, IFile.WriterAppendRawDataBuffer writer,
       long recordsBeforeProgress)
       throws IOException, InterruptedException {
     boolean isRleEnabled = writer.isRleEnabled();
@@ -84,7 +83,7 @@ public class TezMerger {
       int nextResult;
       while ((nextResult = records.next()) != TezRawKeyValueIterator.NO_MORE_KEY_VALUE) {
         // Even if records.isSameKey() is false, the two keys may be the same.
-        DataInputBuffer key = records.isSameKey() ? IFile.REPEAT_KEY : records.getKey();
+        TezRawDataBuffer key = records.isSameKey() ? IFile.REPEAT_KEY : records.getKey();
         writer.appendRle(key, records.getValue(),
             nextResult == TezRawKeyValueIterator.NEXT_KEY_VALUE_STABLE);
         if (((recordCtr++) % recordsBeforeProgress) == 0) { checkProgress(); }
@@ -133,11 +132,11 @@ public class TezMerger {
 
   public static class Segment {
     static final byte[] EMPTY_BYTES = new byte[0];
-    IFile.KeyValueReaderDataInputBuffer reader;
+    IFile.KeyValueReaderRawDataBuffer reader;
     final KeyValueBuffer key = new KeyValueBuffer(EMPTY_BYTES, 0, 0);
     TezCounter mapOutputsCounter;
 
-    public Segment(IFile.KeyValueReaderDataInputBuffer reader, TezCounter mapOutputsCounter) {
+    public Segment(IFile.KeyValueReaderRawDataBuffer reader, TezCounter mapOutputsCounter) {
       this.reader = reader;
       this.mapOutputsCounter = mapOutputsCounter;
     }
@@ -154,7 +153,7 @@ public class TezMerger {
 
     KeyValueBuffer getKey() { return key; }
 
-    DataInputBuffer getValue(DataInputBuffer value) throws IOException {
+    TezRawDataBuffer getValue(TezRawDataBuffer value) throws IOException {
       nextRawValue(value);
       return value;
     }
@@ -163,19 +162,19 @@ public class TezMerger {
       return reader.getLength();
     }
 
-    KeyState readRawKey(DataInputBuffer nextKey) throws IOException {
+    KeyState readRawKey(TezRawDataBuffer nextKey) throws IOException {
       KeyState keyState = reader.readRawKey(nextKey);
-      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
+      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getRemaining());
       return keyState;
     }
 
-    boolean nextRawKey(DataInputBuffer nextKey) throws IOException {
+    boolean nextRawKey(TezRawDataBuffer nextKey) throws IOException {
       boolean hasNext = reader.readRawKey(nextKey) != KeyState.NO_KEY;
-      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getLength() - nextKey.getPosition());
+      key.reset(nextKey.getData(), nextKey.getPosition(), nextKey.getRemaining());
       return hasNext;
     }
 
-    void nextRawValue(DataInputBuffer value) throws IOException {
+    void nextRawValue(TezRawDataBuffer value) throws IOException {
       reader.nextRawValue(value);
     }
 
@@ -256,7 +255,7 @@ public class TezMerger {
   }
 
   public static final class InputStreamSegment extends Segment {
-    public InputStreamSegment(IFile.KeyValueReaderDataInputBuffer reader, TezCounter mapOutputsCounter) {
+    public InputStreamSegment(IFile.KeyValueReaderRawDataBuffer reader, TezCounter mapOutputsCounter) {
       super(reader, mapOutputsCounter);
     }
 
@@ -270,7 +269,7 @@ public class TezMerger {
     private final MultiByteArrayOutputStream byteArrayOutput;
     private final boolean cleanupOnClose;
 
-    IntermediateMemorySegment(IFile.KeyValueReaderDataInputBuffer reader,
+    IntermediateMemorySegment(IFile.KeyValueReaderRawDataBuffer reader,
                               MultiByteArrayOutputStream byteArrayOutput, boolean cleanupOnClose) {
       super(reader, null);
       this.byteArrayOutput = byteArrayOutput;
@@ -303,10 +302,10 @@ public class TezMerger {
     // Invariant: Segment.close() is called for all Segment objects
     List<Segment> segments = new ArrayList<Segment>();
     
-    final DataInputBuffer key = new DataInputBuffer();
-    final DataInputBuffer value = new DataInputBuffer();
-    final DataInputBuffer nextKey = new DataInputBuffer();
-    final DataInputBuffer diskIFileValue = new DataInputBuffer();
+    final TezRawDataBuffer key = new TezRawDataBuffer();
+    final TezRawDataBuffer value = new TezRawDataBuffer();
+    final TezRawDataBuffer nextKey = new TezRawDataBuffer();
+    final TezRawDataBuffer diskIFileValue = new TezRawDataBuffer();
     
     Segment minSegment;
     Comparator<Segment> segmentComparator =   
@@ -345,11 +344,11 @@ public class TezMerger {
       }
     }
 
-    public DataInputBuffer getKey() throws IOException {
+    public TezRawDataBuffer getKey() throws IOException {
       return key;
     }
 
-    public DataInputBuffer getValue() throws IOException {
+    public TezRawDataBuffer getValue() throws IOException {
       return value;
     }
 
@@ -699,14 +698,14 @@ public class TezMerger {
               && MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold);
 
           MultiByteArrayOutputStream byteArrayOutput = null;
-          IFile.WriterAppendDataInputBuffer writer;
+          IFile.WriterAppendRawDataBuffer writer;
           if (writeIntermediateToMemory) {
             byteArrayOutput = new MultiByteArrayOutputStream(fs, outputFile);
             FSDataOutputStream outputStream = new FSDataOutputStream(byteArrayOutput, null);
-            writer = new WriterDataInputBuffer(outputStream, codec, writesCounter, null,
+            writer = new WriterRawDataBuffer(outputStream, codec, writesCounter, null,
                 false, checkForSameKeys, -1, -1, writeBuffer, null, taskContext);
           } else {
-            writer = new WriterDataInputBuffer(fs, outputFile, codec, writesCounter, null,
+            writer = new WriterRawDataBuffer(fs, outputFile, codec, writesCounter, null,
                 checkForSameKeys, writeBuffer, taskContext);
           }
 
@@ -722,7 +721,7 @@ public class TezMerger {
             tempSegment = new DiskSegment(fs, outputFile, 0, fs.getFileStatus(outputFile).getLen(), codec,
                 ifileReadAhead, ifileReadAheadLength, false, null, taskContext);
           } else {
-            IFile.KeyValueReaderDataInputBuffer reader = new Reader(
+            IFile.KeyValueReaderRawDataBuffer reader = new Reader(
                 byteArrayOutput.createInputStreamFrom(0, byteArrayOutput.getTotalBytes()),
                 byteArrayOutput.getTotalBytes(),
                 codec, null, null, ifileReadAhead, ifileReadAheadLength, taskContext);
@@ -805,12 +804,12 @@ public class TezMerger {
 
   private static class EmptyIterator implements TezRawKeyValueIterator {
     @Override
-    public DataInputBuffer getKey() throws IOException {
+    public TezRawDataBuffer getKey() throws IOException {
       throw new RuntimeException("No keys on an empty iterator");
     }
 
     @Override
-    public DataInputBuffer getValue() throws IOException {
+    public TezRawDataBuffer getValue() throws IOException {
       throw new RuntimeException("No values on an empty iterator");
     }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawDataBuffer.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawDataBuffer.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.sort.impl;
+
+/**
+ * Minimal holder for a raw byte-array slice.
+ *
+ * <p>The length is the exclusive end offset, matching the raw-slice semantics used by the
+ * runtime-library sort and merge paths.</p>
+ */
+public class TezRawDataBuffer {
+  private static final byte[] EMPTY_BYTES = new byte[0];
+
+  private byte[] data = EMPTY_BYTES;
+  private int position;
+  private int length;
+
+  public TezRawDataBuffer() {
+  }
+
+  public TezRawDataBuffer(byte[] data, int length) {
+    reset(data, length);
+  }
+
+  public TezRawDataBuffer(byte[] data, int position, int length) {
+    reset(data, position, length);
+  }
+
+  public void reset(byte[] input, int length) {
+    this.data = input;
+    this.position = 0;
+    this.length = length;
+  }
+
+  public void reset(byte[] input, int position, int length) {
+    this.data = input;
+    this.position = position;
+    this.length = position + length;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+
+  public int getPosition() {
+    return position;
+  }
+
+  public int getLength() {
+    return length;
+  }
+
+  public int getRemaining() {
+    return length - position;
+  }
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezRawKeyValueIterator.java
@@ -19,8 +19,6 @@ package org.apache.tez.runtime.library.common.sort.impl;
 
 import java.io.IOException;
 
-import org.apache.hadoop.io.DataInputBuffer;
-
 /**
  * <code>TezRawKeyValueIterator</code> is an iterator used to iterate over
  * the raw keys and values during sort/merge of intermediate data. 
@@ -42,18 +40,18 @@ public interface TezRawKeyValueIterator {
   /** 
    * Gets the current raw key.
    * 
-   * @return Gets the current raw key as a DataInputBuffer
+   * @return Gets the current raw key as a TezRawDataBuffer
    * @throws IOException
    */
-  DataInputBuffer getKey() throws IOException;
+  TezRawDataBuffer getKey() throws IOException;
   
   /** 
    * Gets the current raw value.
    * 
-   * @return Gets the current raw value as a DataInputBuffer 
+   * @return Gets the current raw value as a TezRawDataBuffer
    * @throws IOException
    */
-  DataInputBuffer getValue() throws IOException;
+  TezRawDataBuffer getValue() throws IOException;
   
   /** 
    * Sets up the current key and value (for getKey and getValue).

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -83,7 +83,7 @@ import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileInputStream;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterBytesWritable;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleServer;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
@@ -833,7 +833,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
         for (int i = 0; i < numPartitions; i++) {
-          WriterRawDataBuffer writer = null;
+          WriterDataInputBuffer writer = null;
           try {
             long segmentStart = fsOutput.getPos();
             long numRecords = 0;
@@ -847,7 +847,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                   compressorExternal = outputContext.getCompressor(codec);
                 }
                 // all Writer instances share the same FSDataOutputStream out
-                writer = new WriterRawDataBuffer(
+                writer = new WriterDataInputBuffer(
                     fsOutput, codec, null, null, compositeFetch, false,
                     maxKeyLen, maxValLen,
                     writeBuffer, compressorExternal, outputContext);
@@ -901,7 +901,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     }
   }
 
-  private long writePartition(int pos, WrappedBuffer wrappedBuffer, WriterRawDataBuffer writer,
+  private long writePartition(int pos, WrappedBuffer wrappedBuffer, WriterDataInputBuffer writer,
       TezRawDataBuffer keyBuffer, TezRawDataBuffer valBuffer) throws IOException {
     long numRecords = 0;
     while (pos != WrappedBuffer.PARTITION_ABSENT_POSITION) {
@@ -1366,7 +1366,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       } else {
         out = new FSDataOutputStream(byteArrayOutput, null);
       }
-      WriterRawDataBuffer writer;
+      WriterDataInputBuffer writer;
 
       byte[] writeBuffer = IFile.allocateWriteBuffer();
       for (int i = 0; i < numPartitions; i++) {
@@ -1378,7 +1378,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
           continue;
         }
         // inside close()
-        writer = new WriterRawDataBuffer(
+        writer = new WriterDataInputBuffer(
             out, codec, null, null, compositeFetch, false,
             maxKeyLen, maxValLen,
             writeBuffer, null, outputContext);
@@ -1401,7 +1401,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                 // Skip empty partitions within a spill
                 continue;
               }
-              IFile.KeyValueReaderRawDataBuffer reader = null;
+              IFile.KeyValueReaderDataInputBuffer reader = null;
               TezOffsetRecord spillOffsetRecord =
                   spillInfo.offsetRecordMap != null ? spillInfo.offsetRecordMap.get(i) : null;
               if (!spillCompressed && !compositeFetch) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -878,8 +878,6 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
             }
           }
         }
-        key.close();
-        val.close();
       } finally {
         if (compressorExternal != null) {
           outputContext.returnCompressor(codec.getCompressorType(), compressorExternal);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -55,7 +55,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.Compressor;
@@ -83,7 +83,7 @@ import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.sort.impl.IFileInputStream;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterBytesWritable;
-import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterDataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.WriterRawDataBuffer;
 import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleServer;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
@@ -828,12 +828,12 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
               spillNumber, spillPathDetails.outputFilePath.toString(), canUseBuffers);
         }
 
-        DataInputBuffer key = new DataInputBuffer();
-        DataInputBuffer val = new DataInputBuffer();
+        TezRawDataBuffer key = new TezRawDataBuffer();
+        TezRawDataBuffer val = new TezRawDataBuffer();
         byte[] writeBuffer = IFile.allocateWriteBuffer();
 
         for (int i = 0; i < numPartitions; i++) {
-          WriterDataInputBuffer writer = null;
+          WriterRawDataBuffer writer = null;
           try {
             long segmentStart = fsOutput.getPos();
             long numRecords = 0;
@@ -847,7 +847,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                   compressorExternal = outputContext.getCompressor(codec);
                 }
                 // all Writer instances share the same FSDataOutputStream out
-                writer = new WriterDataInputBuffer(
+                writer = new WriterRawDataBuffer(
                     fsOutput, codec, null, null, compositeFetch, false,
                     maxKeyLen, maxValLen,
                     writeBuffer, compressorExternal, outputContext);
@@ -901,8 +901,8 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     }
   }
 
-  private long writePartition(int pos, WrappedBuffer wrappedBuffer, WriterDataInputBuffer writer,
-      DataInputBuffer keyBuffer, DataInputBuffer valBuffer) throws IOException {
+  private long writePartition(int pos, WrappedBuffer wrappedBuffer, WriterRawDataBuffer writer,
+      TezRawDataBuffer keyBuffer, TezRawDataBuffer valBuffer) throws IOException {
     long numRecords = 0;
     while (pos != WrappedBuffer.PARTITION_ABSENT_POSITION) {
       int metaIndex = pos / INT_SIZE;
@@ -1344,11 +1344,11 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     final Map<Integer, TezOffsetRecord> spillOffsetRecordMap =
         (compositeFetch && !isFinalMergeRleEnabled) ? new HashMap<>() : null;
 
-    DataInputBuffer keyBuffer = new DataInputBuffer();
-    DataInputBuffer valBuffer = new DataInputBuffer();
+    TezRawDataBuffer keyBuffer = new TezRawDataBuffer();
+    TezRawDataBuffer valBuffer = new TezRawDataBuffer();
 
-    DataInputBuffer keyBufferIFile = new DataInputBuffer();
-    DataInputBuffer valBufferIFile = new DataInputBuffer();
+    TezRawDataBuffer keyBufferIFile = new TezRawDataBuffer();
+    TezRawDataBuffer valBufferIFile = new TezRawDataBuffer();
 
     MultiByteArrayOutputStream byteArrayOutput = null;
     if (useFreeMemoryWriterOutput) {
@@ -1366,7 +1366,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       } else {
         out = new FSDataOutputStream(byteArrayOutput, null);
       }
-      WriterDataInputBuffer writer;
+      WriterRawDataBuffer writer;
 
       byte[] writeBuffer = IFile.allocateWriteBuffer();
       for (int i = 0; i < numPartitions; i++) {
@@ -1378,7 +1378,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
           continue;
         }
         // inside close()
-        writer = new WriterDataInputBuffer(
+        writer = new WriterRawDataBuffer(
             out, codec, null, null, compositeFetch, false,
             maxKeyLen, maxValLen,
             writeBuffer, null, outputContext);
@@ -1401,7 +1401,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                 // Skip empty partitions within a spill
                 continue;
               }
-              IFile.KeyValueReaderDataInputBuffer reader = null;
+              IFile.KeyValueReaderRawDataBuffer reader = null;
               TezOffsetRecord spillOffsetRecord =
                   spillInfo.offsetRecordMap != null ? spillInfo.offsetRecordMap.get(i) : null;
               if (!spillCompressed && !compositeFetch) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedInputLegacy.java
@@ -20,7 +20,7 @@ package org.apache.tez.runtime.library.input;
 
 import java.io.IOException;
 
-import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.tez.runtime.library.common.sort.impl.TezRawDataBuffer;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
@@ -37,12 +37,12 @@ public class OrderedGroupedInputLegacy extends OrderedGroupedKVInput {
       if (getNumPhysicalInputs() == 0) {
         return new TezRawKeyValueIterator() {
           @Override
-          public DataInputBuffer getKey() throws IOException {
+          public TezRawDataBuffer getKey() throws IOException {
             throw new RuntimeException("No data available in Input");
           }
 
           @Override
-          public DataInputBuffer getValue() throws IOException {
+          public TezRawDataBuffer getValue() throws IOException {
             throw new RuntimeException("No data available in Input");
           }
 


### PR DESCRIPTION
### Motivation
- Replace heavy Hadoop `DataInputBuffer` usage for raw key/value slices with a minimal, more efficient holder to reduce overhead and make raw-slice semantics explicit. 
- Keep raw-slice semantics (backing array + offset + exclusive-end length) while limiting `DataInputBuffer` to the MapReduce compatibility adapter boundary. 

### Description
- Add `TezRawDataBuffer`, a minimal raw byte-slice holder with `data`, `position`, `length` (exclusive end) and `getRemaining()` helper (`tez-runtime-library/src/main/java/.../TezRawDataBuffer.java`).
- Change `TezRawKeyValueIterator` to expose `TezRawDataBuffer` for `getKey()`/`getValue()` and `next()` semantics.
- Replace IFile raw-buffer APIs and implementations to use the new types and names: `WriterAppendRawDataBuffer`, `WriterRawDataBuffer`, `KeyValueReaderRawDataBuffer`, and update reader/writer implementations accordingly (`IFile`, `Reader`, `Writer` paths).
- Update callers and paths that consume raw KV slices to use `TezRawDataBuffer` and `getRemaining()` instead of `getLength()-getPosition()`, including merge/sort/pipelined-sort, values iterator, in-memory reader/writer, unordered writer, and merge manager (`TezMerger`, `PipelinedSorter`, `MergeManager`, `ValuesIterator`, `InMemoryReader/Writer`, `UnorderedPartitionedKVWriter`, `OrderedGroupedInputLegacy`).
- Preserve Hadoop `DataInputBuffer` only at the MapReduce `RawKeyValueIterator` compatibility boundary by allocating adapter `DataInputBuffer` instances and resetting them from `TezRawDataBuffer` slices inside the MR adapter (`MRTask`).
- Simplify `TezEvent` deserialization by removing the `DataInputBuffer`-specific fast-path and using `readFully` into a new byte array (so `DataInputBuffer` use is localized to the MR compatibility shim).
- Maintain existing offset/length semantics and RLE/Tez-length code paths; most changes are API/type replacements and small arithmetic moves to `getRemaining()`.

### Testing
- Compiled and ran a focused sanity test for the new holder: `javac`/`java -ea` test of `TezRawDataBuffer` (passed).
- Ran repository checks such as `git diff --check` and code searches to verify legacy `WriterDataInputBuffer` / `KeyValueReaderDataInputBuffer` names are removed and remaining `DataInputBuffer` references are limited to the MR compatibility adapter (verified).
- Attempted module compile via Maven (`-DskipTests -Dcheckstyle.skip=true`) for affected modules to validate integration, but the reactor build was blocked before reaching the modified modules due to external plugin resolution failing (protoc plugin `com.github.os72:protoc-jar-maven-plugin:3.11.4` returned HTTP 403), so a full compile of the changed modules could not be completed in this environment.
- Summary: targeted compilation and unit check for the new buffer succeeded; full project/module builds are pending due to external Maven dependency resolution errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2407ba1e6c8328b6a3445f3d06c909)