### PR TITLE
Exempt small PARTITIONED_UNSORTED_OUTPUT requests from scaling and add unit tests

### DIFF
--- a/tez-runtime-internals/pom.xml
+++ b/tez-runtime-internals/pom.xml
@@ -80,6 +80,11 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/common/resources/WeightedScalingMemoryDistributor.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/common/resources/WeightedScalingMemoryDistributor.java
@@ -51,6 +51,7 @@ public class WeightedScalingMemoryDistributor implements InitialMemoryAllocator 
 
   static final double MAX_ADDITIONAL_RESERVATION_FRACTION_PER_IO = 0.1d;
   static final double RESERVATION_FRACTION_PER_IO = 0.015d;
+  static final long PARTITIONED_UNSORTED_OUTPUT_UNSCALED_THRESHOLD_BYTES = 20L << 20;
 
   // TODO: update populateTypeScaleMap() as well
   static final String[] DEFAULT_TASK_MEMORY_WEIGHTED_RATIOS =
@@ -79,7 +80,6 @@ public class WeightedScalingMemoryDistributor implements InitialMemoryAllocator 
   private final EnumMap<RequestType, Integer> typeScaleMap = Maps.newEnumMap(RequestType.class);
 
   private int numRequests = 0;
-  private int numRequestsScaled = 0;
 
   private final List<Request> requests = Lists.newArrayList();
 
@@ -94,44 +94,79 @@ public class WeightedScalingMemoryDistributor implements InitialMemoryAllocator 
       initialProcessMemoryRequestContext(context);
     }
 
-    if (numRequestsScaled == 0) {
-      // Fall back to regular scaling. e.g. BROADCAST : SHUFFLE = 0:1. 
-      // i.e. if Shuffle present, Broadcast gets nothing, but otherwise it
-      // should get an allocation
-      numRequestsScaled = numRequests;
-      for (Request request : requests) {
-        request.requestWeight = 1;
-      }
-    }
-
-    // Scale down while adding requests - don't want to hit Long limits.
-    double totalScaledRequest = 0d;
-    for (Request request : requests) {
-      double requested = request.requestSize * (request.requestWeight / (double) numRequestsScaled);
-      totalScaledRequest += requested;
-    }
-
     // Take a certain amount of memory away for general usage.
     double reserveFraction = computeReservedFraction(numRequests);
 
     Preconditions.checkState(reserveFraction >= 0.0d && reserveFraction <= 1.0d);
     availableBytesForAllocation = (long) (availableBytesForAllocation - (reserveFraction * availableBytesForAllocation));
 
-    // Actual scaling
+    Set<Request> unscaledRequests = new HashSet<Request>();
+    long unscaledRequestTotal = 0;
+    boolean unscaledRequestsFit = true;
+    for (Request request : requests) {
+      if (request.requestType == RequestType.PARTITIONED_UNSORTED_OUTPUT
+          && request.requestSize <= PARTITIONED_UNSORTED_OUTPUT_UNSCALED_THRESHOLD_BYTES) {
+        unscaledRequests.add(request);
+        if (request.requestSize > availableBytesForAllocation - unscaledRequestTotal) {
+          unscaledRequestsFit = false;
+          break;
+        }
+        unscaledRequestTotal += request.requestSize;
+      }
+    }
+    if (!unscaledRequestsFit) {
+      unscaledRequests.clear();
+      unscaledRequestTotal = 0;
+    }
+
+    long availableBytesForScaling = availableBytesForAllocation - unscaledRequestTotal;
+    int remainingRequestWeights = 0;
+    for (Request request : requests) {
+      if (!unscaledRequests.contains(request)) {
+        remainingRequestWeights += request.requestWeight;
+      }
+    }
+    if (remainingRequestWeights == 0) {
+      // Fall back to regular scaling for requests that were not allocated in full.
+      for (Request request : requests) {
+        if (!unscaledRequests.contains(request)) {
+          request.requestWeight = 1;
+          remainingRequestWeights++;
+        }
+      }
+    }
+
+    // Scale down while adding requests - don't want to hit Long limits.
+    double totalScaledRequest = 0d;
+    for (Request request : requests) {
+      if (!unscaledRequests.contains(request)) {
+        totalScaledRequest += request.requestSize
+            * (request.requestWeight / (double) remainingRequestWeights);
+      }
+    }
+
+    // Actual allocation
     List<Long> allocations = Lists.newArrayListWithCapacity(numRequests);
     for (Request request : requests) {
       long allocated = 0;
-      if (request.requestSize == 0) {
+      if (unscaledRequests.contains(request)) {
+        allocated = request.requestSize;
+        allocations.add(allocated);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Allocating requested " + request.requestType + " of type "
+              + request.requestType + " " + request.requestSize + " without scaling");
+        }
+      } else if (request.requestSize == 0) {
         allocations.add(0L);
         if (LOG.isDebugEnabled()) {
           LOG.debug("Scaling requested " + request.requestType + " of type "
               + request.requestType + " 0 to allocated: 0");
         }
       } else {
-        double requestFactor = request.requestWeight / (double) numRequestsScaled;
+        double requestFactor = request.requestWeight / (double) remainingRequestWeights;
         double scaledRequest = requestFactor * request.requestSize;
         allocated = Math.min(
-            (long) ((scaledRequest / totalScaledRequest) * availableBytesForAllocation),
+            (long) ((scaledRequest / totalScaledRequest) * availableBytesForScaling),
             request.requestSize);
         // TODO: If requestedSize is used, the difference (allocated - requestedSize) could be allocated to others.
         allocations.add(allocated);
@@ -154,7 +189,6 @@ public class WeightedScalingMemoryDistributor implements InitialMemoryAllocator 
         context.getComponentType(), context.getRequestedSize(), requestType, typeScaleFactor);
 
     requests.add(request);
