### PR TITLE
Allow additional in-memory buffer allocation when free memory is available to reduce spills

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/MultiByteArrayOutputStream.java
@@ -33,6 +33,7 @@ public class MultiByteArrayOutputStream extends OutputStream {
   // Cf. gla2025.5.26.pptx
   private static final int MIN_CACHE_SIZE_WRITER = 16 * 1024;   // set to 128 * 1024 to start at 128KB
   private static final int MAX_CACHE_SIZE_WRITER = 4 * 1024 * 1024;
+  private static final int EXTRA_CACHE_SIZE_WRITER = 8 * 1024 * 1024;
   private static final int CACHE_SIZE_MULTIPLE = 8;
 
   // assume max number of buffers = 64
@@ -53,6 +54,9 @@ public class MultiByteArrayOutputStream extends OutputStream {
   private long totalBytes = 0;
   private long bufferBytes = 0;
   private final long bufferSizeThreshold;   // bufferSizeThreshold == 0 is allowed
+  private long currentBufferSizeThreshold;
+  private final boolean tryFreeMemoryAfterBufferSizeThreshold;
+  private final long freeMemoryThreshold;
 
   // spill fields
   private final FileSystem fs;
@@ -61,14 +65,19 @@ public class MultiByteArrayOutputStream extends OutputStream {
 
   public MultiByteArrayOutputStream(
       FileSystem fs,
-      Path outputPath) {
-    this(fs, outputPath, DEFAULT_BUFFER_SIZE_THRESHOLD);
+      Path outputPath,
+      boolean tryFreeMemoryAfterBufferSizeThreshold,
+      long freeMemoryThreshold) {
+    this(fs, outputPath, DEFAULT_BUFFER_SIZE_THRESHOLD,
+        tryFreeMemoryAfterBufferSizeThreshold, freeMemoryThreshold);
   }
 
   public MultiByteArrayOutputStream(
       FileSystem fs,
       Path outputPath,
-      long bufferSizeThreshold) {
+      long bufferSizeThreshold,
+      boolean tryFreeMemoryAfterBufferSizeThreshold,
+      long freeMemoryThreshold) {
     // start with an empty byte[] buffer because no data might be written
     this.cacheSize = 0;   // set to the size of currentBuffer
     this.currentBuffer = null;
@@ -76,6 +85,9 @@ public class MultiByteArrayOutputStream extends OutputStream {
     // posInBuf == cacheSize if currentBuffer is full, so currentBuffer is initially considered full
 
     this.bufferSizeThreshold = bufferSizeThreshold;
+    this.currentBufferSizeThreshold = bufferSizeThreshold;
+    this.tryFreeMemoryAfterBufferSizeThreshold = tryFreeMemoryAfterBufferSizeThreshold;
+    this.freeMemoryThreshold = freeMemoryThreshold;
 
     this.fs = fs;
     this.outputPath = outputPath;
@@ -91,14 +103,14 @@ public class MultiByteArrayOutputStream extends OutputStream {
       // in-memory buffer has space
       currentBuffer[posInBuf++] = (byte) b;
       bufferBytes++;
-    } else if (bufferBytes < bufferSizeThreshold) {
-      allocateNewBuffer();
-      currentBuffer[posInBuf++] = (byte) b;
-      bufferBytes++;
     } else {
-      // hit buffer limit: spill future writes
-      spillToFile();
-      fileOut.write(b);
+      allocateBufferOrSpillToFile();
+      if (fileOut != null) {
+        fileOut.write(b);
+      } else {
+        currentBuffer[posInBuf++] = (byte) b;
+        bufferBytes++;
+      }
     }
     totalBytes++;
   }
@@ -131,23 +143,40 @@ public class MultiByteArrayOutputStream extends OutputStream {
         }
       }
       // remaining > 0;
-      if (bufferBytes < bufferSizeThreshold) {
-        allocateNewBuffer();
-      } else {
-        // spill future writes
-        spillToFile();
+      allocateBufferOrSpillToFile();
+    }
+  }
+
+  private void allocateBufferOrSpillToFile() throws IOException {
+    if (bufferBytes < currentBufferSizeThreshold) {
+      allocateNewBuffer();
+    } else if (tryFreeMemoryAfterBufferSizeThreshold
+        && canUseFreeMemoryBuffers(freeMemoryThreshold)) {
+      allocateNewBuffer(EXTRA_CACHE_SIZE_WRITER);
+      currentBufferSizeThreshold += EXTRA_CACHE_SIZE_WRITER;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Allocated extra buffer: bufferBytes={}, bufferSizeThreshold={}, "
+                + "currentBufferSizeThreshold={}, outputPath={}",
+            bufferBytes, bufferSizeThreshold, currentBufferSizeThreshold, outputPath);
       }
+    } else {
+      // hit buffer limit: spill future writes
+      spillToFile();
     }
   }
 
   // allocate a new buffer
   private void allocateNewBuffer() {
-    assert posInBuf == cacheSize;
     if (cacheSize == 0) {
-      cacheSize = MIN_CACHE_SIZE_WRITER;
+      allocateNewBuffer(MIN_CACHE_SIZE_WRITER);
     } else {
-      cacheSize = Math.min(cacheSize * CACHE_SIZE_MULTIPLE, MAX_CACHE_SIZE_WRITER);
+      allocateNewBuffer(Math.min(cacheSize * CACHE_SIZE_MULTIPLE, MAX_CACHE_SIZE_WRITER));
     }
+  }
+
+  private void allocateNewBuffer(int newCacheSize) {
+    assert posInBuf == cacheSize;
+    cacheSize = newCacheSize;
     currentBuffer = new byte[cacheSize];
     buffers.add(currentBuffer);
     posInBuf = 0;
@@ -178,7 +207,9 @@ public class MultiByteArrayOutputStream extends OutputStream {
   @Override
   synchronized public void close() throws IOException {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("Closing: totalBytes={}, bufferBytes={}, outputPath={}", totalBytes, bufferBytes, outputPath);
+      LOG.debug("Closing: totalBytes={}, bufferBytes={}, bufferSizeThreshold={}, "
+              + "currentBufferSizeThreshold={}, outputPath={}",
+          totalBytes, bufferBytes, bufferSizeThreshold, currentBufferSizeThreshold, outputPath);
     }
     if (fileOut != null) {
       fileOut.close();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -704,7 +704,8 @@ public final class PipelinedSorter {
     if (spillToFreeMemory) {
       canUseBuffers = MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold);
       if (canUseBuffers) {
-        byteArrayOutput = new MultiByteArrayOutputStream(localFs, spillFileName);
+        byteArrayOutput = new MultiByteArrayOutputStream(
+            localFs, spillFileName, true, freeMemoryThreshold);
       }
     }
 
@@ -992,7 +993,8 @@ public final class PipelinedSorter {
       MultiByteArrayOutputStream byteArrayOutput = null;
       if (useFreeMemoryWriterOutput
           && MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold)) {
-        byteArrayOutput = new MultiByteArrayOutputStream(localFs, finalOutputFile);
+        byteArrayOutput = new MultiByteArrayOutputStream(
+            localFs, finalOutputFile, true, freeMemoryThreshold);
       }
 
       // the output stream for the final single output file

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -704,7 +704,8 @@ public class TezMerger {
           MultiByteArrayOutputStream byteArrayOutput = null;
           IFile.WriterAppendDataInputBuffer writer;
           if (writeIntermediateToMemory) {
-            byteArrayOutput = new MultiByteArrayOutputStream(fs, outputFile);
+            byteArrayOutput = new MultiByteArrayOutputStream(
+                fs, outputFile, true, freeMemoryThreshold);
             FSDataOutputStream outputStream = new FSDataOutputStream(byteArrayOutput, null);
             writer = new WriterDataInputBuffer(outputStream, codec, writesCounter, null,
                 false, checkForSameKeys, -1, -1, writeBuffer, null, taskContext);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -391,7 +391,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
         byte[] writeBuffer = IFile.allocateWriteBuffer();
         Path finalOutPath = outputFileHandler.getOutputFileForWrite();
         this.singlePartitionByteArrayOutput =
-            new MultiByteArrayOutputStream(rfs, finalOutPath, assignedMemoryBytes);
+            new MultiByteArrayOutputStream(rfs, finalOutPath, assignedMemoryBytes, false, 0L);
         FSDataOutputStream output = new FSDataOutputStream(singlePartitionByteArrayOutput, null);
         this.writer = new IFile.WriterBytesWritable(output, codec, outputRecordsCounter,
             outputRecordBytesCounter, trackMaxKeyValLen, -1, -1, writeBuffer, null, outputContext);
@@ -634,7 +634,7 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     if (spillNumber == 0) {
       // availableMemoryBytes is reserved for this UnorderedPartitionedKVWriter, so create MultiByteArrayOutputStream
       singlePartitionByteArrayOutput = new MultiByteArrayOutputStream(
-          rfs, singlePartitionSpillPathDetails.outputFilePath, assignedMemoryBytes);
+          rfs, singlePartitionSpillPathDetails.outputFilePath, assignedMemoryBytes, false, 0L);
       singlePartitionSpillOutput = new FSDataOutputStream(singlePartitionByteArrayOutput, null);
     } else {
       // we have consumed availableMemoryBytes reserved for this UnorderedPartitionedKVWriter, so check free memory
@@ -642,7 +642,8 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       if (useFreeMemoryWriterOutput
           && MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold)) {
         singlePartitionByteArrayOutput =
-            new MultiByteArrayOutputStream(rfs, singlePartitionSpillPathDetails.outputFilePath);
+            new MultiByteArrayOutputStream(
+                rfs, singlePartitionSpillPathDetails.outputFilePath, true, freeMemoryThreshold);
         singlePartitionSpillOutput = new FSDataOutputStream(singlePartitionByteArrayOutput, null);
       } else {
         singlePartitionSpillOutput = rfs.create(singlePartitionSpillPathDetails.outputFilePath);
@@ -948,7 +949,8 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       if (spillToFreeMemory) {
         canUseBuffers = MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold);
         if (canUseBuffers) {
-          byteArrayOutput = new MultiByteArrayOutputStream(rfs, spillPathDetails.outputFilePath);
+          byteArrayOutput = new MultiByteArrayOutputStream(
+              rfs, spillPathDetails.outputFilePath, true, freeMemoryThreshold);
         }
       }
 
@@ -1492,7 +1494,8 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     MultiByteArrayOutputStream byteArrayOutput = null;
     if (useFreeMemoryWriterOutput) {
       if (MultiByteArrayOutputStream.canUseFreeMemoryBuffers(freeMemoryThreshold)) {
-        byteArrayOutput = new MultiByteArrayOutputStream(rfs, finalOutPath);
+        byteArrayOutput = new MultiByteArrayOutputStream(
+            rfs, finalOutPath, true, freeMemoryThreshold);
       }
     }
 


### PR DESCRIPTION
### Motivation
- Reduce on-disk spills by allowing the in-memory writer to allocate an extra buffer beyond the configured threshold when the JVM has sufficient free memory. 
- Make the behavior configurable so callers can opt-in to attempting extra in-memory allocation and supply the free-memory threshold to check. 
- Propagate the new behavior through writer/merger/spill code paths so memory-backed output can be conditionally used where supported.

### Description
- Extended `MultiByteArrayOutputStream` with two new constructor parameters: `tryFreeMemoryAfterBufferSizeThreshold` and `freeMemoryThreshold`, and added fields `currentBufferSizeThreshold` and `freeMemoryThreshold` to track runtime allocation decisions. 
- Added `EXTRA_CACHE_SIZE_WRITER` constant and a new method `allocateBufferOrSpillToFile()` that either allocates another buffer, allocates an extra buffer when free memory is available, or falls back to `spillToFile()` when thresholds are exceeded. 
- Introduced an `allocateNewBuffer(int)` overload and updated buffer allocation/log messages to include `currentBufferSizeThreshold` for better diagnostics. 
- Updated all call sites to the `MultiByteArrayOutputStream` constructor in `PipelinedSorter`, `TezMerger`, and `UnorderedPartitionedKVWriter` to provide the new parameters (either passing opt-in values or `false, 0L` when not using the free-memory allocation behavior).

### Testing
- Built the modified modules and ran the module unit tests for the affected components with Maven using `mvn -pl tez-api,tez-runtime-library -DskipTests=false test`, and the tests completed successfully. 
- Performed a full project build via `mvn -DskipTests=false package` to verify compilation and packaging, and the build succeeded. 
- Existing automated tests covering spill and writer logic passed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b231c60c8328b20241a1715302e1)