### PR TITLE
Remove unused Maven plugin and reporting declarations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -750,11 +750,6 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.4</version>
           <configuration>
@@ -779,52 +774,8 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>2.2.1</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.hadoop</groupId>
-          <artifactId>hadoop-maven-plugins</artifactId>
-          <version>${hadoop.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>2.4</version>
-        </plugin>
-        <plugin>
-          <artifactId>exec-maven-plugin</artifactId>
-          <groupId>org.codehaus.mojo</groupId>
-          <version>1.3.2</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>${shade-maven-plugin.version}</version>
-        </plugin>
-        <plugin>
-          <groupId>org.eclipse.m2e</groupId>
-          <artifactId>lifecycle-mapping</artifactId>
-          <version>1.0.0</version>
-          <configuration>
-            <lifecycleMappingMetadata>
-              <pluginExecutions>
-                <pluginExecution>
-                  <pluginExecutionFilter>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-maven-plugins</artifactId>
-                    <versionRange>[0,]</versionRange>
-                    <goals>
-                      <goal>protoc</goal>
-                    </goals>
-                  </pluginExecutionFilter>
-                  <action>
-                    <ignore />
-                  </action>
-                </pluginExecution>
-              </pluginExecutions>
-            </lifecycleMappingMetadata>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -193,37 +193,6 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <reportSets>
-          <reportSet>
-            <id>configgen</id>
-            <configuration>
-              <doclet>org.apache.tez.tools.javadoc.doclet.ConfigStandardDoclet</doclet>
-              <docletArtifacts>
-                <docletArtifact>
-                  <groupId>org.apache.tez</groupId>
-                  <artifactId>tez-javadoc-tools</artifactId>
-                  <version>${project.version}</version>
-                </docletArtifact>
-              </docletArtifacts>
-              <destDir>apidocs/configs</destDir>
-              <name>TezConfigGenerator</name>
-              <description>Tez Configuration documentation</description>
-            </configuration>
-            <reports>
-              <report>javadoc</report>
-              <report>aggregate</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <profiles>
     <profile>
       <id>hadoop28</id>

--- a/tez-runtime-library/pom.xml
+++ b/tez-runtime-library/pom.xml
@@ -102,35 +102,4 @@
     </plugins>
   </build>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <reportSets>
-          <reportSet>
-            <id>configgen</id>
-            <configuration>
-              <doclet>org.apache.tez.tools.javadoc.doclet.ConfigStandardDoclet</doclet>
-              <docletArtifacts>
-                <docletArtifact>
-                  <groupId>org.apache.tez</groupId>
-                  <artifactId>tez-javadoc-tools</artifactId>
-                  <version>${project.version}</version>
-                </docletArtifact>
-              </docletArtifacts>
-              <destDir>apidocs/configs</destDir>
-              <name>TezConfigGenerator</name>
-              <description>Tez Configuration documentation</description>
-            </configuration>
-            <reports>
-              <report>javadoc</report>
-              <report>aggregate</report>
-            </reports>
-          </reportSet>
-        </reportSets>
-      </plugin>
-    </plugins>
-  </reporting>
-
 </project>


### PR DESCRIPTION
### Motivation
- Clean up POMs to only declare plugins required for the supported Maven workflows (`clean`, `compile`, `test`, `install`).
- Remove build-time and reporting plugin declarations that are not used during regular development and CI runs to avoid unnecessary configuration drift.
- Simplify module POMs by dropping site/javadoc-only reporting blocks that are not relevant to the used Maven goals.

### Description
- Removed several unused `pluginManagement` entries from the root `pom.xml` including `maven-enforcer-plugin`, `maven-source-plugin`, `hadoop-maven-plugins`, `exec-maven-plugin`, `maven-shade-plugin`, and the Eclipse `lifecycle-mapping` block, leaving only compiler, jar, assembly and clean plugin declarations.
- Removed `reporting` sections that only configured the `maven-javadoc-plugin` from `tez-api/pom.xml` and `tez-runtime-library/pom.xml` to eliminate site/javadoc-only configuration.
- Kept required build plugin executions such as the protobuf `protoc-jar-maven-plugin` and the assembly configuration in modules that still need them.

### Testing
- Ran `git diff --check` to validate there are no whitespace or conflict markers and it passed.
- Parsed modified POMs with `python3` using `xml.etree.ElementTree.parse` to verify the XML remains well-formed and parsing succeeded for `pom.xml`, `tez-api/pom.xml`, and `tez-runtime-library/pom.xml`.
- Attempted `mvn -q -DskipTests install`, but the run was blocked by Maven Central returning HTTP 403 while resolving `org.apache.maven.plugins:maven-install-plugin:3.1.2`, so a full Maven install could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a562be722b083288c41f73e847399e4)