### PR TITLE
Add request/complete API for direct value-byte writes to unordered partitioned writers

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueWriterEdge.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/KeyValueWriterEdge.java
@@ -25,6 +25,18 @@ import org.apache.tez.runtime.api.WriterEdge;
 
 public abstract class KeyValueWriterEdge implements WriterEdge {
 
+  public static class WriteValueBytes {
+    public final byte[] buffer;
+    public final int offsetToValueBytes;
+    public final int maxValueBytes;
+
+    public WriteValueBytes(byte[] buffer, int offsetToValueBytes, int maxValueBytes) {
+      this.buffer = buffer;
+      this.offsetToValueBytes = offsetToValueBytes;
+      this.maxValueBytes = maxValueBytes;
+    }
+  }
+
   // Invariant:
   //   1. closeWriter() must be called and is called only after the last call of write().
   //   2. write()/closeWriter() are called from the same thread (thus never concurrently).
@@ -51,6 +63,10 @@ public abstract class KeyValueWriterEdge implements WriterEdge {
   public abstract int getNumUnorderedPartitions();
 
   public abstract void writeWithPartition(BytesWritable key, BytesWritable value, int partition) throws IOException;
+
+  public abstract WriteValueBytes requestWriteValueBytes(BytesWritable key, int partition) throws IOException;
+
+  public abstract void completeWriteValueBytes(BytesWritable key, int valLen, int partition) throws IOException;
 
   // return value = 0: use key hash to get partition
   // return value = 1: use value hash to get partition

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -616,6 +616,75 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
     }
   }
 
+  @Override
+  public WriteValueBytes requestWriteValueBytes(BytesWritable key, int partition) throws IOException {
+    if (writerState != WriterState.RUNNING) {
+      throw new IOException("Write already closed or spill failed");
+    }
+
+    if (!compositeFetch || numPartitions == 1) {
+      return null;
+    }
+
+    int metaSkip = alignToIntBoundary(currentBuffer.nextPosition) - currentBuffer.nextPosition;
+    int requiredBeforeValue = metaSkip + PARTITIONED_META_SIZE + key.getLength();
+    if (currentBuffer.full || currentBuffer.availableSize < requiredBeforeValue) {
+      return null;
+    }
+
+    int maxValueBytes = currentBuffer.availableSize - requiredBeforeValue;
+    if (maxValueBytes == 0) {
+      return null;
+    }
+
+    return new WriteValueBytes(currentBuffer.buffer,
+        currentBuffer.nextPosition + requiredBeforeValue, maxValueBytes);
+  }
+
+  @Override
+  public void completeWriteValueBytes(BytesWritable key, int valLen, int partition) throws IOException {
+    if (writerState != WriterState.RUNNING) {
+      throw new IOException("Write already closed or spill failed");
+    }
+
+    if (valLen < 0) {
+      throw new IOException("Value length cannot be negative: " + valLen);
+    }
+
+    if (!compositeFetch || numPartitions == 1) {
+      throw new IOException("Direct value-byte writes are supported only for multiple unordered partitions"
+          + " with composite fetch");
+    }
+
+    if (trackMaxKeyValLen) {
+      maxKeyLen = Math.max(maxKeyLen, key.getLength());
+      maxValLen = Math.max(maxValLen, valLen);
+    }
+
+    int metaSkip = alignToIntBoundary(currentBuffer.nextPosition) - currentBuffer.nextPosition;
+    int requiredBeforeValue = metaSkip + PARTITIONED_META_SIZE + key.getLength();
+    long recordBytesWithOverhead = (long) requiredBeforeValue + valLen;
+    if (currentBuffer.full || recordBytesWithOverhead > currentBuffer.availableSize) {
+      throw new IOException("Requested value bytes do not fit in the current buffer");
+    }
+
+    currentBuffer.nextPosition += metaSkip;
+    int metaStart = currentBuffer.nextPosition;
+    currentBuffer.availableSize -= (PARTITIONED_META_SIZE + metaSkip);
+    currentBuffer.nextPosition += PARTITIONED_META_SIZE;
+
+    System.arraycopy(key.getBytesRaw(), key.getOffset(), currentBuffer.buffer,
+        currentBuffer.nextPosition, key.getLength());
+    currentBuffer.nextPosition += key.getLength();
+    currentBuffer.availableSize -= key.getLength();
+
+    int valStart = currentBuffer.nextPosition;
+    currentBuffer.nextPosition += valLen;
+    currentBuffer.availableSize -= valLen;
+
+    updateRecordMetadata(metaSkip, metaStart, valStart, partition);
+  }
+
   private void writeSinglePartitionPipelined(BytesWritable key, BytesWritable value) throws IOException {
     // Encode directly into the final spill format.
     // Closing a spill is synchronous so caller-owned key/value arrays never have to be retained.
@@ -797,6 +866,10 @@ public class UnorderedPartitionedKVWriter extends KeyValuesWriterEdge {
       }
     }
 
+    updateRecordMetadata(metaSkip, metaStart, valStart, partition);
+  }
+
+  private void updateRecordMetadata(int metaSkip, int metaStart, int valStart, int partition) {
     // Meta-data updates
     int metaIndex = metaStart / INT_SIZE;
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/OrderedPartitionedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/OrderedPartitionedKVOutput.java
@@ -145,6 +145,17 @@ public class OrderedPartitionedKVOutput extends AbstractLogicalOutput implements
       }
 
       @Override
+      public WriteValueBytes requestWriteValueBytes(BytesWritable key, int partition) throws IOException {
+        assert false;
+        return null;
+      }
+
+      @Override
+      public void completeWriteValueBytes(BytesWritable key, int valLen, int partition) throws IOException {
+        assert false;
+      }
+
+      @Override
       public int getPartitionerType() {
         assert false;
         return 0;


### PR DESCRIPTION
### Motivation
- Provide a zero-copy mechanism for writing value bytes directly into partition buffers to improve performance for unordered multi-partition composite fetch paths.
- Extend the writer API to enable callers to reserve buffer space and finalize writes without extra copies.

### Description
- Add the `WriteValueBytes` holder class and two new abstract methods `requestWriteValueBytes` and `completeWriteValueBytes` to `KeyValueWriterEdge` to request buffer space and complete direct writes.
- Implement `requestWriteValueBytes` and `completeWriteValueBytes` in `UnorderedPartitionedKVWriter` with checks for writer state, composite fetch support, buffer availability, and metadata updates, and expose the writable buffer region and max writable bytes via `WriteValueBytes`.
- Extracted and consolidated metadata update logic into a new helper `updateRecordMetadata` used by both the standard and direct-write paths.
- Add no-op/asserting overrides of the new methods in `OrderedPartitionedKVOutput` to keep ordered outputs unchanged.

### Testing
- Compiled the runtime library and ran the module unit test suite for `tez-runtime-library` with `mvn -DskipTests=false test` and the tests completed successfully.
- Executed the full project unit tests with `mvn -DskipTests=false test` and observed no regressions in automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a369805951c83288543ed35eeda4f96)