-    numRequestsScaled += typeScaleFactor;
   }
 
   private Integer getScaleFactorForType(RequestType requestType) {

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/common/resources/TestWeightedScalingMemoryDistributor.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/common/resources/TestWeightedScalingMemoryDistributor.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.runtime.common.resources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tez.dag.api.TezConfiguration;
+import org.apache.tez.runtime.common.resources.InitialMemoryRequestContext.ComponentType;
+import org.apache.tez.runtime.common.resources.InitialMemoryRequestContext.RequestType;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class TestWeightedScalingMemoryDistributor {
+
+  private static final long MB = 1L << 20;
+
+  @Test
+  public void testSmallPartitionedUnsortedOutputReceivesFullRequest() {
+    List<Long> allocations = allocate(50 * MB,
+        request(10, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(100, RequestType.SORTED_OUTPUT));
+
+    assertEquals(10 * MB, allocations.get(0).longValue());
+    assertEquals(40 * MB, allocations.get(1).longValue());
+  }
+
+  @Test
+  public void testRequestAtThresholdReceivesFullRequest() {
+    List<Long> allocations = allocate(30 * MB,
+        request(20, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(100, RequestType.SORTED_OUTPUT));
+
+    assertEquals(20 * MB, allocations.get(0).longValue());
+    assertEquals(10 * MB, allocations.get(1).longValue());
+  }
+
+  @Test
+  public void testRequestAboveThresholdIsScaled() {
+    List<Long> allocations = allocate(20 * MB,
+        request(21, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(100, RequestType.SORTED_OUTPUT));
+
+    assertTrue(allocations.get(0) < 21 * MB);
+  }
+
+  @Test
+  public void testOtherRequestTypeIsNotExempt() {
+    List<Long> allocations = allocate(50 * MB,
+        request(10, RequestType.UNSORTED_OUTPUT),
+        request(100, RequestType.SORTED_OUTPUT));
+
+    assertTrue(allocations.get(0) < 10 * MB);
+  }
+
+  @Test
+  public void testMultipleEligibleRequestsFit() {
+    List<Long> allocations = allocate(50 * MB,
+        request(10, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(20, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(100, RequestType.SORTED_OUTPUT));
+
+    assertEquals(10 * MB, allocations.get(0).longValue());
+    assertEquals(20 * MB, allocations.get(1).longValue());
+    assertEquals(20 * MB, allocations.get(2).longValue());
+  }
+
+  @Test
+  public void testEligibleRequestsFallBackToScalingWhenTheyDoNotFit() {
+    List<Long> allocations = allocate(20 * MB,
+        request(15, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(15, RequestType.PARTITIONED_UNSORTED_OUTPUT));
+
+    assertEquals(10 * MB, allocations.get(0).longValue());
+    assertEquals(10 * MB, allocations.get(1).longValue());
+  }
+
+  @Test
+  public void testReservedFractionIsHonored() {
+    Configuration conf = createConfiguration();
+    conf.setDouble(TezConfiguration.TEZ_TASK_SCALE_MEMORY_RESERVE_FRACTION, 0.3d);
+
+    List<Long> allocations = allocate(conf, 100 * MB,
+        request(20, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(100, RequestType.SORTED_OUTPUT));
+
+    assertEquals(20 * MB, allocations.get(0).longValue());
+    assertEquals(50 * MB, allocations.get(1).longValue());
+    assertEquals(70 * MB, sum(allocations));
+  }
+
+  @Test
+  public void testRemainingZeroWeightRequestsUseLinearScaling() {
+    Configuration conf = createConfiguration();
+    conf.setStrings(TezConfiguration.TEZ_TASK_SCALE_MEMORY_WEIGHTED_RATIOS,
+        WeightedScalingMemoryDistributor.generateWeightStrings(1, 0, 0, 0, 0, 0, 0));
+
+    List<Long> allocations = allocate(conf, 40 * MB,
+        request(10, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(20, RequestType.UNSORTED_OUTPUT),
+        request(40, RequestType.OTHER));
+
+    assertEquals(10 * MB, allocations.get(0).longValue());
+    assertEquals(10 * MB, allocations.get(1).longValue());
+    assertEquals(20 * MB, allocations.get(2).longValue());
+  }
+
+  @Test
+  public void testAllRequestsEligibleAndFit() {
+    List<Long> allocations = allocate(40 * MB,
+        request(10, RequestType.PARTITIONED_UNSORTED_OUTPUT),
+        request(20, RequestType.PARTITIONED_UNSORTED_OUTPUT));
+
+    assertEquals(10 * MB, allocations.get(0).longValue());
+    assertEquals(20 * MB, allocations.get(1).longValue());
+  }
+
+  @Test
+  public void testZeroSizedRequestRemainsZero() {
+    List<Long> allocations = allocate(20 * MB,
+        request(0, RequestType.OTHER),
+        request(10, RequestType.PARTITIONED_UNSORTED_OUTPUT));
+
+    assertEquals(0, allocations.get(0).longValue());
+    assertEquals(10 * MB, allocations.get(1).longValue());
+  }
+
+  private static InitialMemoryRequestContext request(long megabytes, RequestType requestType) {
+    return new InitialMemoryRequestContext(megabytes * MB, requestType, ComponentType.OUTPUT,
+        "destination");
+  }
+
+  private static List<Long> allocate(long availableBytes,
+      InitialMemoryRequestContext... requests) {
+    return allocate(createConfiguration(), availableBytes, requests);
+  }
+
+  private static List<Long> allocate(Configuration conf, long availableBytes,
+      InitialMemoryRequestContext... requests) {
+    WeightedScalingMemoryDistributor distributor = new WeightedScalingMemoryDistributor();
+    distributor.setConf(conf);
+    return Lists.newArrayList(distributor.assignMemory(availableBytes, 0, requests.length,
+        Arrays.asList(requests)));
+  }
+
+  private static Configuration createConfiguration() {
+    Configuration conf = new Configuration(false);
+    conf.setDouble(TezConfiguration.TEZ_TASK_SCALE_MEMORY_RESERVE_FRACTION, 0d);
+    conf.setDouble(TezConfiguration.TEZ_TASK_SCALE_MEMORY_ADDITIONAL_RESERVATION_FRACTION_PER_IO,
+        0d);
+    conf.setDouble(TezConfiguration.TEZ_TASK_SCALE_MEMORY_ADDITIONAL_RESERVATION_FRACTION_MAX, 0d);
+    return conf;
+  }
+
+  private static long sum(List<Long> allocations) {
+    long total = 0;
+    for (long allocation : allocations) {
+      total += allocation;
+    }
+    return total;
+  }
+}


### PR DESCRIPTION
### Motivation

- Prevent tiny `PARTITIONED_UNSORTED_OUTPUT` memory requests from being scaled down when they can fit directly, to avoid unnecessary fragmentation and improve fairness.
- Add unit tests to validate the new allocation behavior and reserved-fraction handling.

### Description

- Added a new threshold constant `PARTITIONED_UNSORTED_OUTPUT_UNSCALED_THRESHOLD_BYTES` and logic to allocate small `RequestType.PARTITIONED_UNSORTED_OUTPUT` requests without scaling when they fit.
- Reworked allocation flow to compute the reserved fraction earlier via `computeReservedFraction`, separate out unscaled requests, compute `remainingRequestWeights`, and adjust the scaling/allocation math to use `availableBytesForScaling`.
- Removed reliance on the old `numRequestsScaled` variable and set fallback linear scaling when all remaining weights are zero.
- Added `junit` test dependency to `tez-runtime-internals/pom.xml` and introduced `TestWeightedScalingMemoryDistributor` with multiple scenarios covering threshold behavior, reserve fraction, zero-sized requests, weight edge-cases, and fallback scaling.

### Testing

- Ran the module unit tests with `mvn -pl tez-runtime-internals test` and confirmed `TestWeightedScalingMemoryDistributor` passed all cases.
- Existing allocation-related logic was exercised by the new tests which validated eligible request exemption, fallback scaling, reserved fraction enforcement, and zero-size handling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fe8163ca08328a51be681d89cdeaf)