### PR TITLE
Include jline jars in tez distribution and remove maven-deploy skip in tez-dist

### DIFF
--- a/tez-dist/pom.xml
+++ b/tez-dist/pom.xml
@@ -75,13 +75,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <tarLongFileMode>gnu</tarLongFileMode>

--- a/tez-dist/src/main/assembly/tez-dist.xml
+++ b/tez-dist/src/main/assembly/tez-dist.xml
@@ -42,8 +42,6 @@
             <excludes>
               <exclude>org.apache.tez:*</exclude>
               <exclude>com.datamonad.mr3:*</exclude>
-              <exclude>jline:jline</exclude>
-              <exclude>org.jline:jline</exclude>
             </excludes>
           </dependencySet>
         </dependencySets>


### PR DESCRIPTION
### Motivation

- Ensure `jline` libraries are packaged into the Tez distribution so interactive/console features that depend on them are available.
- Remove the explicit `maven-deploy-plugin` skip configuration from the `tez-dist` build to restore normal plugin behavior for that module.

### Description

- Removed the `maven-deploy-plugin` configuration that set `<skip>true</skip>` from `tez-dist/pom.xml` so the deploy plugin is no longer explicitly disabled for this module.
- Updated `tez-dist/src/main/assembly/tez-dist.xml` to stop excluding `jline:jline` and `org.jline:jline`, allowing those artifacts to be included in the assembled distribution under `/lib`.

### Testing

- Ran the module build with `mvn -P hadoop28 -DskipTests package -pl tez-dist` and the build succeeded.
- Verified the produced assembly output contains `jline` jars in the `/lib` directory of the generated distribution archive.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5622384c6883288d176c3c76450f44)