### PR TITLE
Add vector-batch support for UnorderedPartitionedKVWriter and corresponding reader/IFile metadata

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/TezOffsetRecord.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/TezOffsetRecord.java
@@ -21,11 +21,17 @@ package org.apache.tez.runtime.api;
  * Metadata needed to decode non-RLE Tez IFile records with variable length-prefix transitions.
  */
 public class TezOffsetRecord {
+  public static final int NO_RECORD = -1;
+  public static final int VECTOR_BATCH = -2;
   private final int maxKeyLen;
   private final int maxValLen;
   private final int firstKeyOffset;
   private final int firstValOffset;
   private final int eofPos;
+
+  public static TezOffsetRecord vectorBatch(int eofPos) {
+    return new TezOffsetRecord(VECTOR_BATCH, 0, 0, 0, eofPos);
+  }
 
   public TezOffsetRecord(
       int maxKeyLen,
@@ -40,19 +46,32 @@ public class TezOffsetRecord {
     this.eofPos = eofPos;
   }
 
+  public boolean isVectorBatch() {
+    return maxKeyLen == VECTOR_BATCH;
+  }
+
+  private void requireKeyValue() {
+    if (isVectorBatch()) {
+      throw new IllegalStateException("Key/value metadata is unavailable for vector-batch format");
+    }
+  }
+
   public int getMaxKeyLen() {
     return maxKeyLen;
   }
 
   public int getMaxValLen() {
+    requireKeyValue();
     return maxValLen;
   }
 
   public int getFirstKeyOffset() {
+    requireKeyValue();
     return firstKeyOffset;
   }
 
   public int getFirstValOffset() {
+    requireKeyValue();
     return firstValOffset;
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdgeVector.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueReaderEdgeVector.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.api;
+
+import java.io.IOException;
+
+public interface KeyValueReaderEdgeVector {
+  enum NextResult {
+    END_OF_INPUT,
+    KEY_VALUE,
+    VECTOR_BATCH
+  }
+
+  NextResult nextVectorBatchAware() throws IOException;
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesWriterEdgeVector.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValuesWriterEdgeVector.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.api;
+
+import java.io.IOException;
+import org.apache.hadoop.io.BytesWritable;
+
+public interface KeyValuesWriterEdgeVector {
+  boolean supportsVectorBatch();
+
+  void writeVectorBatch(BytesWritable serializedBatch) throws IOException;
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/readers/UnorderedKVReader.java
@@ -30,13 +30,14 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.runtime.library.api.KeyValueReaderEdge;
+import org.apache.tez.runtime.library.api.KeyValueReaderEdgeVector;
 import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleManager;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.InMemoryReader;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
 import org.apache.tez.runtime.library.common.shuffle.MemoryFetchedInput;
 
-public class UnorderedKVReader extends KeyValueReaderEdge {
+public class UnorderedKVReader extends KeyValueReaderEdge implements KeyValueReaderEdgeVector {
 
   private static final Logger LOG = LoggerFactory.getLogger(UnorderedKVReader.class);
   
@@ -56,6 +57,23 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
   private IFile.KeyValueReaderBytesWritable currentReader;
   
   private long numRecordsRead = 0;
+  private enum ReaderState {
+    INITIAL,
+    CURRENT_KEY_VALUE,
+    CURRENT_VECTOR_BATCH,
+    CONSUMING_ALL,
+    END_OF_INPUT,
+    FAILED
+  }
+
+  private enum LogicalMode {
+    UNDECIDED,
+    KEY_VALUE,
+    VECTOR_BATCH
+  }
+
+  private ReaderState state = ReaderState.INITIAL;
+  private LogicalMode logicalMode = LogicalMode.UNDECIDED;
 
   public UnorderedKVReader(ShuffleManager shuffleManager, Configuration conf,
       CompressionCodec codec, boolean ifileReadAhead, int ifileReadAheadLength,
@@ -77,51 +95,134 @@ public class UnorderedKVReader extends KeyValueReaderEdge {
    * @return true if another key/value(s) pair exists, false if there are no more.
    * @throws IOException if an error occurs
    */
-  @Override  
+  @Override
   public boolean next() throws IOException {
-    if (readNextFromCurrentReader()) {
-      inputRecordCounter.increment(1);
-      numRecordsRead++;
-      return true;
-    } else {
-      boolean nextInputExists = moveToNextInput();
-      while (nextInputExists) {
-        if (readNextFromCurrentReader()) {
-          inputRecordCounter.increment(1);
-          numRecordsRead++;
-          return true;
-        }
-        nextInputExists = moveToNextInput();
-      }
-      LOG.info("Num Records read: " + numRecordsRead);
-      completedProcessing = true;
-      return false;
+    if (state != ReaderState.INITIAL) {
+      throw new RuntimeException("next() is only valid as the initial advance operation");
     }
+    try {
+      if (advanceKeyValue()) {
+        state = ReaderState.CURRENT_KEY_VALUE;
+        return true;
+      }
+      finishInput();
+      return false;
+    } catch (IOException e) {
+      state = ReaderState.FAILED;
+      throw e;
+    }
+  }
+
+  @Override
+  public NextResult nextVectorBatchAware() throws IOException {
+    if (state == ReaderState.END_OF_INPUT) {
+      throw new IOException("Input is already exhausted");
+    }
+    if (state != ReaderState.INITIAL && state != ReaderState.CURRENT_VECTOR_BATCH) {
+      throw new RuntimeException("Invalid vector-aware advance in state " + state);
+    }
+    try {
+      while (true) {
+        if (currentReader == null && !moveToNextInput()) {
+          finishInput();
+          return NextResult.END_OF_INPUT;
+        }
+        boolean vector = currentReader.isVectorBatch();
+        boolean hasRecord;
+        if (vector) {
+          hasRecord = currentReader.nextRawVectorValue(value);
+        } else {
+          hasRecord = readNextFromCurrentReader();
+        }
+        if (!hasRecord) {
+          if (!moveToNextInput()) {
+            finishInput();
+            return NextResult.END_OF_INPUT;
+          }
+          continue;
+        }
+        LogicalMode physicalMode = vector ? LogicalMode.VECTOR_BATCH : LogicalMode.KEY_VALUE;
+        establishMode(physicalMode);
+        inputRecordCounter.increment(1);
+        numRecordsRead++;
+        state = vector ? ReaderState.CURRENT_VECTOR_BATCH : ReaderState.CURRENT_KEY_VALUE;
+        return vector ? NextResult.VECTOR_BATCH : NextResult.KEY_VALUE;
+      }
+    } catch (IOException e) {
+      state = ReaderState.FAILED;
+      throw e;
+    }
+  }
+
+  private boolean advanceKeyValue() throws IOException {
+    while (true) {
+      if (currentReader == null && !moveToNextInput()) {
+        return false;
+      }
+      if (currentReader.isVectorBatch()) {
+        throw new IOException("Vector-batch input requires nextVectorBatchAware()");
+      }
+      if (readNextFromCurrentReader()) {
+        establishMode(LogicalMode.KEY_VALUE);
+        inputRecordCounter.increment(1);
+        numRecordsRead++;
+        return true;
+      }
+      if (!moveToNextInput()) {
+        return false;
+      }
+    }
+  }
+
+  private void establishMode(LogicalMode physicalMode) throws IOException {
+    if (logicalMode == LogicalMode.UNDECIDED) {
+      logicalMode = physicalMode;
+    } else if (logicalMode != physicalMode) {
+      throw new IOException("Mixed non-empty upstream IFile record formats");
+    }
+  }
+
+  private void finishInput() {
+    LOG.info("Num Records read: {}", numRecordsRead);
+    completedProcessing = true;
+    state = ReaderState.END_OF_INPUT;
   }
 
   // The backing byte[] array of key is immutable, so the consumer may keep pointers to it.
   @Override
   public BytesWritable getCurrentKey() throws IOException {
+    if (state != ReaderState.CURRENT_KEY_VALUE) {
+      throw new RuntimeException("Current key is unavailable in state " + state);
+    }
     return key;
   }
 
   // The backing byte[] array of value is immutable, so the consumer may keep pointers to it.
   @Override
   public BytesWritable getCurrentValue() throws IOException {
+    if (state != ReaderState.CURRENT_KEY_VALUE && state != ReaderState.CURRENT_VECTOR_BATCH) {
+      throw new RuntimeException("Current value is unavailable in state " + state);
+    }
     return value;
   }
 
   @Override
   public long consumeAll(KeyValueReaderEdge.ThrowingBiConsumer<BytesWritable, BytesWritable> consumer) throws Exception {
-    assert numRecordsRead == 0L;  // must not be mixed with next()
-    while (moveToNextInput()) {
-      long currentConsumed = currentReader.consumeAll(consumer);
-      inputRecordCounter.increment(currentConsumed);
-      numRecordsRead += currentConsumed;
+    if (state != ReaderState.CURRENT_KEY_VALUE) {
+      throw new RuntimeException("consumeAll() requires one prepared key/value record");
     }
-    LOG.info("Num Records read: {}", numRecordsRead);
-    completedProcessing = true;
-    return numRecordsRead;
+    state = ReaderState.CONSUMING_ALL;
+    try {
+      consumer.accept(key, value);
+      while (advanceKeyValue()) {
+        consumer.accept(key, value);
+      }
+      finishInput();
+      return numRecordsRead;
+    } catch (Exception e) {
+      state = ReaderState.FAILED;
+      throw e;
+    }
   }
 
   public float getProgress() throws IOException, InterruptedException {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryReader.java
@@ -322,6 +322,9 @@ public class InMemoryReader implements IFile.KeyValueReader {
   }
 
   public KeyState readRawKey(BytesWritable key) throws IOException {
+    if (isVectorBatch()) {
+      throw new IllegalStateException("Key access is unavailable for vector-batch format");
+    }
     if (isRleEnabled) {
       return readRawKeyRle(key);
     } else {
@@ -401,6 +404,42 @@ public class InMemoryReader implements IFile.KeyValueReader {
 
     bytesRead += currentValueLength;
     ++recNo;
+  }
+
+  @Override
+  public boolean isVectorBatch() {
+    return tezOffsetRecord != null && tezOffsetRecord.isVectorBatch();
+  }
+
+  @Override
+  public boolean nextRawVectorValue(BytesWritable value) throws IOException {
+    if (!isVectorBatch()) {
+      throw new IllegalStateException("Reader is not in vector-batch format");
+    }
+    try {
+      if (eof) {
+        throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
+      }
+      int valueLength = memDataIn.readInt();
+      bytesRead += Integer.BYTES;
+      if (valueLength == IFile.EOF_MARKER) {
+        int secondMarker = memDataIn.readInt();
+        bytesRead += Integer.BYTES;
+        if (secondMarker != IFile.EOF_MARKER) {
+          throw new IOException("Malformed vector-batch EOF marker: " + secondMarker);
+        }
+        eof = true;
+        return false;
+      }
+      if (valueLength < 0) {
+        throw new IOException("Negative vector-batch value length: " + valueLength);
+      }
+      currentValueLength = valueLength;
+      nextRawValue(value);
+      return true;
+    } catch (RuntimeException e) {
+      throw new IOException("Malformed vector-batch IFile data", e);
+    }
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/InMemoryWriter.java
@@ -64,6 +64,11 @@ public class InMemoryWriter implements IFile.WriterAppendDataInputBuffer {
   }
 
   @Override
+  public void appendVectorBatch(RawDataBuffer value) throws IOException {
+    throw new UnsupportedOperationException("In-memory ordered shuffle does not support vector batches");
+  }
+
+  @Override
   public void appendRle(RawDataBuffer key, RawDataBuffer value, boolean keyStable) throws IOException {
     assert isRleEnabled;
     int keyPosition = key.getPosition();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleHeader.java
@@ -113,14 +113,18 @@ public class ShuffleHeader implements Writable {
     uncompressedLength = in.readLong();
     forReduce = in.readInt();
     int maxKeyLen = in.readInt();
-    if (maxKeyLen < 0) {
+    if (maxKeyLen == TezOffsetRecord.NO_RECORD) {
       tezOffsetRecord = null;
-    } else {
+    } else if (maxKeyLen == TezOffsetRecord.VECTOR_BATCH) {
+      tezOffsetRecord = TezOffsetRecord.vectorBatch(in.readInt());
+    } else if (maxKeyLen >= 0) {
       int maxValLen = in.readInt();
       int firstKeyOffset = in.readInt();
       int firstValOffset = in.readInt();
       int eofPos = in.readInt();
       tezOffsetRecord = new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
+    } else {
+      throw new IOException("Invalid TezOffsetRecord maxKeyLen: " + maxKeyLen);
     }
   }
 
@@ -153,7 +157,7 @@ public class ShuffleHeader implements Writable {
     int length = 8;  // compressedLength
     if (compressedLength != 0) {
       length += 8 + 4;  // uncompressedLength, forReduce
-      length += tezOffsetRecord != null ? 5 * 4 : 4;
+      length += tezOffsetRecord == null ? 4 : (tezOffsetRecord.isVectorBatch() ? 2 * 4 : 5 * 4);
     }
     return length;
   }
@@ -179,6 +183,10 @@ public class ShuffleHeader implements Writable {
     out.writeInt(forReduce);
     if (tezOffsetRecord != null) {
       out.writeInt(tezOffsetRecord.getMaxKeyLen());
+      if (tezOffsetRecord.isVectorBatch()) {
+        out.writeInt(tezOffsetRecord.getEofPos());
+        return;
+      }
       out.writeInt(tezOffsetRecord.getMaxValLen());
       out.writeInt(tezOffsetRecord.getFirstKeyOffset());
       out.writeInt(tezOffsetRecord.getFirstValOffset());

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -102,6 +102,7 @@ public class IFile {
     // call when isRleEnabled is not statically known
     void appendNoRle(RawDataBuffer key, RawDataBuffer value) throws IOException;
     void appendNoRleTez(RawDataBuffer key, RawDataBuffer value) throws IOException;
+    void appendVectorBatch(RawDataBuffer value) throws IOException;
 
     void appendRle(RawDataBuffer key, RawDataBuffer value, boolean keyStable) throws IOException;
 
@@ -112,6 +113,7 @@ public class IFile {
   public interface WriterAppendBytesWritable {
     void appendNoRle(BytesWritable key, BytesWritable value) throws IOException;
     void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException;
+    void appendVectorBatch(BytesWritable value) throws IOException;
 
     void close() throws IOException;
   }
@@ -257,6 +259,13 @@ public class IFile {
     }
 
     @Override
+    public void enableVectorBatchFormat() {
+      if (numRecordsWritten != 0 || isRleEnabled || !useMaxKeyValLen) {
+        throw new IllegalStateException("Vector-batch format must be selected before writing Tez records");
+      }
+      vectorBatchFormat = true;
+    }
+
     protected void writeValue(byte[] data, int offset, int length) throws IOException {
       if (!bufferFull) {
         totalSize += INT_SIZE + length;
@@ -269,6 +278,14 @@ public class IFile {
     }
 
     @Override
+    public void appendVectorBatch(BytesWritable value) throws IOException {
+      if (!vectorBatchFormat) {
+        throw new IllegalStateException("Writer is not in vector-batch format");
+      }
+      writeValue(value.getBytesRaw(), value.getOffset(), value.getLength());
+      ++numRecordsWritten;
+    }
+
     public void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException {
       assert false;
     }
@@ -352,6 +369,7 @@ public class IFile {
     protected int firstKeyOffset = -1;
     protected int firstValOffset = -1;
     protected int eofPos = -1;
+    protected boolean vectorBatchFormat = false;
 
     protected Writer(FSDataOutputStream outputStream,
                      CompressionCodec codec,
@@ -474,6 +492,19 @@ public class IFile {
       }
     }
 
+    protected void requireKeyValueFormat() {
+      if (vectorBatchFormat) {
+        throw new IllegalStateException("Writer is in vector-batch format");
+      }
+    }
+
+    public void enableVectorBatchFormat() {
+      if (numRecordsWritten != 0 || isRleEnabled || !useMaxKeyValLen) {
+        throw new IllegalStateException("Vector-batch format must be selected before writing Tez records");
+      }
+      vectorBatchFormat = true;
+    }
+
     protected void writeValue(byte[] data, int offset, int length) throws IOException {
       bufferWriteInt(length); // value length
       bufferWriteBytes(data, offset, length);
@@ -497,6 +528,10 @@ public class IFile {
 
     protected void onClose() throws IOException {
       if (useMaxKeyValLen) {
+        if (vectorBatchFormat) {
+          eofPos = (int) decompressedBytesWritten;
+          return;
+        }
         if (numRecordsWritten == 0) {
           maxKeyLen = 0;
           maxValLen = 0;
@@ -575,7 +610,8 @@ public class IFile {
         return null;
       } else {
         assert eofPos >= 0;   // must be called after close()
-        return new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
+        return vectorBatchFormat ? TezOffsetRecord.vectorBatch(eofPos)
+            : new TezOffsetRecord(maxKeyLen, maxValLen, firstKeyOffset, firstValOffset, eofPos);
       }
     }
   }
@@ -628,6 +664,7 @@ public class IFile {
     }
 
     public void appendNoRle(RawDataBuffer key, RawDataBuffer value) throws IOException {
+      requireKeyValueFormat();
       assert !isRleEnabled && !useMaxKeyValLen;
       int keyLength = key.getLength();
       int valueLength = value.getLength();
@@ -639,12 +676,14 @@ public class IFile {
 
     public void appendNoRle(byte[] keyData, int keyOffset, int keyLength,
                             byte[] valueData, int valueOffset, int valueLength) throws IOException {
+      requireKeyValueFormat();
       assert !isRleEnabled && !useMaxKeyValLen;
       super.writeKVPair(keyData, keyOffset, keyLength, valueData, valueOffset, valueLength);
       ++numRecordsWritten;
     }
 
     public void appendNoRleTez(RawDataBuffer key, RawDataBuffer value) throws IOException {
+      requireKeyValueFormat();
       assert !isRleEnabled && useMaxKeyValLen;
       int keyLength = key.getLength();
       int valueLength = value.getLength();
@@ -681,7 +720,16 @@ public class IFile {
       ++numRecordsWritten;
     }
 
+    public void appendVectorBatch(RawDataBuffer value) throws IOException {
+      if (!vectorBatchFormat) {
+        throw new IllegalStateException("Writer is not in vector-batch format");
+      }
+      writeValue(value.getData(), value.getPosition(), value.getLength());
+      ++numRecordsWritten;
+    }
+
     public void appendRle(RawDataBuffer key, RawDataBuffer value, boolean keyStable) throws IOException {
+      requireKeyValueFormat();
       assert isRleEnabled && !useMaxKeyValLen;
       int keyLength = key.getLength();
       int valueLength = value.getLength();
@@ -699,6 +747,7 @@ public class IFile {
     public void appendRle(byte[] keyData, int keyOffset, int keyLength,
                           byte[] valueData, int valueOffset, int valueLength, boolean keyStable)
         throws IOException {
+      requireKeyValueFormat();
       assert isRleEnabled && !useMaxKeyValLen;
       boolean sameKey = keyLength != 0 && FastByteComparisons.compareEqual(
           previousKeyData, previousKeyOffset, previousKeyLength, keyData, keyOffset, keyLength);
@@ -814,6 +863,7 @@ public class IFile {
     }
 
     public void appendNoRle(BytesWritable key, BytesWritable value) throws IOException {
+      requireKeyValueFormat();
       assert !isRleEnabled;
       assert !useMaxKeyValLen;
       int keyLength = key.getLength();
@@ -824,7 +874,16 @@ public class IFile {
       ++numRecordsWritten;
     }
 
+    public void appendVectorBatch(BytesWritable value) throws IOException {
+      if (!vectorBatchFormat) {
+        throw new IllegalStateException("Writer is not in vector-batch format");
+      }
+      writeValue(value.getBytesRaw(), value.getOffset(), value.getLength());
+      ++numRecordsWritten;
+    }
+
     public void appendNoRleTez(BytesWritable key, BytesWritable value) throws IOException {
+      requireKeyValueFormat();
       assert !isRleEnabled;
       assert useMaxKeyValLen;
       int recordStartOffset = (int) getDecompressedBytesWritten();
@@ -899,6 +958,8 @@ public class IFile {
     Reader.KeyState readRawKey(BytesWritable key) throws IOException;
     // After readRawValue() returns, the backing byte[] array is immutable, so the consumer may keep pointers to it.
     void nextRawValue(BytesWritable value) throws IOException;
+    boolean nextRawVectorValue(BytesWritable value) throws IOException;
+    boolean isVectorBatch();
 
     // Retrieves all key/value pairs, where both BytesWritable arguments are backed by immutable byte[] arrays.
     // consumeAll() must not be mixed with readRawKey()/nextRawValue().
@@ -1299,6 +1360,36 @@ public class IFile {
       bytesRead += INT_SIZE + INT_SIZE;
     }
 
+    public boolean isVectorBatch() {
+      return tezOffsetRecord != null && tezOffsetRecord.isVectorBatch();
+    }
+
+    public boolean nextRawVectorValue(BytesWritable value) throws IOException {
+      if (!isVectorBatch()) {
+        throw new IllegalStateException("Reader is not in vector-batch format");
+      }
+      if (eof) {
+        throw new IOException(String.format("Reached EOF. Completed reading %d", bytesRead));
+      }
+      int valueLength = readInt();
+      bytesRead += INT_SIZE;
+      if (valueLength == EOF_MARKER) {
+        int secondMarker = readInt();
+        bytesRead += INT_SIZE;
+        if (secondMarker != EOF_MARKER) {
+          throw new IOException("Malformed vector-batch EOF marker: " + secondMarker);
+        }
+        eof = true;
+        return false;
+      }
+      if (valueLength < 0) {
+        throw new IOException("Negative vector-batch value length: " + valueLength);
+      }
+      currentValueLength = valueLength;
+      nextRawValue(value);
+      return true;
+    }
+
     private boolean positionToNextRecordNoRle() throws IOException {
       // Sanity check
       if (eof) {
@@ -1380,6 +1471,9 @@ public class IFile {
     }
 
     public KeyState readRawKey(RawDataBuffer key) throws IOException {
+      if (isVectorBatch()) {
+        throw new IllegalStateException("Key access is unavailable for vector-batch format");
+      }
       if (isRleEnabled) {
         return readRawKeyRle(key);
       } else {
@@ -1425,6 +1519,9 @@ public class IFile {
     }
 
     public KeyState readRawKey(BytesWritable key) throws IOException {
+      if (isVectorBatch()) {
+        throw new IllegalStateException("Key access is unavailable for vector-batch format");
+      }
       if (isRleEnabled) {
         return readRawKeyRle(key);
       } else {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -72,6 +72,7 @@ import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.api.TezTaskOutput;
 import org.apache.tez.runtime.api.TezOffsetRecord;
 import org.apache.tez.runtime.library.api.KeyValuesWriterEdge;
+import org.apache.tez.runtime.library.api.KeyValuesWriterEdgeVector;
 import org.apache.tez.runtime.library.api.Partitioner;
 import org.apache.tez.runtime.api.events.CompositeDataMovementEvent;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
@@ -106,7 +107,7 @@ import javax.annotation.Nullable;
 
 import static org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord.ensureSpillFilePermissions;
 
-public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
+public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge implements KeyValuesWriterEdgeVector {
 
   private static final Logger LOG = LoggerFactory.getLogger(UnorderedPartitionedKVWriter.class);
   private static final boolean isDebugEnabled = LOG.isDebugEnabled();
@@ -230,6 +231,14 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       return deflater;
     }
   };
+
+  private enum LogicalMode {
+    UNDECIDED,
+    KEY_VALUE,
+    VECTOR_BATCH
+  }
+
+  private volatile LogicalMode logicalMode = LogicalMode.UNDECIDED;
 
   private enum WriterState {
     RUNNING,
@@ -525,9 +534,42 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     }
   }
 
+  @Override
+  public boolean supportsVectorBatch() {
+    return singlePartition && compositeFetch && !useCachedStream;
+  }
+
+  private void selectMode(LogicalMode requested) {
+    if (logicalMode == LogicalMode.UNDECIDED) {
+      logicalMode = requested;
+    } else if (logicalMode != requested) {
+      throw new RuntimeException("Cannot mix key/value and vector-batch records on one writer");
+    }
+  }
+
+  @Override
+  public void writeVectorBatch(BytesWritable serializedBatch) throws IOException {
+    if (!supportsVectorBatch()) {
+      throw new RuntimeException("Vector batches are unsupported by this writer configuration");
+    }
+    selectMode(LogicalMode.VECTOR_BATCH);
+    if (writerState != WriterState.RUNNING) {
+      throw new IOException("Write already closed or spill failed");
+    }
+    if (skipBuffers) {
+      if (writer.getRawLength() == 0) {
+        writer.enableVectorBatchFormat();
+      }
+      writer.appendVectorBatch(serializedBatch);
+    } else {
+      write(new BytesWritable(), serializedBatch, 0);
+    }
+  }
+
   // TODO: optimize, if this method is actually called
   @Override
   public void write(BytesWritable key, Iterable<BytesWritable> values) throws IOException {
+    selectMode(LogicalMode.KEY_VALUE);
     Iterator<BytesWritable> it = values.iterator();
     while (it.hasNext()) {
       write(key, it.next());
@@ -536,6 +578,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
 
   @Override
   public void write(BytesWritable key, BytesWritable value) throws IOException {
+    selectMode(LogicalMode.KEY_VALUE);
     // Skipping checks for key-value types.
     // IFile takes care of these, but should be removed from there as well.
 
@@ -861,6 +904,9 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                     fsOutput, codec, null, null, compositeFetch, false,
                     maxKeyLen, maxValLen,
                     writeBuffer, compressorExternal, outputContext);
+                if (logicalMode == LogicalMode.VECTOR_BATCH) {
+                  writer.enableVectorBatchFormat();
+                }
               }
               numRecords += writeBufferedPartition(i, buffer, writer, key, val);
             }
@@ -940,7 +986,9 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       keyBuffer.reset(wrappedBuffer.buffer, pos + SINGLE_PARTITION_META_SIZE, keyLength);
       valBuffer.reset(wrappedBuffer.buffer, pos + SINGLE_PARTITION_META_SIZE + keyLength, valLength);
 
-      if (compositeFetch) {
+      if (logicalMode == LogicalMode.VECTOR_BATCH) {
+        writer.appendVectorBatch(valBuffer);
+      } else if (compositeFetch) {
         writer.appendNoRleTez(keyBuffer, valBuffer);
       } else {
         writer.appendNoRle(keyBuffer, valBuffer);
@@ -1423,6 +1471,9 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
             out, codec, null, null, compositeFetch, false,
             maxKeyLen, maxValLen,
             writeBuffer, null, outputContext);
+        if (logicalMode == LogicalMode.VECTOR_BATCH) {
+          writer.enableVectorBatchFormat();
+        }
         try {
           for (WrappedBuffer buffer : filledBuffers) {
             if (hasRecordsForPartition(i, buffer)) {
@@ -1503,13 +1554,24 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                 // Note that reader.close() itself may throw IOException and reader.decompressor may not be returned to the pool.
                 // For the same reason, this not memory leak because reader.decompressor is eventually garbage collected.
                 try {
-                  while (reader.readRawKey(keyBufferIFile) != IFile.Reader.KeyState.NO_KEY) {
-                    // TODO Inefficient for large records, since the entire record will be read into memory.
-                    reader.nextRawValue(valBufferIFile);
-                    if (compositeFetch) {
-                      writer.appendNoRleTez(keyBufferIFile, valBufferIFile);
-                    } else {
-                      writer.appendNoRle(keyBufferIFile, valBufferIFile);
+                  boolean vectorSpill = spillOffsetRecord != null && spillOffsetRecord.isVectorBatch();
+                  if (vectorSpill != (logicalMode == LogicalMode.VECTOR_BATCH)) {
+                    throw new IOException("Spill record format does not match writer logical mode");
+                  }
+                  if (vectorSpill) {
+                    BytesWritable vectorValue = new BytesWritable();
+                    while (((IFile.KeyValueReaderBytesWritable) reader).nextRawVectorValue(vectorValue)) {
+                      writer.appendVectorBatch(new RawDataBuffer(vectorValue.getBytesRaw(),
+                          vectorValue.getOffset(), vectorValue.getLength()));
+                    }
+                  } else {
+                    while (reader.readRawKey(keyBufferIFile) != IFile.Reader.KeyState.NO_KEY) {
+                      reader.nextRawValue(valBufferIFile);
+                      if (compositeFetch) {
+                        writer.appendNoRleTez(keyBufferIFile, valBufferIFile);
+                      } else {
+                        writer.appendNoRle(keyBufferIFile, valBufferIFile);
+                      }
                     }
                   }
                 } finally {
@@ -1638,7 +1700,10 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
                 compositeFetch,
                 maxKeyLen, maxValLen,
                 IFile.allocateWriteBufferSingle(), null, outputContext);
-            if (compositeFetch) {
+            if (logicalMode == LogicalMode.VECTOR_BATCH) {
+              writer.enableVectorBatchFormat();
+              writer.appendVectorBatch(value);
+            } else if (compositeFetch) {
               writer.appendNoRleTez(key, value);
             } else {
               writer.appendNoRle(key, value);

--- a/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -1073,7 +1073,7 @@ public class ShuffleHandler {
           if (partLength != 0) {
             TezOffsetRecord offsetRecord = outputInfo.getTezOffsetRecord(reduce);
             contentLength += 8 + 4;  // uncompressedLength, forReduce
-            contentLength += offsetRecord != null ? 5 * 4 : 4;
+            contentLength += offsetRecord == null ? 4 : (offsetRecord.isVectorBatch() ? 2 * 4 : 5 * 4);
           }
           contentLength += partLength;
         }


### PR DESCRIPTION
### Motivation

- Enable value-only vector-batch delivery for the unordered single-partition Tez shuffle path to reduce serialization overhead when allowed by configuration.  
- Communicate physical record format (key/value vs vector-batch) via extended Tez composite metadata so readers can interpret IFile contents correctly.  
- Preserve existing Hadoop-shuffle and cached-stream/DME behavior (they remain ordinary key/value only). 

### Description

- Add public vector APIs: `KeyValuesWriterEdgeVector` with `supportsVectorBatch()` and `writeVectorBatch(BytesWritable)` and `KeyValueReaderEdgeVector` with `NextResult` and `nextVectorBatchAware()`.  
- Extend `TezOffsetRecord` to encode reserved values (`NO_RECORD == -1`, `VECTOR_BATCH == -2`) and provide `vectorBatch(eofPos)` and `isVectorBatch()` helpers; add validation for key/value metadata access when vector-mode is present.  
- Update composite shuffle header encoding/decoding and content-length calculation to serialize the reserved `maxKeyLen` sentinel values and to accept/validate the compact vector metadata form.  
- Add vector-batch support inside `IFile` writers/readers: allow selecting a vector mode, write/read value-only records (4-byte value length + value bytes), validate EOF markers, and expose `getTezOffsetRecord()` that can represent vector-mode.  
- Extend `UnorderedPartitionedKVWriter` with logical-mode selection and capability check (`supportsVectorBatch()`), `writeVectorBatch()` implementation, vector-aware buffering/spill/final-merge flow, and format validation when merging spills.  
- Implement reader-side state machine and vector-aware advance in `UnorderedKVReader` and `InMemoryReader`: add `nextVectorBatchAware()` that crosses IFile boundaries, establishes a single logical input mode, and atomically reports `KEY_VALUE`, `VECTOR_BATCH` or `END_OF_INPUT`, plus access/sequence contract enforcement and `consumeAll()` behavior for key/value path.  
- Add format-consistency checks on reopen/merge of spills so mixed non-empty upstream modes cause `IOException`.  
- Keep DME/cached-stream and Hadoop-shuffle paths unchanged (they remain unable to write or read vector-batch IFiles). 

### Testing

- Ran repository static/diff checks: `git diff --check` — no whitespace/formatting errors reported.  
- Verified that no test sources were added or modified.  
- Attempted build of the affected module (`tez-runtime-library`) with Maven to validate compilation, but the environment could not resolve a build plugin dependency (`com.github.os72:protoc-jar-maven-plugin:3.11.4`) due to remote access returning HTTP 403; the compilation check was therefore blocked by the environment and not completed.  

If you want, I can split this into smaller PRs (API/metadata first, then IFile/writer/reader changes) or help adapt the build so the offline/blocked plugin resolution is avoided for CI verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27ee06db188328b7b3494ae9577e56)